### PR TITLE
Fixes to pass make on fresh Ubuntu 18.04

### DIFF
--- a/build/libevent/Makefile
+++ b/build/libevent/Makefile
@@ -19,7 +19,7 @@ export CFLAGS=-fPIC
 
 all: build
 
-build: __sep bindirs
+build: __sep bindirs source
 ifeq (,$(wildcard $(BUILD_DIR)/Makefile))
 	$(SHOW)cd $(BUILD_DIR); $(realpath $(SRCDIR))/configure $(CONFIGURE_FLAGS)
 endif


### PR DESCRIPTION
@rafie @MeirShpilraien 

Also:

- [ ] there is a dependency on redis-server in pack.sh... this is problematic-ish
- [ ] creating /opt/redislabs reuires sudo
- [ ] tools (eg. RLTest) should be installed for the user

Signed-off-by: Itamar Haber <itamar@redislabs.com>