### PR TITLE
Changed the following:

### DIFF
--- a/src/GearsBuilder.py
+++ b/src/GearsBuilder.py
@@ -10,24 +10,6 @@ globals()['str'] = str
 
 redisgears._saveGlobals()
 
-def CreatePythonReaderCallback(prefix):
-    def PythonReaderCallback():
-        pref = prefix
-        cursor = '0'
-        res = execute('scan', cursor, 'COUNT', '10000', 'MATCH', pref)
-        cursor = res[0]
-        keys = res[1]
-        while int(cursor) != 0:
-            for k in keys:
-                yield k
-            res = execute('scan', cursor, 'COUNT', '10000', 'MATCH', pref)
-            cursor = res[0]
-            keys = res[1]
-        for k in keys:
-                yield k
-    return PythonReaderCallback
-
-
 def ShardReaderCallback():
     res = execute('RG.INFOCLUSTER')
     if res == 'no cluster mode':
@@ -39,7 +21,7 @@ def ShardReaderCallback():
 class GearsBuilder():
     def __init__(self, reader='KeysReader', defaultArg='*', desc=None):
         self.realReader = reader
-        if(reader == 'KeysOnlyReader' or reader == 'ShardsIDReader'):
+        if(reader == 'ShardsIDReader'):
             reader = 'PythonReader'
         self.reader = reader
         self.gearsCtx = gearsCtx(self.reader, desc)
@@ -126,8 +108,6 @@ class GearsBuilder():
         if(collect):
             self.gearsCtx.collect()
         arg = arg if arg else self.defaultArg
-        if(self.realReader == 'KeysOnlyReader'):
-            arg = CreatePythonReaderCallback(arg)
         if(self.realReader == 'ShardsIDReader'):
             arg = ShardReaderCallback
         self.gearsCtx.run(arg)

--- a/src/execution_plan.h
+++ b/src/execution_plan.h
@@ -12,6 +12,7 @@
 #include "redisgears.h"
 #include "commands.h"
 #include "utils/dict.h"
+#include "utils/adlist.h"
 #ifdef WITHPYTHON
 #include <redisgears_python.h>
 #endif
@@ -167,9 +168,10 @@ typedef enum ExecutionPlanStatus{
 #define EXECUTION_PLAN_STR_ID_LEN  REDISMODULE_NODE_ID_LEN + 13
 
 typedef struct WorkerData{
-	struct event_base* eb;
-	int notifyPipe[2];
-	pthread_t thread;
+    Gears_list* notifications;
+    pthread_mutex_t lock;
+    pthread_cond_t cond;
+    pthread_t thread;
 }WorkerData;
 
 typedef struct ExecutionPlan{
@@ -182,6 +184,7 @@ typedef struct ExecutionPlan{
     Record** results;
     Record** errors;
     ExecutionPlanStatus status;
+    bool isDone;
     bool sentRunRequest;
     RedisGears_OnExecutionDoneCallback callback;
     void* privateData;

--- a/src/keys_reader.c
+++ b/src/keys_reader.c
@@ -177,22 +177,19 @@ static Record* KeysReader_ReadKey(RedisModuleCtx* rctx, KeysReaderCtx* readerCtx
         return NULL;
     }
 
+    char* keyCStr = RG_ALLOC(keyLen + 1);
+    memcpy(keyCStr, keyStr, keyLen);
+    keyCStr[keyLen] = '\0';
+
     if(readerCtx->readValue){
 
         record = RedisGears_KeyRecordCreate();
-
-        char* keyCStr = RG_ALLOC(keyLen + 1);
-        memcpy(keyCStr, keyStr, keyLen);
-        keyCStr[keyLen] = '\0';
 
         RedisGears_KeyRecordSetKey(record, keyCStr, keyLen);
 
         ValueToRecordMapper(rctx, record, keyHandler);
     }else{
 
-        char* keyCStr = RG_ALLOC(keyLen + 1);
-        memcpy(keyCStr, keyStr, keyLen);
-        keyCStr[keyLen] = '\0';
         record = RedisGears_StringRecordCreate(keyCStr, keyLen);
 
     }

--- a/src/keys_reader.c
+++ b/src/keys_reader.c
@@ -24,21 +24,35 @@ static Record* KeysReader_Next(ExecutionCtx* ectx, void* ctx);
 static Record* (*KeysReader_NextCallback)(ExecutionCtx* rctx, void* ctx) = KeysReader_Next;
 
 typedef struct KeysReaderCtx{
+    size_t matchLen;
     char* match;
     long long cursorIndex;
     bool isDone;
     Record** pendingRecords;
+    bool readValue;
+    bool isPrefix;
     ResultsIterator* iter;
     RedisModuleDictIter* iter1;
 }KeysReaderCtx;
 
-static KeysReaderCtx* KeysReaderCtx_Create(char* match){
+static KeysReaderCtx* KeysReaderCtx_Create(char* match, bool readValue){
 #define PENDING_KEYS_INIT_CAP 10
+    bool isPrefix = false;
+    size_t matchLen = 0;
+    if(match){
+        matchLen = strlen(match);
+        if(match[matchLen - 1] == '*'){
+            isPrefix = true;
+        }
+    }
     KeysReaderCtx* krctx = RG_ALLOC(sizeof(*krctx));
     *krctx = (KeysReaderCtx){
+        .matchLen = matchLen,
         .match = match,
         .cursorIndex = 0,
         .isDone = false,
+        .readValue = readValue,
+        .isPrefix = isPrefix,
         .pendingRecords = array_new(Record*, PENDING_KEYS_INIT_CAP),
 		.iter = NULL,
 		.iter1 = NULL,
@@ -55,6 +69,10 @@ static void RG_KeysReaderCtxDeserialize(void* ctx, Gears_BufferReader* br){
     KeysReaderCtx* krctx = (KeysReaderCtx*)ctx;
     char* match = RedisGears_BRReadString(br);
     krctx->match = RG_STRDUP(match);
+    krctx->matchLen = strlen(krctx->match);
+    if(match[krctx->matchLen - 1] == '*'){
+        krctx->isPrefix = true;
+    }
 }
 
 static void KeysReader_Free(void* ctx){
@@ -149,7 +167,42 @@ static Record* ValueToRecordMapper(RedisModuleCtx* rctx, Record* record, RedisMo
     }
 }
 
-static Record* KeysReader_NextKey(RedisModuleCtx* rctx, KeysReaderCtx* readerCtx){
+static Record* KeysReader_ReadKey(RedisModuleCtx* rctx, KeysReaderCtx* readerCtx, RedisModuleString* key){
+    size_t keyLen;
+    const char* keyStr = RedisModule_StringPtrLen(key, &keyLen);
+    Record* record = NULL;
+
+    RedisModuleKey *keyHandler = RedisModule_OpenKey(rctx, key, REDISMODULE_READ);
+    if(!keyHandler){
+        return NULL;
+    }
+
+    if(readerCtx->readValue){
+
+        record = RedisGears_KeyRecordCreate();
+
+        char* keyCStr = RG_ALLOC(keyLen + 1);
+        memcpy(keyCStr, keyStr, keyLen);
+        keyCStr[keyLen] = '\0';
+
+        RedisGears_KeyRecordSetKey(record, keyCStr, keyLen);
+
+        ValueToRecordMapper(rctx, record, keyHandler);
+    }else{
+
+        char* keyCStr = RG_ALLOC(keyLen + 1);
+        memcpy(keyCStr, keyStr, keyLen);
+        keyCStr[keyLen] = '\0';
+        record = RedisGears_StringRecordCreate(keyCStr, keyLen);
+
+    }
+
+    RedisModule_CloseKey(keyHandler);
+
+    return record;
+}
+
+static Record* KeysReader_ScanNextKey(RedisModuleCtx* rctx, KeysReaderCtx* readerCtx){
     if(array_len(readerCtx->pendingRecords) > 0){
         return array_pop(readerCtx->pendingRecords);
     }
@@ -195,28 +248,12 @@ static Record* KeysReader_NextKey(RedisModuleCtx* rctx, KeysReaderCtx* readerCtx
             RedisModuleCallReply *keyReply = RedisModule_CallReplyArrayElement(keysReply, i);
             assert(RedisModule_CallReplyType(keyReply) == REDISMODULE_REPLY_STRING);
             RedisModuleString* key = RedisModule_CreateStringFromCallReply(keyReply);
-            RedisModuleKey *keyHandler = RedisModule_OpenKey(rctx, key, REDISMODULE_READ);
-            if(!keyHandler){
-                RedisModule_FreeString(rctx, key);
+            Record* record = KeysReader_ReadKey(rctx, readerCtx, key);
+            if(record == NULL){
                 continue;
             }
-            size_t keyLen;
-            const char* keyStr = RedisModule_StringPtrLen(key, &keyLen);
-
-            Record* record = RedisGears_KeyRecordCreate();
-
-            char* keyCStr = RG_ALLOC(keyLen + 1);
-            memcpy(keyCStr, keyStr, keyLen);
-            keyCStr[keyLen] = '\0';
-
-            RedisGears_KeyRecordSetKey(record, keyCStr, keyLen);
-
-            ValueToRecordMapper(rctx, record, keyHandler);
-
-            readerCtx->pendingRecords = array_append(readerCtx->pendingRecords, record);
-
             RedisModule_FreeString(rctx, key);
-            RedisModule_CloseKey(keyHandler);
+            readerCtx->pendingRecords = array_append(readerCtx->pendingRecords, record);
         }
         RedisModule_FreeCallReply(reply);
         LockHandler_Release(rctx);
@@ -297,7 +334,21 @@ static Record* KeysReader_SearchIndexNext(ExecutionCtx* ectx, void* ctx){
 
 static Record* KeysReader_Next(ExecutionCtx* ectx, void* ctx){
     KeysReaderCtx* readerCtx = ctx;
-    Record* record = KeysReader_NextKey(RedisGears_GetRedisModuleCtx(ectx), readerCtx);
+    Record* record = NULL;
+    if(readerCtx->isPrefix){
+        record = KeysReader_ScanNextKey(RedisGears_GetRedisModuleCtx(ectx), readerCtx);
+    }else{
+        if(readerCtx->isDone){
+            return NULL;
+        }
+        RedisModuleString* key = RedisModule_CreateString(NULL, readerCtx->match, readerCtx->matchLen);
+        RedisModuleCtx* rctx = RedisGears_GetRedisModuleCtx(ectx);
+        LockHandler_Acquire(rctx);
+        record = KeysReader_ReadKey(rctx, readerCtx, key);
+        LockHandler_Release(rctx);
+        RedisModule_FreeString(NULL, key);
+        readerCtx->isDone = true;
+    }
     return record;
 }
 
@@ -423,7 +474,20 @@ int KeysReader_Initialize(RedisModuleCtx* ctx){
 }
 
 static Reader* KeysReader_Create(void* arg){
-    KeysReaderCtx* ctx = KeysReaderCtx_Create(arg);
+    KeysReaderCtx* ctx = KeysReaderCtx_Create(arg, true);
+    Reader* r = RG_ALLOC(sizeof(*r));
+    *r = (Reader){
+        .ctx = ctx,
+        .next = KeysReader_NextCallback,
+        .free = KeysReader_Free,
+        .serialize = RG_KeysReaderCtxSerialize,
+        .deserialize = RG_KeysReaderCtxDeserialize,
+    };
+    return r;
+}
+
+static Reader* KeysOnlyReader_Create(void* arg){
+    KeysReaderCtx* ctx = KeysReaderCtx_Create(arg, false);
     Reader* r = RG_ALLOC(sizeof(*r));
     *r = (Reader){
         .ctx = ctx,
@@ -437,6 +501,12 @@ static Reader* KeysReader_Create(void* arg){
 
 RedisGears_ReaderCallbacks KeysReader = {
         .create = KeysReader_Create,
+        .registerTrigger = KeysReader_RegisrterTrigger,
+        .unregisterTrigger = KeysReader_UnregisterTrigger,
+};
+
+RedisGears_ReaderCallbacks KeysOnlyReader = {
+        .create = KeysOnlyReader_Create,
         .registerTrigger = KeysReader_RegisrterTrigger,
         .unregisterTrigger = KeysReader_UnregisterTrigger,
 };

--- a/src/keys_reader.h
+++ b/src/keys_reader.h
@@ -1,9 +1,3 @@
-/*
- * keys_reader.h
- *
- *  Created on: 9 Jan 2019
- *      Author: root
- */
 
 #ifndef SRC_KEYS_READER_H_
 #define SRC_KEYS_READER_H_
@@ -11,6 +5,7 @@
 #include "redisgears.h"
 
 extern RedisGears_ReaderCallbacks KeysReader;
+extern RedisGears_ReaderCallbacks KeysOnlyReader;
 
 int KeysReader_Initialize(RedisModuleCtx* ctx);
 

--- a/src/module.c
+++ b/src/module.c
@@ -188,7 +188,7 @@ static bool RG_RegisterExecutionDoneCallback(ExecutionPlan* ep, RedisGears_OnExe
 }
 
 static bool RG_IsDone(ExecutionPlan* ep){
-	return(ep->status == DONE);
+	return(ep->isDone);
 }
 
 static const char* RG_GetId(ExecutionPlan* ep){
@@ -461,6 +461,7 @@ int RedisGears_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     Cluster_Init();
 
     RGM_RegisterReader(KeysReader);
+    RGM_RegisterReader(KeysOnlyReader);
     RGM_RegisterReader(StreamReader);
     RGM_RegisterFilter(Example_Filter, NULL);
     RGM_RegisterMap(GetValueMapper, NULL);

--- a/src/redisgears.h
+++ b/src/redisgears.h
@@ -60,6 +60,7 @@ typedef struct Reader{
  * Default readers to use
  */
 #define KeysReader KeysReader
+#define KeysOnlyReader KeysOnlyReader
 #define StreamReader StreamReader
 
 /**

--- a/src/redisgears_python.c
+++ b/src/redisgears_python.c
@@ -703,6 +703,7 @@ static PyObject* executeCommand(PyObject *cls, PyObject *args){
     PyObject* command = PyTuple_GetItem(args, 0);
     if(!PyUnicode_Check(command)){
         PyErr_SetString(GearsError, "the given command must be a string");
+        LockHandler_Release(rctx);
         return NULL;
     }
     const char* commandStr = PyUnicode_AsUTF8AndSize(command, NULL);


### PR DESCRIPTION
1. if setting MaxExecutions to 0, no execution will be deleted automatically.
2. Events to execution are sent via a linked list and not with libevent to prevent deadlock
3. Keys only reader is now implemented in C to increase performance, in addition, if exect match (no prefix)
   is requested then 'scan' command will not be used.