### PR TITLE
Added platforms build facility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+# .git/
 /bin/
 /deps/cpython/
 /deps/libevent/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,52 @@
-# BUILD redisfab/redisgears-${OSNICK}:M.m.b-x64
+# BUILD redisfab/redisgears-${OSNICK}:M.m.b-${ARCH}
 
-# stretch|bionic|buster
+# OSNICK=bionic|stretch|buster
 ARG OSNICK=buster
 
+# OS=debian:buster-slim|debian:stretch-slim|ubuntu:bionic
+ARG OS=debian:buster-slim
+
+# ARCH=x64|arm64v8|arm32v7
+ARG ARCH=x64
+
+ARG REDISVER=5.0.5
+
 #----------------------------------------------------------------------------------------------
-# FROM redisfab/redis-x64-${OSNICK}:5.0.5 AS builder
-FROM redis:latest AS builder
+# FROM redis:latest AS redis
+FROM redisfab/redis-${ARCH}-${OSNICK}:${REDISVER} AS redis
+FROM ${OS} AS builder
+
+ARG OSNICK
+ARG OS
+ARG ARCH
+ARG REDISVER
+
+RUN echo "Building for ${OSNICK} (${OS}) for ${ARCH}"
+
+WORKDIR /build
+COPY --from=redis /usr/local/ /usr/local/
 
 ADD . /build
-WORKDIR /build
 
 RUN ./deps/readies/bin/getpy2
 RUN ./system-setup.py
 RUN make fetch SHOW=1
 RUN make all SHOW=1
 
+ARG PACK=0
 ARG TEST=0
 
+RUN if [ "$PACK" = "1" ]; then make pack; fi
 RUN if [ "$TEST" = "1" ]; then make test; fi
 
 #----------------------------------------------------------------------------------------------
-# FROM redisfab/redis-x64-${OSNICK}:5.0.5
-FROM redis:latest
+# FROM redis:latest
+FROM redisfab/redis-${ARCH}-${OSNICK}:${REDISVER}
+
+ARG OSNICK
+ARG OS
+ARG ARCH
+ARG REDISVER
 
 ENV REDIS_MODULES /opt/redislabs/lib/modules
 

--- a/Makefile
+++ b/Makefile
@@ -243,11 +243,19 @@ pack ramp_pack: __sep deps build $(CPYTHON_PREFIX)
 
 #----------------------------------------------------------------------------------------------
 
+ifeq ($(GDB),1)
+RLTEST_GDB=-i
+endif
+
 test: __sep
 ifeq ($(DEBUG),1)
-	$(SHOW)cd pytest; ./run_tests_valgrind.sh
+	$(SHOW)set -e; cd pytest; ./run_tests_valgrind.sh
 else
-	$(SHOW)cd pytest; ./run_tests.sh
+ifneq ($(TEST),)
+	@set -e; cd pytest; PYDEBUG=1 RLTest --test $(TEST) $(RLTEST_GDB) -s --module $(abspath $(TARGET))
+else
+	$(SHOW)set -e; cd pytest; ./run_tests.sh
+endif
 endif
 
 #----------------------------------------------------------------------------------------------

--- a/build/platforms/Makefile
+++ b/build/platforms/Makefile
@@ -1,0 +1,33 @@
+
+ROOT=../..
+
+PLATFORMS=centos7 fedora xenial bionic stretch buster
+
+REPO=localhost/redisgears
+
+OS.centos7=centos:7.6.1810
+OS.fedora=fedora:30
+OS.xenial=ubuntu:xenial
+OS.bionic=ubuntu:bionic
+OS.stretch=debian:stretch
+OS.buster=debian:buster
+
+ARGS=\
+	-f $(ROOT)/Dockerfile \
+	--build-arg TEST=1 \
+	--build-arg PACK=1 \
+	$(ROOT)
+
+define build_platform
+$(1):
+	@docker build $(BUILD_OPT) -t $(REPO):$(1) --build-arg OSNICK=$(1) --build-arg OS=$(OS.$(1)) $(ARGS)
+
+.PHONY: $(1)
+endef
+
+platforms:
+	@echo "Platforms: $(PLATFORMS)"
+
+all: $(PLATFORMS)
+
+$(foreach P,$(PLATFORMS),$(eval $(call build_platform,$(P))))

--- a/pytest/test_basics.py
+++ b/pytest/test_basics.py
@@ -1,7 +1,11 @@
+import sys
+import os
 from RLTest import Env
 import yaml
 import time
 
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../deps/readies"))
+import paella
 
 def getConnectionByEnv(env):
     conn = None
@@ -355,7 +359,7 @@ redisgears.registerTimeEvent(1, func, 'timeEvent')
 
 def testExecuteCommandWithNullTerminated(env):
     env.skipOnCluster()
-    env.expect('set', 'x', 'test\x00test').equal('OK')
+    env.expect('set', 'x', 'test\x00test').equal(True)
     env.expect('get', 'x').equal('test\x00test')
     env.cmd('RG.PYEXECUTE', "GearsBuilder().foreach(lambda x: redisgears.executeCommand('SET', 'bar', str(x['value']))).map(lambda x: str(x)).run()")
     env.expect('get', 'bar').equal('test\x00test')
@@ -573,11 +577,10 @@ GB().filter(lambda r: r['key'] != 'all_keys').repartition(lambda r: 'all_keys').
         registrations = self.env.cmd('RG.DUMPREGISTRATIONS')
         self.env.assertEqual(len(registrations), 1)
         registrationID = registrations[0][1]
-        
         self.conn.execute_command('set', 'x', '1')
         time.sleep(1)
         res = self.conn.execute_command('smembers', 'all_keys')
-        self.env.assertEqual(res, ['x'])
+        self.env.assertEqual(res.pop(), 'x')
 
         self.env.expect('RG.UNREGISTER', registrationID).equal('OK')
         time.sleep(1) # wait for dump registrations to reach all the shards
@@ -588,7 +591,7 @@ GB().filter(lambda r: r['key'] != 'all_keys').repartition(lambda r: 'all_keys').
         self.conn.execute_command('set', 'y', '1')
         time.sleep(1)
         res = self.conn.execute_command('smembers', 'all_keys')
-        self.env.assertEqual(res, ['x'])
+        self.env.assertEqual(res.pop(), 'x')
 
         executions = self.env.cmd('RG.DUMPEXECUTIONS')
         for e in executions:

--- a/system-setup.py
+++ b/system-setup.py
@@ -95,9 +95,13 @@ class RedisGearsSetup(paella.Setup):
         self.pip_install("pipenv gevent")
 
     def common_last(self):
-        # RLTest before RAMP due to redis<->redis-py-cluster version dependency
-        self.pip_install("git+https://github.com/RedisLabsModules/RLTest.git@master")
-        self.pip_install("git+https://github.com/RedisLabs/RAMP@master")
+        # this is due to rmbuilder older versions. should be removed once fixed.
+        self.run("pip uninstall -y -q redis redis-py-cluster ramp-packer RLTest rmtest semantic-version || true")
+        # redis-py-cluster should be installed from git due to redis-py dependency
+        self.pip_install("--no-cache-dir git+https://github.com/Grokzen/redis-py-cluster.git@master")
+        # the following can be probably installed from pypi
+        self.pip_install("--no-cache-dir git+https://github.com/RedisLabsModules/RLTest.git@master")
+        self.pip_install("--no-cache-dir git+https://github.com/RedisLabs/RAMP@master")
 
 #----------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Performs Docker builds for supported platforms via:
make -C build/platforms <<platform-name>>

Supported platforms are shown by:
make -C build/platforms platforms