### PR TITLE
Added execution max idle parameter

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -503,7 +503,7 @@ static void Cluster_SendMsgToNode(Node* node, SendMsg* msg){
     if(node->status == NodeStatus_Connected){
         redisAsyncCommandArgv(node->c, OnResponseArrived, node, 5, (const char**)sentMsg->args, sentMsg->sizes);
     }else{
-        RedisModule_Log(NULL, "warning", "message was not sent because status is not connected");
+        RedisModule_Log(NULL, "verbose", "message was not sent because status is not connected");
     }
     Gears_listAddNodeTail(node->pendingMessages, sentMsg);
 }

--- a/src/config.h
+++ b/src/config.h
@@ -15,6 +15,7 @@ long long GearsConfig_GetMaxExecutions();
 long long GearsConfig_GetMaxExecutionsPerRegistration();
 long long GearsConfig_GetProfileExecutions();
 long long GearsConfig_GetPythonAttemptTraceback();
+long long GearsConfig_GetExecutionMaxIdleTime();
 const char* GearsConfig_GetDependenciesUrl();
 const char* GearsConfig_GetDependenciesSha256();
 long long GearsConfig_CreateVenv();

--- a/src/execution_plan.h
+++ b/src/execution_plan.h
@@ -217,6 +217,8 @@ typedef struct ExecutionPlan{
     WorkerData* assignWorker;
     ExecutionMode mode;
     Gears_listNode* nodeOnExecutionsList;
+    RedisModuleTimerID maxIdleReachedTimer;
+    bool maxIdleTimerSet;
 }ExecutionPlan;
 
 typedef struct FlatBasicStep{
@@ -248,6 +250,7 @@ typedef struct FlatExecutionPlan{
     Gears_Buffer* serializedFep;
     FlatBasicStep onExecutionStartStep;
     FlatBasicStep onRegisteredStep;
+    size_t maxIdleMiliSec;
 }FlatExecutionPlan;
 
 typedef struct ExecutionCtx{


### PR DESCRIPTION
Execution will be aborted if it was idle for more then the max idle value (by default 30 seconds).
If execution is aborted and messages about this exeuction is reached from other shards,
then it will be ignored, which means that eventually the execution will be timedout on all the shards.