### PR TITLE
added 'with atomic()' to allow atomic execution of python code.

### DIFF
--- a/src/GearsBuilder.py
+++ b/src/GearsBuilder.py
@@ -1,6 +1,8 @@
 import redisgears
 import redisgears as rg
 from redisgears import executeCommand as execute
+from redisgears import executeCommand as execute
+from redisgears import atomicCtx as atomic
 from redisgears import getMyHashTag as hashtag
 from redisgears import registerTimeEvent as registerTE
 from redisgears import gearsCtx

--- a/src/execution_plan.c
+++ b/src/execution_plan.c
@@ -903,7 +903,7 @@ static Record* ExecutionPlan_CollectNextRecord(ExecutionPlan* ep, ExecutionStep*
 			    // we need to clear and rewrite cause buff contains garbage
 			    Gears_BufferClear(buff);
 			    RedisGears_BWWriteBuffer(&bw, ep->id, ID_LEN); // serialize execution plan id
-                RedisGears_BWWriteLong(&bw, step->stepId); // serialize step id
+			    RedisGears_BWWriteLong(&bw, step->stepId); // serialize step id
 			    record = RG_ErrorRecordCreate(err, strlen(err));
 			    err = NULL;
 			    serializationRes = RG_SerializeRecord(&bw, record, &err);

--- a/src/record.c
+++ b/src/record.c
@@ -313,7 +313,7 @@ void RG_PyObjRecordSet(Record* r, PyObject* obj){
 }
 #endif
 
-void RG_SerializeRecord(Gears_BufferWriter* bw, Record* r){
+int RG_SerializeRecord(Gears_BufferWriter* bw, Record* r, char** err){
     RedisGears_BWWriteLong(bw, r->type);
     switch(r->type){
     case STRING_RECORD:
@@ -329,14 +329,18 @@ void RG_SerializeRecord(Gears_BufferWriter* bw, Record* r){
     case LIST_RECORD:
         RedisGears_BWWriteLong(bw, RedisGears_ListRecordLen(r));
         for(size_t i = 0 ; i < RedisGears_ListRecordLen(r) ; ++i){
-            RG_SerializeRecord(bw, r->listRecord.records[i]);
+            if(RG_SerializeRecord(bw, r->listRecord.records[i], err) != REDISMODULE_OK){
+                return REDISMODULE_ERR;
+            }
         }
         break;
     case KEY_RECORD:
         RedisGears_BWWriteString(bw, r->keyRecord.key);
         if(r->keyRecord.record){
             RedisGears_BWWriteLong(bw, 1); // value exists
-            RG_SerializeRecord(bw, r->keyRecord.record);
+            if(RG_SerializeRecord(bw, r->keyRecord.record, err) != REDISMODULE_OK){
+                return REDISMODULE_ERR;
+            }
         }else{
             RedisGears_BWWriteLong(bw, 0); // value missing
         }
@@ -346,12 +350,15 @@ void RG_SerializeRecord(Gears_BufferWriter* bw, Record* r){
         break;
 #ifdef WITHPYTHON
     case PY_RECORD:
-        RedisGearsPy_PyObjectSerialize(r->pyRecord.obj, bw);
+        if(RedisGearsPy_PyObjectSerialize(r->pyRecord.obj, bw, err) != REDISMODULE_OK){
+            return REDISMODULE_ERR;
+        }
         break;
 #endif
     default:
         assert(false);
     }
+    return REDISMODULE_OK;
 }
 
 Record* RG_DeserializeRecord(Gears_BufferReader* br){

--- a/src/record.h
+++ b/src/record.h
@@ -74,7 +74,7 @@ void RG_HashSetRecordFreeKeysArray(char** keyArr);
 Record* RG_KeyHandlerRecordCreate(RedisModuleKey* handler);
 RedisModuleKey* RG_KeyHandlerRecordGet(Record* r);
 
-void RG_SerializeRecord(Gears_BufferWriter* bw, Record* r);
+int RG_SerializeRecord(Gears_BufferWriter* bw, Record* r, char** err);
 Record* RG_DeserializeRecord(Gears_BufferReader* br);
 
 #ifdef WITHPYTHON

--- a/src/redisgears_python.c
+++ b/src/redisgears_python.c
@@ -879,6 +879,37 @@ static PyObject* registerExecution(PyObject *self, PyObject *args, PyObject *kar
     return Py_None;
 }
 
+typedef struct PyAtomic{
+   PyObject_HEAD
+   RedisModuleCtx* ctx;
+} PyAtomic;
+
+static PyObject* atomicEnter(PyObject *self, PyObject *args){
+    PyAtomic* pyAtomic = (PyAtomic*)self;
+    LockHandler_Acquire(pyAtomic->ctx);
+    Py_INCREF(self);
+    return self;
+}
+
+static PyObject* atomicExit(PyObject *self, PyObject *args){
+    PyAtomic* pyAtomic = (PyAtomic*)self;
+    LockHandler_Release(pyAtomic->ctx);
+    Py_INCREF(self);
+    return self;
+}
+
+static void PyAtomic_Destruct(PyObject *pyObj){
+    PyAtomic* pyAtomic = (PyAtomic*)pyObj;
+    RedisModule_FreeThreadSafeContext(pyAtomic->ctx);
+    Py_TYPE(pyObj)->tp_free((PyObject*)pyObj);
+}
+
+PyMethodDef PyAtomicMethods[] = {
+    {"__enter__", atomicEnter, METH_VARARGS, "acquire the GIL"},
+    {"__exit__", atomicExit, METH_VARARGS, "release the GIL"},
+    {NULL, NULL, 0, NULL}
+};
+
 /* Flat Execution operations */
 PyMethodDef PyFlatExecutionMethods[] = {
     {"map", map, METH_VARARGS, "map operation on each record"},
@@ -909,6 +940,30 @@ static void PyFlatExecution_Destruct(PyObject *pyObj){
     Py_TYPE(pyObj)->tp_free((PyObject*)pyObj);
 }
 
+static PyTypeObject PyAtomicType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "redisgears.PyAtomic",     /* tp_name */
+    sizeof(PyAtomic),          /* tp_basicsize */
+    0,                         /* tp_itemsize */
+    PyAtomic_Destruct,         /* tp_dealloc */
+    0,                         /* tp_print */
+    0,                         /* tp_getattr */
+    0,                         /* tp_setattr */
+    0,                         /* tp_compare */
+    0,                         /* tp_repr */
+    0,                         /* tp_as_number */
+    0,                         /* tp_as_sequence */
+    0,                         /* tp_as_mapping */
+    0,                         /* tp_hash */
+    0,                         /* tp_call */
+    0,                         /* tp_str */
+    0,                         /* tp_getattro */
+    0,                         /* tp_setattro */
+    0,                         /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,        /* tp_flags */
+    "PyAtomic",                /* tp_doc */
+};
+
 static PyTypeObject PyFlatExecutionType = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "redisgears.PyFlatExecution",       /* tp_name */
@@ -932,6 +987,12 @@ static PyTypeObject PyFlatExecutionType = {
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,        /* tp_flags */
     "PyFlatExecution",         /* tp_doc */
 };
+
+static PyObject* atomicCtx(PyObject *cls, PyObject *args){
+    PyAtomic* pyAtomic = PyObject_New(PyAtomic, &PyAtomicType);
+    pyAtomic->ctx = RedisModule_GetThreadSafeContext(NULL);
+    return (PyObject*)pyAtomic;
+}
 
 static PyObject* gearsCtx(PyObject *cls, PyObject *args){
     PythonThreadCtx* ptctx = GetPythonThreadCtx();
@@ -1789,6 +1850,7 @@ static PyObject* gearsTimeEvent(PyObject *cls, PyObject *args){
 
 PyMethodDef EmbRedisGearsMethods[] = {
     {"gearsCtx", gearsCtx, METH_VARARGS, "creating an empty gears context"},
+    {"atomicCtx", atomicCtx, METH_VARARGS, "creating a atomic ctx for atomic block"},
     {"_saveGlobals", saveGlobals, METH_VARARGS, "should not be use"},
     {"executeCommand", executeCommand, METH_VARARGS, "execute a redis command and return the result"},
     {"log", RedisLog, METH_VARARGS, "write a message into the redis log file"},
@@ -2469,15 +2531,15 @@ static char* RedisGearsPy_PyObjectToString(void* arg){
     return objCstr;
 }
 
-void RedisGearsPy_PyObjectSerialize(void* arg, Gears_BufferWriter* bw){
+int RedisGearsPy_PyObjectSerialize(void* arg, Gears_BufferWriter* bw, char** err){
     void* old = RedisGearsPy_Lock(NULL);
     PyObject* obj = arg;
     PyObject* objStr = PyMarshal_WriteObjectToString(obj, Py_MARSHAL_VERSION);
     if(!objStr){
-        char* error = getPyError();
-        RedisModule_Log(NULL, "warning", "Error occured on RedisGearsPy_PyObjectSerialize, error=%s", error);
-        RG_FREE(error);
-        assert(false);
+        *err = getPyError();
+        RedisModule_Log(NULL, "warning", "Error occured on RedisGearsPy_PyObjectSerialize, error=%s", *err);
+        RedisGearsPy_Unlock(old);
+        return REDISMODULE_ERR;
     }
     size_t len;
     char* objStrCstr;
@@ -2485,7 +2547,7 @@ void RedisGearsPy_PyObjectSerialize(void* arg, Gears_BufferWriter* bw){
     RedisGears_BWWriteBuffer(bw, objStrCstr, len);
     Py_DECREF(objStr);
     RedisGearsPy_Unlock(old);
-    return;
+    return REDISMODULE_OK;
 }
 
 void* RedisGearsPy_PyObjectDeserialize(Gears_BufferReader* br){
@@ -2920,23 +2982,34 @@ int RedisGearsPy_Init(RedisModuleCtx *ctx){
     PyTensorType.tp_new = PyType_GenericNew;
     PyGraphRunnerType.tp_new = PyType_GenericNew;
     PyFlatExecutionType.tp_new = PyType_GenericNew;
+    PyAtomicType.tp_new = PyType_GenericNew;
 
     PyFlatExecutionType.tp_methods = PyFlatExecutionMethods;
+    PyAtomicType.tp_methods = PyAtomicMethods;
 
     if (PyType_Ready(&PyTensorType) < 0){
         RedisModule_Log(ctx, "warning", "PyTensorType not ready");
+        return REDISMODULE_ERR;
     }
 
     if (PyType_Ready(&PyGraphRunnerType) < 0){
         RedisModule_Log(ctx, "warning", "PyGraphRunnerType not ready");
+        return REDISMODULE_ERR;
     }
 
     if (PyType_Ready(&PyTorchScriptRunnerType) < 0){
         RedisModule_Log(ctx, "warning", "PyGraphRunnerType not ready");
+        return REDISMODULE_ERR;
     }
 
     if (PyType_Ready(&PyFlatExecutionType) < 0){
         RedisModule_Log(ctx, "warning", "PyFlatExecutionType not ready");
+        return REDISMODULE_ERR;
+    }
+
+    if (PyType_Ready(&PyAtomicType) < 0){
+        RedisModule_Log(ctx, "warning", "PyAtomicType not ready");
+        return REDISMODULE_ERR;
     }
 
     PyObject* pName = PyUnicode_FromString("gearsclient");
@@ -2958,12 +3031,13 @@ int RedisGearsPy_Init(RedisModuleCtx *ctx){
     Py_INCREF(&PyGraphRunnerType);
     Py_INCREF(&PyTorchScriptRunnerType);
     Py_INCREF(&PyFlatExecutionType);
+    Py_INCREF(&PyAtomicType);
 
     PyModule_AddObject(redisAIModule, "PyTensor", (PyObject *)&PyTensorType);
     PyModule_AddObject(redisAIModule, "PyGraphRunner", (PyObject *)&PyGraphRunnerType);
     PyModule_AddObject(redisAIModule, "PyTorchScriptRunner", (PyObject *)&PyTorchScriptRunnerType);
     PyModule_AddObject(redisGearsModule, "PyFlatExecution", (PyObject *)&PyFlatExecutionType);
-
+    PyModule_AddObject(redisGearsModule, "PyAtomic", (PyObject *)&PyAtomicType);
     GearsError = PyErr_NewException("spam.error", NULL, NULL);
     Py_INCREF(GearsError);
     PyModule_AddObject(redisGearsModule, "GearsError", GearsError);

--- a/src/redisgears_python.h
+++ b/src/redisgears_python.h
@@ -16,7 +16,7 @@ typedef struct PythonSessionCtx PythonSessionCtx;
 
 typedef void (*DoneCallbackFunction)(ExecutionPlan*, void*); 
 
-void RedisGearsPy_PyObjectSerialize(void* arg, Gears_BufferWriter* bw);
+int RedisGearsPy_PyObjectSerialize(void* arg, Gears_BufferWriter* bw, char** err);
 void* RedisGearsPy_PyObjectDeserialize(Gears_BufferReader* br);
 int RedisGearsPy_Execute(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int RedisGearsPy_ExecuteWithCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, DoneCallbackFunction callback);


### PR DESCRIPTION
Sometime you need to execute a block of code and make sure not other commands will
run in between, 'with atomic()' allows you to do it.
example:
```
with atomic():
   execute(...)
   execute(...)
   execute(...)
```