### PR TITLE
Added thread pull support to run execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,8 @@ SRCDIR=src
 _SOURCES=utils/adlist.c utils/buffer.c utils/dict.c module.c execution_plan.c \
 	mgmt.c readers/keys_reader.c example.c filters.c mappers.c utils/thpool.c \
 	extractors.c reducers.c record.c cluster.c commands.c readers/streams_reader.c \
-	globals.c config.c lock_handler.c module_init.c slots_table.c common.c readers/command_reader.c
+	globals.c config.c lock_handler.c module_init.c slots_table.c common.c readers/command_reader.c \
+	readers/shardid_reader.c
 ifeq ($(WITHPYTHON),1)
 _SOURCES += redisgears_python.c
 endif

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ CC=gcc
 SRCDIR=src
 
 _SOURCES=utils/adlist.c utils/buffer.c utils/dict.c module.c execution_plan.c \
-	mgmt.c readers/keys_reader.c example.c filters.c mappers.c \
+	mgmt.c readers/keys_reader.c example.c filters.c mappers.c utils/thpool.c \
 	extractors.c reducers.c record.c cluster.c commands.c readers/streams_reader.c \
 	globals.c config.c lock_handler.c module_init.c slots_table.c common.c readers/command_reader.c
 ifeq ($(WITHPYTHON),1)

--- a/pytest/test_basics.py
+++ b/pytest/test_basics.py
@@ -357,7 +357,8 @@ GB().map(returnX).run()
     env.expect('rg.pyexecute', script).equal([['2'], []])
     env.expect('rg.pyexecute', script).equal([['2'], []])
 
-def testAbortExecution(env):
+def testAbortExecution():
+    env = Env(moduleArgs='executionThreads 1')
     env.skipOnCluster()
     infinitScript = '''
 def InfinitLoop(r):

--- a/pytest/test_errors.py
+++ b/pytest/test_errors.py
@@ -147,12 +147,12 @@ def testCommandReaderWithBadArgs(env):
     env.expect('rg.pyexecute', 'GB("CommandReader").register("bla")').error().contains('command argument is not string')
 
 def testCommandReaderRegisterSameCommand(env):
-    env.expect('rg.pyexecute', 'GB("CommandReader").register(command="command")').ok()
-    env.expect('rg.pyexecute', 'GB("CommandReader").register(command="command")').error().contains('Command already registered')
+    env.expect('rg.pyexecute', 'GB("CommandReader").register(trigger="command")').ok()
+    env.expect('rg.pyexecute', 'GB("CommandReader").register(trigger="command")').error().contains('Command already registered')
 
 def testCommandReaderRegisterWithExcpetionCommand(env):
-    env.expect('rg.pyexecute', 'GB("CommandReader").foreach(lambda x: noexists).register(command="command")').ok()
-    env.expect('rg.command', 'command').error().contains("'noexists' is not defined")
+    env.expect('rg.pyexecute', 'GB("CommandReader").foreach(lambda x: noexists).register(trigger="command")').ok()
+    env.expect('rg.trigger', 'command').error().contains("'noexists' is not defined")
 
 
 class testStepsWrongArgs:

--- a/pytest/test_register.py
+++ b/pytest/test_register.py
@@ -871,14 +871,14 @@ def testStreamTrimming(env):
 
 def testCommandReaderBasic(env):
     conn = getConnectionByEnv(env)
-    env.expect('RG.PYEXECUTE', "GB('CommandReader').flatmap(lambda x: x).distinct().sort().register(command='test1')").ok()
-    env.expect('RG.COMMAND', 'test1', 'this', 'is', 'a', 'test').equal(['a', 'is', 'test', 'test1', 'this'])
-    env.expect('RG.PYEXECUTE', "GB('CommandReader').flatmap(lambda x: x).distinct().sort().register(command='test2', mode='sync')").ok()
-    env.expect('RG.COMMAND', 'test2', 'this', 'is', 'a', 'test').equal(['a', 'is', 'test', 'test2', 'this'])
-    env.expect('RG.PYEXECUTE', "GB('CommandReader').flatmap(lambda x: x).distinct().sort().register(command='test3', mode='async_local')").ok()
-    env.expect('RG.COMMAND', 'test3', 'this', 'is', 'a', 'test').equal(['a', 'is', 'test', 'test3', 'this'])
+    env.expect('RG.PYEXECUTE', "GB('CommandReader').flatmap(lambda x: x).distinct().sort().register(trigger='test1')").ok()
+    env.expect('RG.TRIGGER', 'test1', 'this', 'is', 'a', 'test').equal(['a', 'is', 'test', 'test1', 'this'])
+    env.expect('RG.PYEXECUTE', "GB('CommandReader').flatmap(lambda x: x).distinct().sort().register(trigger='test2', mode='sync')").ok()
+    env.expect('RG.TRIGGER', 'test2', 'this', 'is', 'a', 'test').equal(['a', 'is', 'test', 'test2', 'this'])
+    env.expect('RG.PYEXECUTE', "GB('CommandReader').flatmap(lambda x: x).distinct().sort().register(trigger='test3', mode='async_local')").ok()
+    env.expect('RG.TRIGGER', 'test3', 'this', 'is', 'a', 'test').equal(['a', 'is', 'test', 'test3', 'this'])
 
 def testCommandReaderCluster(env):
     conn = getConnectionByEnv(env)
-    env.expect('RG.PYEXECUTE', "GB('CommandReader').count().register(command='GetNumShard')").ok()
-    env.expect('RG.COMMAND', 'GetNumShard').equal([str(env.shardsCount)])
+    env.expect('RG.PYEXECUTE', "GB('CommandReader').count().register(trigger='GetNumShard')").ok()
+    env.expect('RG.TRIGGER', 'GetNumShard').equal([str(env.shardsCount)])

--- a/pytest/test_register.py
+++ b/pytest/test_register.py
@@ -136,7 +136,8 @@ def testMaxExecutionPerRegistrationKeysReader(env):
     for r in registrations:
         env.expect('RG.UNREGISTER', r[1], ).equal('OK')
 
-def testUnregisterKeysReaderWithAbortExecutions(env):
+def testUnregisterKeysReaderWithAbortExecutions():
+    env = Env(moduleArgs='executionThreads 1')
     env.skipOnCluster()
     infinitScript = '''
 counter = 0
@@ -194,7 +195,8 @@ GB().map(InfinitLoop).register('*', mode='async_local')
 
     env.cmd('RG.DROPEXECUTION', eid)
 
-def testUnregisterStreamReaderWithAbortExecutions(env):
+def testUnregisterStreamReaderWithAbortExecutions():
+    env = Env(moduleArgs='executionThreads 1')
     env.skipOnCluster()
     infinitScript = '''
 counter = 0
@@ -417,19 +419,20 @@ def testRegistersSurviveRestart(env):
                             "foreach(lambda x: execute('incrby', 'NumOfKeys{%s}' % (hashtag()), ('1' if 'value' in x.keys() else '-1')))."
                             "register(mode='async_local')")
 
+    # todo: change it not to use sleep
     time.sleep(0.1) # wait for execution to reach all the shards
 
     for _ in env.reloading_iterator():
-        for i in range(100):
+        for i in range(20):
             conn.set(str(i), str(i))
 
-        for i in range(100):
+        for i in range(20):
             conn.delete(str(i))
 
         # wait for all executions to finish
         res = 0
-        while res < 200:
-            res = env.cmd('rg.pyexecute', "GB('ShardsIDReader').map(lambda x: len([r for r in execute('rg.dumpexecutions') if r[3] == 'done'])).aggregate(0, lambda a, x: x, lambda a, x: a + x).run()")
+        while res < 80:
+            res = int(env.cmd('rg.pyexecute', "GB('ShardsIDReader').map(lambda x: len([r for r in execute('rg.dumpexecutions') if r[3] == 'done'])).aggregate(0, lambda a, x: x, lambda a, x: a + x).run()")[0][0])
 
         numOfKeys = env.cmd('rg.pyexecute', "GB().map(lambda x: int(x['value'])).aggregate(0, lambda a, x: x, lambda a, x: a + x).run('NumOfKeys*')")[0][0]
         env.assertEqual(numOfKeys, '0')
@@ -827,8 +830,8 @@ def testStreamTrimming(env):
     conn = getConnectionByEnv(env)
 
     # {06S} is going to first slot
-    env.cmd('rg.pyexecute', "GB('StreamReader').register('s1{06S}')")
-    env.cmd('rg.pyexecute', "GB('StreamReader').register('s2{06S}', trimStream=False)")
+    env.cmd('rg.pyexecute', "GB('StreamReader').register('s1{06S}', mode='async_local')")
+    env.cmd('rg.pyexecute', "GB('StreamReader').register('s2{06S}', mode='async_local', trimStream=False)")
 
     env.cmd('XADD s2{06S} * foo bar')
     env.cmd('XADD s1{06S} * foo bar')

--- a/ramp.yml
+++ b/ramp.yml
@@ -30,4 +30,4 @@ exclude_commands:
     - rg.networktest
     - rg.pyfreeinterpreter
 overide_command:
-    - {"command_arity": -1, "command_name": "rg.command", "first_key": 2, "flags": ["readonly"], "last_key": 2, "step": 1}
+    - {"command_arity": -1, "command_name": "rg.trigger", "first_key": 2, "flags": ["readonly"], "last_key": 2, "step": 1}

--- a/src/GearsBuilder.py
+++ b/src/GearsBuilder.py
@@ -128,7 +128,7 @@ class GearsBuilder():
                  onFailedPolicy="continue",
                  onFailedRetryInterval=1,
                  trimStream=True,
-                 command=None,
+                 trigger=None,
                  convertToStr=True,
                  collect=True):
         if(convertToStr):
@@ -145,7 +145,7 @@ class GearsBuilder():
                                onFailedPolicy=onFailedPolicy, 
                                onFailedRetryInterval=onFailedRetryInterval,
                                trimStream=trimStream,
-                               command=command)
+                               trigger=trigger)
 
 def createDecorator(f):
     def deco(self, *args):

--- a/src/commands.c
+++ b/src/commands.c
@@ -173,7 +173,7 @@ Record* Command_AbortExecutionMap(ExecutionCtx* rctx, Record *data, void* arg){
         ExecutionPlan* gearsCtx = RedisGears_GetExecution(executionId);
 
         if(!gearsCtx){
-            RedisGears_SetError(rctx, "execution does not exists");
+            RedisGears_SetError(rctx, "execution does not exist");
             LockHandler_Release(ctx);
             return NULL;
         }

--- a/src/commands.c
+++ b/src/commands.c
@@ -3,10 +3,14 @@
 #include "cluster.h"
 #include "record.h"
 #include "execution_plan.h"
+#include "lock_handler.h"
 #ifdef WITHPYTHON
 #include <Python.h>
 #include <object.h>
 #endif
+
+static ExecutionThreadPool* mgmtPool;
+static WorkerData* mgmtWorker;
 
 static void Command_ReturnResult(RedisModuleCtx* rctx, Record* record){
     size_t listLen;
@@ -159,37 +163,46 @@ int Command_GetResultsBlocking(RedisModuleCtx *ctx, RedisModuleString **argv, in
 	return REDISMODULE_OK;
 }
 
-int Command_AbortExecution(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
-    if(argc != 2){
-        return RedisModule_WrongArity(ctx);
+Record* Command_AbortExecutionMap(ExecutionCtx* rctx, Record *data, void* arg){
+    const char* executionId = arg;
+    RedisGears_FreeRecord(data);
+    RedisModuleCtx* ctx = RedisGears_GetRedisModuleCtx(rctx);
+
+    while(true){
+        LockHandler_Acquire(ctx);
+        ExecutionPlan* gearsCtx = RedisGears_GetExecution(executionId);
+
+        if(!gearsCtx){
+            RedisGears_SetError(rctx, "execution does not exists");
+            LockHandler_Release(ctx);
+            return NULL;
+        }
+
+        if(RedisGears_IsDone(gearsCtx)){
+            LockHandler_Release(ctx);
+            return RedisGears_StringRecordCreate(RG_STRDUP("OK"), strlen("OK"));
+        }
+
+        if(gearsCtx->isPaused){
+            // abort the execution and execute its Done Actions
+            gearsCtx->status = ABORTED;
+            EPStatus_DoneAction(gearsCtx);
+            LockHandler_Release(ctx);
+            return RedisGears_StringRecordCreate(RG_STRDUP("OK"), strlen("OK"));
+        }
+#ifdef WITHPYTHON
+        // execution is running
+        unsigned long threadID = (unsigned long)gearsCtx->executionPD;
+        LockHandler_Release(ctx);
+
+        RedisGearsPy_ForceStop(threadID);
+        usleep(1000);
+#else
+        LockHandler_Release(ctx);
+#endif
     }
-
-    const char* id = RedisModule_StringPtrLen(argv[1], NULL);
-    ExecutionPlan* gearsCtx = RedisGears_GetExecution(id);
-
-    if(!gearsCtx){
-        RedisModule_ReplyWithError(ctx, "Execution plan does not exits");
-        return REDISMODULE_OK;
-    }
-
-    if(RedisGears_IsDone(gearsCtx)){
-        RedisModule_ReplyWithError(ctx, "Execution already finished.");
-        return REDISMODULE_OK;
-    }
-
-    if(EPIsFlagOff(gearsCtx, EFIsLocal)){
-        RedisModule_ReplyWithError(ctx, "Can not abort non-local execution.");
-        return REDISMODULE_OK;
-    }
-
-    if(RedisGears_AbortExecution(gearsCtx) != REDISMODULE_OK){
-        RedisModule_ReplyWithError(ctx, "Failed aborting execution.");
-        return REDISMODULE_OK;
-    }
-
-    RedisModule_ReplyWithSimpleString(ctx, "OK");
-
-    return REDISMODULE_OK;
+    assert(false);
+    return NULL;
 }
 
 int Command_DropExecution(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
@@ -215,6 +228,81 @@ int Command_DropExecution(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
 	RedisModule_ReplyWithSimpleString(ctx, "OK");
 
 	return REDISMODULE_OK;
+}
+
+static void Command_AbortDone(ExecutionPlan* gearsCtx, void *privateData){
+    RedisModuleBlockedClient* bc = privateData;
+    RedisModuleCtx* rctx = RedisModule_GetThreadSafeContext(bc);
+    if(RedisGears_GetErrorsLen(gearsCtx) > 0){
+        Record* error = RedisGears_GetError(gearsCtx, 0);
+        RedisModule_ReplyWithError(rctx, RedisGears_StringRecordGet(error, NULL));
+    }else{
+        RedisModule_ReplyWithSimpleString(rctx, "OK");
+    }
+    RedisModule_UnblockClient(bc, NULL);
+    RedisModule_FreeThreadSafeContext(rctx);
+
+    RedisGears_DropExecution(gearsCtx);
+}
+
+int Command_AbortExecution(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
+    if(argc != 2){
+        return RedisModule_WrongArity(ctx);
+    }
+
+    RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
+
+    const char* id = RedisModule_StringPtrLen(argv[1], NULL);
+
+    char* err = NULL;
+    FlatExecutionPlan* fep = RGM_CreateCtx(ShardIDReader);
+    RGM_Map(fep, Command_AbortExecutionMap, RG_STRDUP(id));
+    RGM_Collect(fep);
+    ExecutionPlan* ep = RedisGears_Run(fep, ExecutionModeAsync, NULL, Command_AbortDone, bc, mgmtWorker, &err);
+    if(!ep){
+        RedisModule_AbortBlock(bc);
+        RedisModule_ReplyWithError(ctx, err);
+        RG_FREE(err);
+    }
+
+    RedisGears_FreeFlatExecution(fep);
+
+    return REDISMODULE_OK;
+}
+
+static void Command_StringFree(void* arg){
+    RG_FREE(arg);
+}
+
+static void* Command_StringDup(void* arg){
+    return RG_STRDUP(arg);
+}
+
+static int Command_StringSerialize(void* arg, Gears_BufferWriter* bw, char** err){
+    RedisGears_BWWriteString(bw, arg);
+    return REDISMODULE_OK;
+}
+
+static void* Command_StringDeserialize(FlatExecutionPlan* fep, Gears_BufferReader* br, char** err){
+    const char* id = RedisGears_BRReadString(br);
+    return RG_STRDUP(id);
+}
+
+static char* Command_StringToString(void* arg){
+    return RG_STRDUP(arg);
+}
+
+int Command_Init(){
+    mgmtPool = ExecutionPlan_CreateThreadPool("MgmtPool", 1);
+    mgmtWorker = ExecutionPlan_CreateWorker(mgmtPool);
+    ArgType* stringType = RedisGears_CreateType("StringType",
+                                                Command_StringFree,
+                                                Command_StringDup,
+                                                Command_StringSerialize,
+                                                Command_StringDeserialize,
+                                                Command_StringToString);
+    RGM_RegisterMap(Command_AbortExecutionMap, stringType)
+    return REDISMODULE_OK;
 }
 
 

--- a/src/commands.h
+++ b/src/commands.h
@@ -18,6 +18,7 @@ int Command_AbortExecution(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
 int Command_DropExecution(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int Command_GetResults(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int Command_GetResultsBlocking(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-int Command_ReExecute(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+
+int Command_Init();
 
 #endif /* SRC_COMMANDS_H_ */

--- a/src/config.h
+++ b/src/config.h
@@ -18,6 +18,7 @@ long long GearsConfig_GetPythonAttemptTraceback();
 const char* GearsConfig_GetDependenciesUrl();
 const char* GearsConfig_GetDependenciesSha256();
 long long GearsConfig_CreateVenv();
+long long GearsConfig_ExecutionThreads();
 const char* GearsConfig_GetExtraConfigVals(const char* key);
 
 #endif /* SRC_CONFIG_H_ */

--- a/src/execution_plan.c
+++ b/src/execution_plan.c
@@ -2034,7 +2034,6 @@ void ExecutionPlan_Initialize(){
     epData.epDict = Gears_dictCreate(dictTypeHeapIdsPtr, NULL);
     epData.registeredFepDict = Gears_dictCreate(dictTypeHeapIdsPtr, NULL);
     epData.epList = Gears_listCreate();
-    pthread_mutex_init(&epData.mutex, NULL);
 
     Cluster_RegisterMsgReceiverM(ExecutionPlan_UnregisterExecutionReceived);
     Cluster_RegisterMsgReceiverM(ExecutionPlan_OnReceived);

--- a/src/mgmt.c
+++ b/src/mgmt.c
@@ -41,6 +41,7 @@ GENERATE(Accumulate)
 GENERATE(AccumulateByKey)
 GENERATE(FepPrivateData)
 GENERATE(ExecutionOnStart)
+GENERATE(ExecutionOnUnpaused)
 GENERATE(FlatExecutionOnRegistered)
 
 void Mgmt_Init(){
@@ -54,5 +55,6 @@ void Mgmt_Init(){
     AccumulateByKeysMgmt_Init();
     FepPrivateDatasMgmt_Init();
     ExecutionOnStartsMgmt_Init();
+    ExecutionOnUnpausedsMgmt_Init();
     FlatExecutionOnRegisteredsMgmt_Init();
 }

--- a/src/mgmt.h
+++ b/src/mgmt.h
@@ -70,6 +70,10 @@ bool ExecutionOnStartsMgmt_Add(const char* name, RedisGears_ExecutionOnStartCall
 RedisGears_ExecutionOnStartCallback ExecutionOnStartsMgmt_Get(const char* name);
 ArgType* ExecutionOnStartsMgmt_GetArgType(const char* name);
 
+bool ExecutionOnUnpausedsMgmt_Add(const char* name, RedisGears_ExecutionOnUnpausedCallback callback, ArgType* type);
+RedisGears_ExecutionOnUnpausedCallback ExecutionOnUnpausedsMgmt_Get(const char* name);
+ArgType* ExecutionOnUnpausedsMgmt_GetArgType(const char* name);
+
 bool FlatExecutionOnRegisteredsMgmt_Add(const char* name, RedisGears_FlatExecutionOnRegisteredCallback callback, ArgType* type);
 RedisGears_FlatExecutionOnRegisteredCallback FlatExecutionOnRegisteredsMgmt_Get(const char* name);
 ArgType* FlatExecutionOnRegisteredsMgmt_GetArgType(const char* name);

--- a/src/module.c
+++ b/src/module.c
@@ -237,8 +237,8 @@ static KeysReaderTriggerArgs* RG_KeysReaderTriggerArgsCreate(const char* regex, 
     return KeysReaderTriggerArgs_Create(regex, eventTypes, keyTypes);
 }
 
-static CommandReaderTriggerArgs* RG_CommandReaderTriggerArgsCreate(const char* command){
-    return CommandReaderTriggerArgs_Create(command);
+static CommandReaderTriggerArgs* RG_CommandReaderTriggerArgsCreate(const char* trigger){
+    return CommandReaderTriggerArgs_Create(trigger);
 }
 static void RG_CommandReaderTriggerArgsFree(CommandReaderTriggerArgs* args){
     CommandReaderTriggerArgs_Free(args);

--- a/src/readers/command_reader.c
+++ b/src/readers/command_reader.c
@@ -47,7 +47,7 @@ static CommandReaderTriggerCtx* CommandReaderTriggerCtx_Create(FlatExecutionPlan
             .numAborted = 0,
             .lastError = NULL,
             .pendingExections = Gears_dictCreate(&Gears_dictTypeHeapStrings, NULL),
-            .wd = RedisGears_WorkerDataCreate(),
+            .wd = RedisGears_WorkerDataCreate(NULL),
     };
     return ret;
 }

--- a/src/readers/command_reader.c
+++ b/src/readers/command_reader.c
@@ -4,17 +4,17 @@
 #include "record.h"
 
 typedef struct CommandReaderTriggerArgs{
-    char* command;
+    char* trigger;
 }CommandReaderTriggerArgs;
 
-CommandReaderTriggerArgs* CommandReaderTriggerArgs_Create(const char* commandName){
+CommandReaderTriggerArgs* CommandReaderTriggerArgs_Create(const char* trigger){
     CommandReaderTriggerArgs* ret = RG_ALLOC(sizeof(*ret));
-    ret->command = RG_STRDUP(commandName);
+    ret->trigger = RG_STRDUP(trigger);
     return ret;
 }
 
 void CommandReaderTriggerArgs_Free(CommandReaderTriggerArgs* crtArgs){
-    RG_FREE(crtArgs->command);
+    RG_FREE(crtArgs->trigger);
     RG_FREE(crtArgs);
 }
 
@@ -154,7 +154,7 @@ static Reader* CommandReader_Create(void* arg){
 
 static void CommandReader_InnerRegister(FlatExecutionPlan* fep, ExecutionMode mode, CommandReaderTriggerArgs* crtArgs){
     CommandReaderTriggerCtx* crtCtx = CommandReaderTriggerCtx_Create(fep, mode, crtArgs);
-    Gears_dictAdd(CommandRegistrations, crtArgs->command, crtCtx);
+    Gears_dictAdd(CommandRegistrations, crtArgs->trigger, crtCtx);
 }
 
 static int CommandReader_RegisrterTrigger(FlatExecutionPlan* fep, ExecutionMode mode, void* args, char** err){
@@ -162,7 +162,7 @@ static int CommandReader_RegisrterTrigger(FlatExecutionPlan* fep, ExecutionMode 
         CommandRegistrations = Gears_dictCreate(&Gears_dictTypeHeapStrings, NULL);
     }
     CommandReaderTriggerArgs* crtArgs = args;
-    CommandReaderTriggerCtx* crtCtx = Gears_dictFetchValue(CommandRegistrations, crtArgs->command);
+    CommandReaderTriggerCtx* crtCtx = Gears_dictFetchValue(CommandRegistrations, crtArgs->trigger);
     if(crtCtx){
         *err = RG_STRDUP("Command already registered");
         return REDISMODULE_ERR;
@@ -220,14 +220,14 @@ static void CommandReader_UnregisterTrigger(FlatExecutionPlan* fep, bool abortPe
 
             array_free(abortEpArray);
         }
-        Gears_dictDelete(CommandRegistrations, crtCtx->args->command);
+        Gears_dictDelete(CommandRegistrations, crtCtx->args->trigger);
         CommandReaderTriggerCtx_Free(crtCtx);
     }
 }
 
 static void CommandReader_SerializeArgs(void* var, Gears_BufferWriter* bw){
     CommandReaderTriggerArgs* crtArgs = var;
-    RedisGears_BWWriteString(bw, crtArgs->command);
+    RedisGears_BWWriteString(bw, crtArgs->trigger);
 }
 
 static void* CommandReader_DeserializeArgs(Gears_BufferReader* br){
@@ -265,8 +265,8 @@ static void CommandReader_DumpRegistrationData(RedisModuleCtx* ctx, FlatExecutio
     }
     RedisModule_ReplyWithStringBuffer(ctx, "args", strlen("args"));
     RedisModule_ReplyWithArray(ctx, 2);
-    RedisModule_ReplyWithStringBuffer(ctx, "command", strlen("command"));
-    RedisModule_ReplyWithStringBuffer(ctx, crtCtx->args->command, strlen(crtCtx->args->command));
+    RedisModule_ReplyWithStringBuffer(ctx, "trigger", strlen("trigger"));
+    RedisModule_ReplyWithStringBuffer(ctx, crtCtx->args->trigger, strlen(crtCtx->args->trigger));
 }
 
 static void CommandReader_RdbSave(RedisModuleIO *rdb){
@@ -442,7 +442,7 @@ static void CommandReader_OnDone(ExecutionPlan* ep, void* privateData){
     CommandPD_Free(pd);
 }
 
-static int CommandReader_Command(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
+static int CommandReader_Trigger(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
     if(argc < 2){
         return RedisModule_WrongArity(ctx);
     }
@@ -492,7 +492,7 @@ int CommandReader_Initialize(RedisModuleCtx* ctx){
     // this command is considered readonly but it might actaully right data to redis
     // using rm_call. In this case the effect of the execution is replicated
     // and not the execution itself.
-    if (RedisModule_CreateCommand(ctx, "rg.command", CommandReader_Command, "readonly", 0, 0, 0) != REDISMODULE_OK) {
+    if (RedisModule_CreateCommand(ctx, "rg.trigger", CommandReader_Trigger, "readonly", 0, 0, 0) != REDISMODULE_OK) {
         RedisModule_Log(ctx, "warning", "could not register command rg.command");
         return REDISMODULE_ERR;
     }

--- a/src/readers/command_reader.h
+++ b/src/readers/command_reader.h
@@ -6,7 +6,7 @@
 extern RedisGears_ReaderCallbacks CommandReader;
 
 int CommandReader_Initialize(RedisModuleCtx* ctx);
-CommandReaderTriggerArgs* CommandReaderTriggerArgs_Create(const char* commandName);
+CommandReaderTriggerArgs* CommandReaderTriggerArgs_Create(const char* trigger);
 void CommandReaderTriggerArgs_Free(CommandReaderTriggerArgs* crtArgs);
 
 #endif /* SRC_READERS_COMMAND_READER_H_ */

--- a/src/readers/keys_reader.c
+++ b/src/readers/keys_reader.c
@@ -29,6 +29,7 @@ typedef struct KeysReaderRegisterData{
     unsigned long long numAborted;
     Gears_list* localPendingExecutions;
     Gears_list* localDoneExecutions;
+    WorkerData* wd;
 }KeysReaderRegisterData;
 
 Gears_list* keysReaderRegistration = NULL;
@@ -94,6 +95,7 @@ static void KeysReaderRegisterData_Free(KeysReaderRegisterData* rData){
         }
         KeysReaderTriggerArgs_Free(rData->args);
         FlatExecutionPlan_Free(rData->fep);
+        RedisGears_WorkerDataFree(rData->wd);
         RG_FREE(rData);
     }
 }
@@ -112,6 +114,7 @@ static KeysReaderRegisterData* KeysReaderRegisterData_Create(FlatExecutionPlan* 
         .numAborted = 0,
         .localPendingExecutions = Gears_listCreate(),
         .localDoneExecutions = Gears_listCreate(),
+        .wd = RedisGears_WorkerDataCreate(),
     };
     return rData;
 }
@@ -521,10 +524,14 @@ static int KeysReader_OnKeyTouched(RedisModuleCtx *ctx, int type, const char *ev
             void* privateData = NULL;
             callback = KeysReader_ExecutionDone;
             privateData = KeysReaderRegisterData_GetShallowCopy(rData);
-            ExecutionPlan* ep = RedisGears_Run(rData->fep, rData->mode, RG_STRDUP(keyCStr), callback, privateData, NULL);
+            char* err = NULL;
+            ExecutionPlan* ep = RedisGears_Run(rData->fep, rData->mode, RG_STRDUP(keyCStr), callback, privateData, rData->wd, &err);
             if(!ep){
                 ++rData->numAborted;
-                RedisModule_Log(ctx, "warning", "could not execute flat execution on trigger");
+                RedisModule_Log(ctx, "warning", "could not execute flat execution on trigger, %s", err);
+                if(err){
+                    RG_FREE(err);
+                }
                 continue;
             }
             if(EPIsFlagOn(ep, EFIsLocal) && rData->mode != ExecutionModeSync){

--- a/src/readers/keys_reader.c
+++ b/src/readers/keys_reader.c
@@ -114,7 +114,7 @@ static KeysReaderRegisterData* KeysReaderRegisterData_Create(FlatExecutionPlan* 
         .numAborted = 0,
         .localPendingExecutions = Gears_listCreate(),
         .localDoneExecutions = Gears_listCreate(),
-        .wd = RedisGears_WorkerDataCreate(),
+        .wd = RedisGears_WorkerDataCreate(NULL),
     };
     return rData;
 }

--- a/src/readers/shardid_reader.c
+++ b/src/readers/shardid_reader.c
@@ -1,0 +1,61 @@
+#include "shardid_reader.h"
+#include "cluster.h"
+
+typedef struct ShardIDReaderCtx{
+    bool isDone;
+}ShardIDReaderCtx;
+
+static Record* ShardIDReader_Next(ExecutionCtx* rctx, void* ctx){
+    ShardIDReaderCtx* sidCtx = ctx;
+    if(sidCtx->isDone){
+        return NULL;
+    }
+    const char* myId = Cluster_IsClusterMode() ? Cluster_GetMyId() : "1";
+    sidCtx->isDone = true;
+    return RedisGears_StringRecordCreate(RG_STRDUP(myId), strlen(myId));
+}
+
+static void ShardIDReader_free(void* ctx){
+    RG_FREE(ctx);
+}
+
+static void ShardIDReader_reset(void* ctx, void * arg){
+    ShardIDReaderCtx* sidCtx = ctx;
+    sidCtx->isDone = false;
+}
+
+static void ShardIDReader_serialize(void* ctx, Gears_BufferWriter* bw){
+
+}
+
+static void ShardIDReader_deserialize(FlatExecutionPlan* fep, void* ctx, Gears_BufferReader* br){
+
+}
+
+static Reader* ShardIDReader_Create(void* arg){
+    ShardIDReaderCtx* ctx = RG_ALLOC(sizeof(*ctx));
+    ctx->isDone = false;
+    Reader* r = RG_ALLOC(sizeof(*r));
+    *r = (Reader){
+        .ctx = ctx,
+        .next = ShardIDReader_Next,
+        .reset = ShardIDReader_reset,
+        .free = ShardIDReader_free,
+        .serialize = ShardIDReader_serialize,
+        .deserialize = ShardIDReader_deserialize,
+    };
+    return r;
+}
+
+RedisGears_ReaderCallbacks ShardIDReader = {
+        .create = ShardIDReader_Create,
+        .registerTrigger = NULL,
+        .unregisterTrigger = NULL,
+        .serializeTriggerArgs = NULL,
+        .deserializeTriggerArgs = NULL,
+        .freeTriggerArgs = NULL,
+        .dumpRegistratioData = NULL,
+        .rdbSave = NULL,
+        .rdbLoad = NULL,
+        .clear = NULL,
+};

--- a/src/readers/shardid_reader.h
+++ b/src/readers/shardid_reader.h
@@ -1,0 +1,15 @@
+/*
+ * shardid_reader.h
+ *
+ *  Created on: Feb 27, 2020
+ *      Author: root
+ */
+
+#ifndef SRC_READERS_SHARDID_READER_H_
+#define SRC_READERS_SHARDID_READER_H_
+
+#include "redisgears.h"
+
+extern RedisGears_ReaderCallbacks ShardIDReader;
+
+#endif /* SRC_READERS_SHARDID_READER_H_ */

--- a/src/readers/streams_reader.c
+++ b/src/readers/streams_reader.c
@@ -262,7 +262,7 @@ static StreamReaderTriggerCtx* StreamReaderTriggerCtx_Create(FlatExecutionPlan* 
         .lastError = NULL,
         .localPendingExecutions = Gears_listCreate(),
         .localDoneExecutions = Gears_listCreate(),
-        .wd = RedisGears_WorkerDataCreate(),
+        .wd = RedisGears_WorkerDataCreate(NULL),
     };
     return srctx;
 }

--- a/src/redisgears.h
+++ b/src/redisgears.h
@@ -28,6 +28,7 @@ typedef struct ExecutionPlan ExecutionPlan;
 typedef struct ExecutionCtx ExecutionCtx;
 typedef struct FlatExecutionPlan FlatExecutionPlan;
 typedef struct Record Record;
+typedef struct WorkerData WorkerData;
 
 /**
  * Records type definitions
@@ -304,8 +305,8 @@ int MODULE_API_FUNC(RedisGears_FlatMap)(FlatExecutionPlan* ctx, char* name, void
 int MODULE_API_FUNC(RedisGears_Limit)(FlatExecutionPlan* ctx, size_t offset, size_t len);
 #define RGM_Limit(ctx, offset, len) RedisGears_Limit(ctx, offset, len)
 
-ExecutionPlan* MODULE_API_FUNC(RedisGears_Run)(FlatExecutionPlan* ctx, ExecutionMode mode, void* arg, RedisGears_OnExecutionDoneCallback callback, void* privateData, char** err);
-#define RGM_Run(ctx, mode, arg, callback, privateData, err) RedisGears_Run(ctx, mode, arg, callback, privateData, err)
+ExecutionPlan* MODULE_API_FUNC(RedisGears_Run)(FlatExecutionPlan* ctx, ExecutionMode mode, void* arg, RedisGears_OnExecutionDoneCallback callback, void* privateData, WorkerData* worker, char** err);
+#define RGM_Run(ctx, mode, arg, callback, privateData, err) RedisGears_Run(ctx, mode, arg, callback, privateData, NULL, err)
 
 int MODULE_API_FUNC(RedisGears_Register)(FlatExecutionPlan* fep, ExecutionMode mode, void* arg, char** err);
 #define RGM_Register(ctx, mode, arg, err) RedisGears_Register(ctx, mode, arg, err)
@@ -353,6 +354,10 @@ void MODULE_API_FUNC(RedisGears_SetPrivateData)(ExecutionCtx* ctx, void* PD);
 bool MODULE_API_FUNC(RedisGears_AddOnDoneCallback)(ExecutionPlan* ep, RedisGears_OnExecutionDoneCallback callback, void* privateData);
 
 const char* MODULE_API_FUNC(RedisGears_GetMyHashTag)();
+
+WorkerData* MODULE_API_FUNC(RedisGears_WorkerDataCreate)();
+void MODULE_API_FUNC(RedisGears_WorkerDataFree)(WorkerData* worker);
+WorkerData* MODULE_API_FUNC(RedisGears_WorkerDataGetShallowCopy)(WorkerData* worker);
 
 int MODULE_API_FUNC(RedisGears_GetLLApiVersion)();
 
@@ -471,6 +476,10 @@ static int RedisGears_Initialize(RedisModuleCtx* ctx){
     REDISGEARS_MODULE_INIT_FUNCTION(ctx, DropLocalyOnDone);
 
     REDISGEARS_MODULE_INIT_FUNCTION(ctx, GetMyHashTag);
+
+    REDISGEARS_MODULE_INIT_FUNCTION(ctx, WorkerDataCreate);
+    REDISGEARS_MODULE_INIT_FUNCTION(ctx, WorkerDataFree);
+    REDISGEARS_MODULE_INIT_FUNCTION(ctx, WorkerDataGetShallowCopy);
 
     if(RedisGears_GetLLApiVersion() < REDISGEARS_LLAPI_VERSION){
         return REDISMODULE_ERR;

--- a/src/redisgears.h
+++ b/src/redisgears.h
@@ -187,7 +187,7 @@ void MODULE_API_FUNC(RedisGears_StreamReaderTriggerArgsFree)(StreamReaderTrigger
 KeysReaderTriggerArgs* MODULE_API_FUNC(RedisGears_KeysReaderTriggerArgsCreate)(const char* regex, Arr(char*) eventTypes, Arr(int) keyTypes);
 void MODULE_API_FUNC(RedisGears_KeysReaderTriggerArgsFree)(KeysReaderTriggerArgs* args);
 
-CommandReaderTriggerArgs* MODULE_API_FUNC(RedisGears_CommandReaderTriggerArgsCreate)(const char* command);
+CommandReaderTriggerArgs* MODULE_API_FUNC(RedisGears_CommandReaderTriggerArgsCreate)(const char* trigger);
 void MODULE_API_FUNC(RedisGears_CommandReaderTriggerArgsFree)(CommandReaderTriggerArgs* args);
 
 /**

--- a/src/redisgears_python.c
+++ b/src/redisgears_python.c
@@ -809,18 +809,18 @@ static void registerFreeArgs(FlatExecutionPlan* fep, void* args){
 }
 
 static void* registerCreateCommandArgs(PyObject *kargs){
-    const char* command = NULL;
-    PyObject* pyCommand = PyDict_GetItemString(kargs, "command");
-    if(!pyCommand){
+    const char* trigger = NULL;
+    PyObject* pyTrigger = PyDict_GetItemString(kargs, "trigger");
+    if(!pyTrigger){
         PyErr_SetString(GearsError, "command argument was not given");
         return NULL;
     }
-    if(!PyUnicode_Check(pyCommand)){
+    if(!PyUnicode_Check(pyTrigger)){
         PyErr_SetString(GearsError, "command argument is not string");
         return NULL;
     }
-    command = PyUnicode_AsUTF8AndSize(pyCommand, NULL);
-    return RedisGears_CommandReaderTriggerArgsCreate(command);
+    trigger = PyUnicode_AsUTF8AndSize(pyTrigger, NULL);
+    return RedisGears_CommandReaderTriggerArgsCreate(trigger);
 }
 
 static void* registerCreateArgs(FlatExecutionPlan* fep, PyObject *kargs, ExecutionMode mode){

--- a/src/redisgears_python.h
+++ b/src/redisgears_python.h
@@ -21,7 +21,7 @@ void* RedisGearsPy_PyObjectDeserialize(Gears_BufferReader* br);
 int RedisGearsPy_Execute(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int RedisGearsPy_ExecuteWithCallback(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, DoneCallbackFunction callback);
 int RedisGearsPy_Init(RedisModuleCtx *ctx);
-void RedisGearsPy_ForceStop(ExecutionCtx* ep);
+void RedisGearsPy_ForceStop(unsigned long threadID);
 PythonSessionCtx* RedisGearsPy_Lock(PythonSessionCtx* currSession);
 void RedisGearsPy_Unlock(PythonSessionCtx* prevSession);
 bool RedisGearsPy_IsLockAcquired();

--- a/src/utils/thpool.c
+++ b/src/utils/thpool.c
@@ -1,0 +1,502 @@
+/* ********************************
+ * Author:       Johan Hanssen Seferidis
+ * License:	     MIT
+ * Description:  Library providing a threading pool where you can add
+ *               work. For usage, check the thpool.h file or README.md
+ *
+ */
+/** @file thpool.h */ /*
+                       *
+                       ********************************/
+
+//#define _POSIX_C_SOURCE 200809L
+#include <unistd.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <errno.h>
+#include <time.h>
+#if defined(__linux__)
+#include <sys/prctl.h>
+#endif
+
+#include "thpool.h"
+
+#include "redisgears_memory.h"
+
+#ifdef THPOOL_DEBUG
+#define THPOOL_DEBUG 1
+#else
+#define THPOOL_DEBUG 0
+#endif
+
+#if !defined(DISABLE_PRINT) || defined(THPOOL_DEBUG)
+#define err(str) fprintf(stderr, str)
+#else
+#define err(str)
+#endif
+
+static volatile int threads_keepalive;
+static volatile int threads_on_hold;
+
+/* ========================== STRUCTURES ============================ */
+
+/* Binary semaphore */
+typedef struct bsem {
+  pthread_mutex_t mutex;
+  pthread_cond_t cond;
+  int v;
+} bsem;
+
+/* Job */
+typedef struct job {
+  struct job* prev;            /* pointer to previous job   */
+  void (*function)(void* arg); /* function pointer          */
+  void* arg;                   /* function's argument       */
+} job;
+
+/* Job queue */
+typedef struct jobqueue {
+  pthread_mutex_t rwmutex; /* used for queue r/w access */
+  job* front;              /* pointer to front of queue */
+  job* rear;               /* pointer to rear  of queue */
+  bsem* has_jobs;          /* flag as binary semaphore  */
+  int len;                 /* number of jobs in queue   */
+} jobqueue;
+
+/* Thread */
+typedef struct thread {
+  int id;                   /* friendly id               */
+  pthread_t pthread;        /* pointer to actual thread  */
+  struct thpool_* thpool_p; /* access to thpool          */
+} thread;
+
+/* Threadpool */
+typedef struct thpool_ {
+  thread** threads;                 /* pointer to threads        */
+  volatile int num_threads_alive;   /* threads currently alive   */
+  volatile int num_threads_working; /* threads currently working */
+  pthread_mutex_t thcount_lock;     /* used for thread count etc */
+  pthread_cond_t threads_all_idle;  /* signal to thpool_wait     */
+  jobqueue jobqueue;                /* job queue                 */
+} thpool_;
+
+/* ========================== PROTOTYPES ============================ */
+
+static int thread_init(thpool_* thpool_p, struct thread** thread_p, int id);
+static void* thread_do(struct thread* thread_p);
+static void thread_hold(int sig_id);
+static void thread_destroy(struct thread* thread_p);
+
+static int jobqueue_init(jobqueue* jobqueue_p);
+static void jobqueue_clear(jobqueue* jobqueue_p);
+static void jobqueue_push(jobqueue* jobqueue_p, struct job* newjob_p);
+static struct job* jobqueue_pull(jobqueue* jobqueue_p);
+static void jobqueue_destroy(jobqueue* jobqueue_p);
+
+static void bsem_init(struct bsem* bsem_p, int value);
+static void bsem_reset(struct bsem* bsem_p);
+static void bsem_post(struct bsem* bsem_p);
+static void bsem_post_all(struct bsem* bsem_p);
+static void bsem_wait(struct bsem* bsem_p);
+
+/* ========================== THREADPOOL ============================ */
+
+/* Initialise thread pool */
+struct thpool_* thpool_init(int num_threads) {
+
+  threads_on_hold = 0;
+  threads_keepalive = 1;
+
+  if (num_threads < 0) {
+    num_threads = 0;
+  }
+
+  /* Make new thread pool */
+  thpool_* thpool_p;
+  thpool_p = (struct thpool_*)RG_ALLOC(sizeof(struct thpool_));
+  if (thpool_p == NULL) {
+    err("thpool_init(): Could not allocate memory for thread pool\n");
+    return NULL;
+  }
+  thpool_p->num_threads_alive = 0;
+  thpool_p->num_threads_working = 0;
+
+  /* Initialise the job queue */
+  if (jobqueue_init(&thpool_p->jobqueue) == -1) {
+    err("thpool_init(): Could not allocate memory for job queue\n");
+    RG_FREE(thpool_p);
+    return NULL;
+  }
+
+  /* Make threads in pool */
+  thpool_p->threads = (struct thread**)RG_ALLOC(num_threads * sizeof(struct thread*));
+  if (thpool_p->threads == NULL) {
+    err("thpool_init(): Could not allocate memory for threads\n");
+    jobqueue_destroy(&thpool_p->jobqueue);
+    RG_FREE(thpool_p);
+    return NULL;
+  }
+
+  pthread_mutex_init(&(thpool_p->thcount_lock), NULL);
+  pthread_cond_init(&thpool_p->threads_all_idle, NULL);
+
+  /* Thread init */
+  int n;
+  for (n = 0; n < num_threads; n++) {
+    thread_init(thpool_p, &thpool_p->threads[n], n);
+#if THPOOL_DEBUG
+    printf("THPOOL_DEBUG: Created thread %d in pool \n", n);
+#endif
+  }
+
+  /* Wait for threads to initialize */
+  while (thpool_p->num_threads_alive != num_threads) {
+  }
+
+  return thpool_p;
+}
+
+/* Add work to the thread pool */
+int thpool_add_work(thpool_* thpool_p, void (*function_p)(void*), void* arg_p) {
+  job* newjob;
+
+  newjob = (struct job*)RG_ALLOC(sizeof(struct job));
+  if (newjob == NULL) {
+    err("thpool_add_work(): Could not allocate memory for new job\n");
+    return -1;
+  }
+
+  /* add function and argument */
+  newjob->function = function_p;
+  newjob->arg = arg_p;
+
+  /* add job to queue */
+  jobqueue_push(&thpool_p->jobqueue, newjob);
+
+  return 0;
+}
+
+/* Wait until all jobs have finished */
+void thpool_wait(thpool_* thpool_p) {
+  pthread_mutex_lock(&thpool_p->thcount_lock);
+  while (thpool_p->jobqueue.len || thpool_p->num_threads_working) {
+    pthread_cond_wait(&thpool_p->threads_all_idle, &thpool_p->thcount_lock);
+  }
+  pthread_mutex_unlock(&thpool_p->thcount_lock);
+}
+
+/* Destroy the threadpool */
+void thpool_destroy(thpool_* thpool_p) {
+  /* No need to destory if it's NULL */
+  if (thpool_p == NULL) return;
+
+  volatile int threads_total = thpool_p->num_threads_alive;
+
+  /* End each thread 's infinite loop */
+  threads_keepalive = 0;
+
+  /* Give one second to kill idle threads */
+  double TIMEOUT = 1.0;
+  time_t start, end;
+  double tpassed = 0.0;
+  time(&start);
+  while (tpassed < TIMEOUT && thpool_p->num_threads_alive) {
+    bsem_post_all(thpool_p->jobqueue.has_jobs);
+    time(&end);
+    tpassed = difftime(end, start);
+  }
+
+  /* Poll remaining threads */
+  while (thpool_p->num_threads_alive) {
+    bsem_post_all(thpool_p->jobqueue.has_jobs);
+    sleep(1);
+  }
+
+  /* Job queue cleanup */
+  jobqueue_destroy(&thpool_p->jobqueue);
+  /* Deallocs */
+  int n;
+  for (n = 0; n < threads_total; n++) {
+    thread_destroy(thpool_p->threads[n]);
+  }
+  RG_FREE(thpool_p->threads);
+  RG_FREE(thpool_p);
+}
+
+/* Pause all threads in threadpool */
+void thpool_pause(thpool_* thpool_p) {
+  int n;
+  for (n = 0; n < thpool_p->num_threads_alive; n++) {
+    pthread_kill(thpool_p->threads[n]->pthread, SIGUSR2);
+  }
+}
+
+/* Resume all threads in threadpool */
+void thpool_resume(thpool_* thpool_p) {
+  // resuming a single threadpool hasn't been
+  // implemented yet, meanwhile this supresses
+  // the warnings
+  (void)thpool_p;
+
+  threads_on_hold = 0;
+}
+
+int thpool_num_threads_working(thpool_* thpool_p) {
+  return thpool_p->num_threads_working;
+}
+
+/* ============================ THREAD ============================== */
+
+/* Initialize a thread in the thread pool
+ *
+ * @param thread        address to the pointer of the thread to be created
+ * @param id            id to be given to the thread
+ * @return 0 on success, -1 otherwise.
+ */
+static int thread_init(thpool_* thpool_p, struct thread** thread_p, int id) {
+
+  *thread_p = (struct thread*)RG_ALLOC(sizeof(struct thread));
+  if (thread_p == NULL) {
+    err("thread_init(): Could not allocate memory for thread\n");
+    return -1;
+  }
+
+  (*thread_p)->thpool_p = thpool_p;
+  (*thread_p)->id = id;
+
+  pthread_create(&(*thread_p)->pthread, NULL, (void*)thread_do, (*thread_p));
+  pthread_detach((*thread_p)->pthread);
+  return 0;
+}
+
+/* Sets the calling thread on hold */
+static void thread_hold(int sig_id) {
+  (void)sig_id;
+  threads_on_hold = 1;
+  while (threads_on_hold) {
+    sleep(1);
+  }
+}
+
+/* What each thread is doing
+ *
+ * In principle this is an endless loop. The only time this loop gets interuppted is once
+ * thpool_destroy() is invoked or the program exits.
+ *
+ * @param  thread        thread that will run this function
+ * @return nothing
+ */
+static void* thread_do(struct thread* thread_p) {
+
+  /* Set thread name for profiling and debuging */
+  char thread_name[128] = {0};
+  sprintf(thread_name, "thread-pool-%d", thread_p->id);
+
+#if defined(__linux__)
+  /* Use prctl instead to prevent using _GNU_SOURCE flag and implicit declaration */
+  prctl(PR_SET_NAME, thread_name);
+#elif defined(__APPLE__) && defined(__MACH__)
+  pthread_setname_np(thread_name);
+#else
+  err("thread_do(): pthread_setname_np is not supported on this system");
+#endif
+
+  /* Assure all threads have been created before starting serving */
+  thpool_* thpool_p = thread_p->thpool_p;
+
+  /* Register signal handler */
+  struct sigaction act;
+  sigemptyset(&act.sa_mask);
+  act.sa_flags = 0;
+  act.sa_handler = thread_hold;
+  if (sigaction(SIGUSR2, &act, NULL) == -1) {
+    err("thread_do(): cannot handle SIGUSR1");
+  }
+
+  /* Mark thread as alive (initialized) */
+  pthread_mutex_lock(&thpool_p->thcount_lock);
+  thpool_p->num_threads_alive += 1;
+  pthread_mutex_unlock(&thpool_p->thcount_lock);
+
+  while (threads_keepalive) {
+
+    bsem_wait(thpool_p->jobqueue.has_jobs);
+
+    if (threads_keepalive) {
+
+      pthread_mutex_lock(&thpool_p->thcount_lock);
+      thpool_p->num_threads_working++;
+      pthread_mutex_unlock(&thpool_p->thcount_lock);
+
+      /* Read job from queue and execute it */
+      void (*func_buff)(void*);
+      void* arg_buff;
+      job* job_p = jobqueue_pull(&thpool_p->jobqueue);
+      if (job_p) {
+        func_buff = job_p->function;
+        arg_buff = job_p->arg;
+        func_buff(arg_buff);
+        RG_FREE(job_p);
+      }
+
+      pthread_mutex_lock(&thpool_p->thcount_lock);
+      thpool_p->num_threads_working--;
+      if (!thpool_p->num_threads_working) {
+        pthread_cond_signal(&thpool_p->threads_all_idle);
+      }
+      pthread_mutex_unlock(&thpool_p->thcount_lock);
+    }
+  }
+  pthread_mutex_lock(&thpool_p->thcount_lock);
+  thpool_p->num_threads_alive--;
+  pthread_mutex_unlock(&thpool_p->thcount_lock);
+
+  return NULL;
+}
+
+/* Frees a thread  */
+static void thread_destroy(thread* thread_p) {
+  RG_FREE(thread_p);
+}
+
+/* ============================ JOB QUEUE =========================== */
+
+/* Initialize queue */
+static int jobqueue_init(jobqueue* jobqueue_p) {
+  jobqueue_p->len = 0;
+  jobqueue_p->front = NULL;
+  jobqueue_p->rear = NULL;
+
+  jobqueue_p->has_jobs = (struct bsem*)RG_ALLOC(sizeof(struct bsem));
+  if (jobqueue_p->has_jobs == NULL) {
+    return -1;
+  }
+
+  pthread_mutex_init(&(jobqueue_p->rwmutex), NULL);
+  bsem_init(jobqueue_p->has_jobs, 0);
+
+  return 0;
+}
+
+/* Clear the queue */
+static void jobqueue_clear(jobqueue* jobqueue_p) {
+
+  while (jobqueue_p->len) {
+    RG_FREE(jobqueue_pull(jobqueue_p));
+  }
+
+  jobqueue_p->front = NULL;
+  jobqueue_p->rear = NULL;
+  bsem_reset(jobqueue_p->has_jobs);
+  jobqueue_p->len = 0;
+}
+
+/* Add (allocated) job to queue
+ */
+static void jobqueue_push(jobqueue* jobqueue_p, struct job* newjob) {
+
+  pthread_mutex_lock(&jobqueue_p->rwmutex);
+  newjob->prev = NULL;
+
+  switch (jobqueue_p->len) {
+
+    case 0: /* if no jobs in queue */
+      jobqueue_p->front = newjob;
+      jobqueue_p->rear = newjob;
+      break;
+
+    default: /* if jobs in queue */
+      jobqueue_p->rear->prev = newjob;
+      jobqueue_p->rear = newjob;
+  }
+  jobqueue_p->len++;
+
+  bsem_post(jobqueue_p->has_jobs);
+  pthread_mutex_unlock(&jobqueue_p->rwmutex);
+}
+
+/* Get first job from queue(removes it from queue)
+<<<<<<< HEAD
+ *
+ * Notice: Caller MUST hold a mutex
+=======
+>>>>>>> da2c0fe45e43ce0937f272c8cd2704bdc0afb490
+ */
+static struct job* jobqueue_pull(jobqueue* jobqueue_p) {
+
+  pthread_mutex_lock(&jobqueue_p->rwmutex);
+  job* job_p = jobqueue_p->front;
+
+  switch (jobqueue_p->len) {
+
+    case 0: /* if no jobs in queue */
+      break;
+
+    case 1: /* if one job in queue */
+      jobqueue_p->front = NULL;
+      jobqueue_p->rear = NULL;
+      jobqueue_p->len = 0;
+      break;
+
+    default: /* if >1 jobs in queue */
+      jobqueue_p->front = job_p->prev;
+      jobqueue_p->len--;
+      /* more than one job in queue -> post it */
+      bsem_post(jobqueue_p->has_jobs);
+  }
+
+  pthread_mutex_unlock(&jobqueue_p->rwmutex);
+  return job_p;
+}
+
+/* Free all queue resources back to the system */
+static void jobqueue_destroy(jobqueue* jobqueue_p) {
+  jobqueue_clear(jobqueue_p);
+  RG_FREE(jobqueue_p->has_jobs);
+}
+
+/* ======================== SYNCHRONISATION ========================= */
+
+/* Init semaphore to 1 or 0 */
+static void bsem_init(bsem* bsem_p, int value) {
+  if (value < 0 || value > 1) {
+    err("bsem_init(): Binary semaphore can take only values 1 or 0");
+    exit(1);
+  }
+  pthread_mutex_init(&(bsem_p->mutex), NULL);
+  pthread_cond_init(&(bsem_p->cond), NULL);
+  bsem_p->v = value;
+}
+
+/* Reset semaphore to 0 */
+static void bsem_reset(bsem* bsem_p) {
+  bsem_init(bsem_p, 0);
+}
+
+/* Post to at least one thread */
+static void bsem_post(bsem* bsem_p) {
+  pthread_mutex_lock(&bsem_p->mutex);
+  bsem_p->v = 1;
+  pthread_cond_signal(&bsem_p->cond);
+  pthread_mutex_unlock(&bsem_p->mutex);
+}
+
+/* Post to all threads */
+static void bsem_post_all(bsem* bsem_p) {
+  pthread_mutex_lock(&bsem_p->mutex);
+  bsem_p->v = 1;
+  pthread_cond_broadcast(&bsem_p->cond);
+  pthread_mutex_unlock(&bsem_p->mutex);
+}
+
+/* Wait on semaphore until semaphore has value 0 */
+static void bsem_wait(bsem* bsem_p) {
+  pthread_mutex_lock(&bsem_p->mutex);
+  while (bsem_p->v != 1) {
+    pthread_cond_wait(&bsem_p->cond, &bsem_p->mutex);
+  }
+  bsem_p->v = 0;
+  pthread_mutex_unlock(&bsem_p->mutex);
+}

--- a/src/utils/thpool.h
+++ b/src/utils/thpool.h
@@ -1,0 +1,187 @@
+/**********************************
+ * @author      Johan Hanssen Seferidis
+ * License:     MIT
+ *
+ **********************************/
+
+#ifndef _THPOOL_
+#define _THPOOL_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* =================================== API ======================================= */
+
+
+typedef struct thpool_* threadpool;
+
+
+/**
+ * @brief  Initialize threadpool
+ *
+ * Initializes a threadpool. This function will not return untill all
+ * threads have initialized successfully.
+ *
+ * @example
+ *
+ *    ..
+ *    threadpool thpool;                     //First we declare a threadpool
+ *    thpool = thpool_init(4);               //then we initialize it to 4 threads
+ *    ..
+ *
+ * @param  num_threads   number of threads to be created in the threadpool
+ * @return threadpool    created threadpool on success,
+ *                       NULL on error
+ */
+threadpool thpool_init(int num_threads);
+
+
+/**
+ * @brief Add work to the job queue
+ *
+ * Takes an action and its argument and adds it to the threadpool's job queue.
+ * If you want to add to work a function with more than one arguments then
+ * a way to implement this is by passing a pointer to a structure.
+ *
+ * NOTICE: You have to cast both the function and argument to not get warnings.
+ *
+ * @example
+ *
+ *    void print_num(int num){
+ *       printf("%d\n", num);
+ *    }
+ *
+ *    int main() {
+ *       ..
+ *       int a = 10;
+ *       thpool_add_work(thpool, (void*)print_num, (void*)a);
+ *       ..
+ *    }
+ *
+ * @param  threadpool    threadpool to which the work will be added
+ * @param  function_p    pointer to function to add as work
+ * @param  arg_p         pointer to an argument
+ * @return 0 on successs, -1 otherwise.
+ */
+int thpool_add_work(threadpool, void (*function_p)(void*), void* arg_p);
+
+
+/**
+ * @brief Wait for all queued jobs to finish
+ *
+ * Will wait for all jobs - both queued and currently running to finish.
+ * Once the queue is empty and all work has completed, the calling thread
+ * (probably the main program) will continue.
+ *
+ * Smart polling is used in wait. The polling is initially 0 - meaning that
+ * there is virtually no polling at all. If after 1 seconds the threads
+ * haven't finished, the polling interval starts growing exponentially
+ * untill it reaches max_secs seconds. Then it jumps down to a maximum polling
+ * interval assuming that heavy processing is being used in the threadpool.
+ *
+ * @example
+ *
+ *    ..
+ *    threadpool thpool = thpool_init(4);
+ *    ..
+ *    // Add a bunch of work
+ *    ..
+ *    thpool_wait(thpool);
+ *    puts("All added work has finished");
+ *    ..
+ *
+ * @param threadpool     the threadpool to wait for
+ * @return nothing
+ */
+void thpool_wait(threadpool);
+
+
+/**
+ * @brief Pauses all threads immediately
+ *
+ * The threads will be paused no matter if they are idle or working.
+ * The threads return to their previous states once thpool_resume
+ * is called.
+ *
+ * While the thread is being paused, new work can be added.
+ *
+ * @example
+ *
+ *    threadpool thpool = thpool_init(4);
+ *    thpool_pause(thpool);
+ *    ..
+ *    // Add a bunch of work
+ *    ..
+ *    thpool_resume(thpool); // Let the threads start their magic
+ *
+ * @param threadpool    the threadpool where the threads should be paused
+ * @return nothing
+ */
+void thpool_pause(threadpool);
+
+
+/**
+ * @brief Unpauses all threads if they are paused
+ *
+ * @example
+ *    ..
+ *    thpool_pause(thpool);
+ *    sleep(10);              // Delay execution 10 seconds
+ *    thpool_resume(thpool);
+ *    ..
+ *
+ * @param threadpool     the threadpool where the threads should be unpaused
+ * @return nothing
+ */
+void thpool_resume(threadpool);
+
+
+/**
+ * @brief Destroy the threadpool
+ *
+ * This will wait for the currently active threads to finish and then 'kill'
+ * the whole threadpool to free up memory.
+ *
+ * @example
+ * int main() {
+ *    threadpool thpool1 = thpool_init(2);
+ *    threadpool thpool2 = thpool_init(2);
+ *    ..
+ *    thpool_destroy(thpool1);
+ *    ..
+ *    return 0;
+ * }
+ *
+ * @param threadpool     the threadpool to destroy
+ * @return nothing
+ */
+void thpool_destroy(threadpool);
+
+
+/**
+ * @brief Show currently working threads
+ *
+ * Working threads are the threads that are performing work (not idle).
+ *
+ * @example
+ * int main() {
+ *    threadpool thpool1 = thpool_init(2);
+ *    threadpool thpool2 = thpool_init(2);
+ *    ..
+ *    printf("Working threads: %d\n", thpool_num_threads_working(thpool1));
+ *    ..
+ *    return 0;
+ * }
+ *
+ * @param threadpool     the threadpool of interest
+ * @return integer       number of threads working
+ */
+int thpool_num_threads_working(threadpool);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/utils/thpool.h
+++ b/src/utils/thpool.h
@@ -14,7 +14,7 @@ extern "C" {
 /* =================================== API ======================================= */
 
 
-typedef struct thpool_* threadpool;
+typedef struct Gears_thpool_* Gears_threadpool;
 
 
 /**
@@ -34,7 +34,7 @@ typedef struct thpool_* threadpool;
  * @return threadpool    created threadpool on success,
  *                       NULL on error
  */
-threadpool thpool_init(int num_threads);
+Gears_threadpool Gears_thpool_init(int num_threads);
 
 
 /**
@@ -64,7 +64,7 @@ threadpool thpool_init(int num_threads);
  * @param  arg_p         pointer to an argument
  * @return 0 on successs, -1 otherwise.
  */
-int thpool_add_work(threadpool, void (*function_p)(void*), void* arg_p);
+int Gears_thpool_add_work(Gears_threadpool, void (*function_p)(void*), void* arg_p);
 
 
 /**
@@ -94,7 +94,7 @@ int thpool_add_work(threadpool, void (*function_p)(void*), void* arg_p);
  * @param threadpool     the threadpool to wait for
  * @return nothing
  */
-void thpool_wait(threadpool);
+void Gears_thpool_wait(Gears_threadpool);
 
 
 /**
@@ -118,7 +118,7 @@ void thpool_wait(threadpool);
  * @param threadpool    the threadpool where the threads should be paused
  * @return nothing
  */
-void thpool_pause(threadpool);
+void Gears_thpool_pause(Gears_threadpool);
 
 
 /**
@@ -134,7 +134,7 @@ void thpool_pause(threadpool);
  * @param threadpool     the threadpool where the threads should be unpaused
  * @return nothing
  */
-void thpool_resume(threadpool);
+void Gears_thpool_resume(Gears_threadpool);
 
 
 /**
@@ -156,7 +156,7 @@ void thpool_resume(threadpool);
  * @param threadpool     the threadpool to destroy
  * @return nothing
  */
-void thpool_destroy(threadpool);
+void Gears_thpool_destroy(Gears_threadpool);
 
 
 /**
@@ -177,7 +177,7 @@ void thpool_destroy(threadpool);
  * @param threadpool     the threadpool of interest
  * @return integer       number of threads working
  */
-int thpool_num_threads_working(threadpool);
+int Gears_thpool_num_threads_working(Gears_threadpool);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
1. We have a thread pull for execution run
2. It is possible to define a virtual worker.
   Execution on same worker will not run in parallel.
   Registrations use it to force execution order.
   Other execution run on their own worker, i.e, no execution order is prommised.