### PR TITLE
Adds rgcluster docker

### DIFF
--- a/recipes/cluster/Dockerfile
+++ b/recipes/cluster/Dockerfile
@@ -1,0 +1,9 @@
+FROM redislabs/redisgears:latest
+
+WORKDIR /cluster
+COPY create-cluster .
+COPY docker-config.sh .
+COPY docker-entrypoint.sh /usr/local/bin
+EXPOSE 30001-30006
+CMD []
+

--- a/recipes/cluster/README.md
+++ b/recipes/cluster/README.md
@@ -1,0 +1,15 @@
+# RedisGears Cluster Docker Image
+Use this to have a RedisGears-enabled Redis Cluster running inside a single container with one command. This uses Redis' [_create-cluster_](https://github.com/antirez/redis/tree/unstable/utils/create-cluster) utility.
+
+By default, it bootstraps a 3-shard cluster on ports 30001-30003. To run:
+
+```
+docker run -d -p 30001:30001 -p 30002:30002 -p 30003:30003 redislabs/rgcluster
+```
+
+## Configuration
+The default configuration is set by the contents of [docker-config.sh](docker-config.sh). To override it, create your own - e.g., "myconfig.sh" - on the host, for example and mount it to the container's `/cluster/config.sh` filesystem like so:
+
+```
+docker run -d $PWD/myconfig.sh:/cluster/config.sh redislabs/rgcluster
+```

--- a/recipes/cluster/create-cluster
+++ b/recipes/cluster/create-cluster
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# Settings
+BIN_PATH="../../"
+CLUSTER_HOST=127.0.0.1
+PORT=30000
+TIMEOUT=2000
+NODES=6
+REPLICAS=1
+PROTECTED_MODE=yes
+ADDITIONAL_OPTIONS=""
+
+# You may want to put the above config parameters into config.sh in order to
+# override the defaults without modifying this script.
+
+if [ -a config.sh ]
+then
+    source "config.sh"
+fi
+
+# Computed vars
+ENDPORT=$((PORT+NODES))
+
+if [ "$1" == "start" ]
+then
+    while [ $((PORT < ENDPORT)) != "0" ]; do
+        PORT=$((PORT+1))
+        echo "Starting $PORT"
+        $BIN_PATH/redis-server --port $PORT  --protected-mode $PROTECTED_MODE --cluster-enabled yes --cluster-config-file nodes-${PORT}.conf --cluster-node-timeout $TIMEOUT --appendonly yes --appendfilename appendonly-${PORT}.aof --dbfilename dump-${PORT}.rdb --logfile ${PORT}.log --daemonize yes ${ADDITIONAL_OPTIONS}
+    done
+    exit 0
+fi
+
+if [ "$1" == "create" ]
+then
+    HOSTS=""
+    while [ $((PORT < ENDPORT)) != "0" ]; do
+        PORT=$((PORT+1))
+        HOSTS="$HOSTS $CLUSTER_HOST:$PORT"
+    done
+    $BIN_PATH/redis-cli --cluster create $HOSTS --cluster-replicas $REPLICAS
+    exit 0
+fi
+
+if [ "$1" == "stop" ]
+then
+    while [ $((PORT < ENDPORT)) != "0" ]; do
+        PORT=$((PORT+1))
+        echo "Stopping $PORT"
+        $BIN_PATH/redis-cli -p $PORT shutdown nosave
+    done
+    exit 0
+fi
+
+if [ "$1" == "watch" ]
+then
+    PORT=$((PORT+1))
+    while [ 1 ]; do
+        clear
+        date
+        $BIN_PATH/redis-cli -p $PORT cluster nodes | head -30
+        sleep 1
+    done
+    exit 0
+fi
+
+if [ "$1" == "tail" ]
+then
+    INSTANCE=$2
+    PORT=$((PORT+INSTANCE))
+    tail -f ${PORT}.log
+    exit 0
+fi
+
+if [ "$1" == "tailall" ]
+then
+    tail -f *.log
+    exit 0
+fi
+
+if [ "$1" == "call" ]
+then
+    while [ $((PORT < ENDPORT)) != "0" ]; do
+        PORT=$((PORT+1))
+        $BIN_PATH/redis-cli -p $PORT $2 $3 $4 $5 $6 $7 $8 $9
+    done
+    exit 0
+fi
+
+if [ "$1" == "clean" ]
+then
+    rm -rf *.log
+    rm -rf appendonly*.aof
+    rm -rf dump*.rdb
+    rm -rf nodes*.conf
+    exit 0
+fi
+
+if [ "$1" == "clean-logs" ]
+then
+    rm -rf *.log
+    exit 0
+fi
+
+echo "Usage: $0 [start|create|stop|watch|tail|clean]"
+echo "start       -- Launch Redis Cluster instances."
+echo "create      -- Create a cluster using redis-cli --cluster create."
+echo "stop        -- Stop Redis Cluster instances."
+echo "watch       -- Show CLUSTER NODES output (first 30 lines) of first node."
+echo "tail <id>   -- Run tail -f of instance at base port + ID."
+echo "tailall     -- Run tail -f for all the log files at once."
+echo "clean       -- Remove all instances data, logs, configs."
+echo "clean-logs  -- Remove just instances logs."

--- a/recipes/cluster/docker-config.sh
+++ b/recipes/cluster/docker-config.sh
@@ -1,0 +1,7 @@
+BIN_PATH=/usr/local/bin
+CLUSTER_HOST=127.0.0.1
+PORT=30000
+NODES=3
+REPLICAS=0
+PROTECTED_MODE=no
+ADDITIONAL_OPTIONS="--loadmodule /var/opt/redislabs/lib/modules/redisgears.so"

--- a/recipes/cluster/docker-entrypoint.sh
+++ b/recipes/cluster/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+# Allow user-mounted config
+if [ ! -f config.sh ]
+then
+    cp docker-config.sh config.sh
+fi
+
+bash ./create-cluster start
+printf 'yes' | bash ./create-cluster create
+redis-cli --cluster call 127.0.0.1:30001 RG.REFRESHCLUSTER
+bash ./create-cluster tailall


### PR DESCRIPTION
Pretty cool stuff:
```
$ docker build -t rgcluster . && docker run -it --rm --name rgcluster -p 30001:30001  -p 30002:30002 -p 30003:303  rgcluster
Sending build context to Docker daemon  11.78kB
Step 1/7 : FROM redislabs/redisgears:latest
 ---> ab5dab76312f
Step 2/7 : WORKDIR /cluster
 ---> Using cache
 ---> 12fb7f4417ca
Step 3/7 : COPY create-cluster .
 ---> Using cache
 ---> ab5e4a407628
Step 4/7 : COPY docker-config.sh .
 ---> Using cache
 ---> 7b74870248cd
Step 5/7 : COPY docker-entrypoint.sh /usr/local/bin
 ---> Using cache
 ---> ea6509f9957a
Step 6/7 : EXPOSE 30001-30006
 ---> Using cache
 ---> b865e362b5f8
Step 7/7 : CMD []
 ---> Using cache
 ---> 33f65377eced
Successfully built 33f65377eced
Successfully tagged rgcluster:latest
Starting 30001
Starting 30002
Starting 30003
>>> Performing hash slots allocation on 3 nodes...
Master[0] -> Slots 0 - 5460
Master[1] -> Slots 5461 - 10922
Master[2] -> Slots 10923 - 16383
M: 6ba44da80e6bb26551bbc4ea0f39ec74bcafee12 127.0.0.1:30001
   slots:[0-5460] (5461 slots) master
M: c75c71a9c75a68afdaf93a6e320b95e5185deb4b 127.0.0.1:30002
   slots:[5461-10922] (5462 slots) master
M: 2e70b0a225758a2818c751daa3edab01e8337f41 127.0.0.1:30003
   slots:[10923-16383] (5461 slots) master
Can I set the above configuration? (type 'yes' to accept): >>> Nodes configuration updated
>>> Assign a different config epoch to each node
>>> Sending CLUSTER MEET messages to join the cluster
Waiting for the cluster to join
.
>>> Performing Cluster Check (using node 127.0.0.1:30001)
M: 6ba44da80e6bb26551bbc4ea0f39ec74bcafee12 127.0.0.1:30001
   slots:[0-5460] (5461 slots) master
M: 2e70b0a225758a2818c751daa3edab01e8337f41 127.0.0.1:30003
   slots:[10923-16383] (5461 slots) master
M: c75c71a9c75a68afdaf93a6e320b95e5185deb4b 127.0.0.1:30002
   slots:[5461-10922] (5462 slots) master
[OK] All nodes agree about slots configuration.
>>> Check for open slots...
>>> Check slots coverage...
[OK] All 16384 slots covered.
>>> Calling RG.REFRESHCLUSTER
127.0.0.1:30001: OK
127.0.0.1:30003: OK
127.0.0.1:30002: OK
==> 30001.log <==
9:M 28 Feb 2020 12:53:18.803 * <rg> Found venv installation under: /var/opt/redislabs/lib/modules/python3/.venv
9:M 28 Feb 2020 12:53:18.856 * <rg> Initializing Python environment with: exec(open('/var/opt/redislabs/lib/modules/python3/.venv/bin/activate_this.py').read(), {'__file__': '/var/opt/redislabs/lib/modules/python3/.venv/bin/activate_this.py'})
9:M 28 Feb 2020 12:53:19.144 * Module 'rg' loaded from /var/opt/redislabs/lib/modules/redisgears.so
9:M 28 Feb 2020 12:53:19.144 * Ready to accept connections
9:M 28 Feb 2020 12:53:19.154 # configEpoch set to 1 via CLUSTER SET-CONFIG-EPOCH
9:M 28 Feb 2020 12:53:19.248 # IP address for this node updated to 127.0.0.1
9:M 28 Feb 2020 12:53:21.175 * <module> connected : 127.0.0.1:30002, status = 0

9:M 28 Feb 2020 12:53:21.175 * <module> connected : 127.0.0.1:30003, status = 0


==> 30002.log <==
11:M 28 Feb 2020 12:53:18.805 * <rg> Found venv installation under: /var/opt/redislabs/lib/modules/python3/.venv
11:M 28 Feb 2020 12:53:18.856 * <rg> Initializing Python environment with: exec(open('/var/opt/redislabs/lib/modules/python3/.venv/bin/activate_this.py').read(), {'__file__': '/var/opt/redislabs/lib/modules/python3/.venv/bin/activate_this.py'})
11:M 28 Feb 2020 12:53:19.144 * Module 'rg' loaded from /var/opt/redislabs/lib/modules/redisgears.so
11:M 28 Feb 2020 12:53:19.144 * Ready to accept connections
11:M 28 Feb 2020 12:53:19.154 # configEpoch set to 2 via CLUSTER SET-CONFIG-EPOCH
11:M 28 Feb 2020 12:53:19.351 # IP address for this node updated to 127.0.0.1
11:M 28 Feb 2020 12:53:21.178 * <module> connected : 127.0.0.1:30003, status = 0

11:M 28 Feb 2020 12:53:21.178 * <module> connected : 127.0.0.1:30001, status = 0


==> 30003.log <==
13:M 28 Feb 2020 12:53:18.808 * <rg> Found venv installation under: /var/opt/redislabs/lib/modules/python3/.venv
13:M 28 Feb 2020 12:53:18.856 * <rg> Initializing Python environment with: exec(open('/var/opt/redislabs/lib/modules/python3/.venv/bin/activate_this.py').read(), {'__file__': '/var/opt/redislabs/lib/modules/python3/.venv/bin/activate_this.py'})
13:M 28 Feb 2020 12:53:19.143 * Module 'rg' loaded from /var/opt/redislabs/lib/modules/redisgears.so
13:M 28 Feb 2020 12:53:19.144 * Ready to accept connections
13:M 28 Feb 2020 12:53:19.155 # configEpoch set to 3 via CLUSTER SET-CONFIG-EPOCH
13:M 28 Feb 2020 12:53:19.351 # IP address for this node updated to 127.0.0.1
13:M 28 Feb 2020 12:53:21.177 * <module> connected : 127.0.0.1:30002, status = 0

13:M 28 Feb 2020 12:53:21.177 * <module> connected : 127.0.0.1:30001, status = 0


==> 30001.log <==
9:M 28 Feb 2020 12:53:21.195 # Cluster state changed: ok

==> 30002.log <==
11:M 28 Feb 2020 12:53:21.195 # Cluster state changed: ok

==> 30003.log <==
13:M 28 Feb 2020 12:53:21.195 # Cluster state changed: ok
```