### PR TITLE
Typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ RedisGears supports full python syntax and low level c api. In addition you can 
 * [Sub-interpreters](/docs/subinterpreters.md)
 
 # Future plans
-* GearsQL - SQL like language for quering your data.
+* GearsQL - SQL like language for querying your data.
 
 ## Mailing List / Forum
 Got questions? Feel free to ask at the [RedisGears mailing list](https://groups.google.com/forum/#!forum/redisgears).


### PR DESCRIPTION
Updated the spelling of 'querying' in the 'Future Plans' section of the readme