### PR TITLE
Api fixes

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -19,6 +19,7 @@ The following sections describe the supported commands.
 | [`RG.PYEXECUTE`](#rgpyexecute) | Executes a Python function |
 | [`RG.PYSTATS`](#rgpystats) | Returns memory usage statistics |
 | [`RG.REFRESHCLUSTER`](#rgrefreshcluster) | Refreshes node's view of the cluster |
+| [`RG.TRIGGER`](#rgtrigger) | Triggers execution of registration |
 | [`RG.UNREGISTER`](#rgunregister) | Removes registration |
 
 **Syntax Conventions**
@@ -52,7 +53,7 @@ A simple 'OK' if successful, or an error if the execution does not exist or had 
 **Examples**
 
 ```
-127.0.0.1:6379> RG.ABORTEXECUTION 0000000000000000000000000000000000000000-1
+redis> RG.ABORTEXECUTION 0000000000000000000000000000000000000000-1
 OK
 ```
 
@@ -76,9 +77,9 @@ An array with an entry per key. The entry is a String being the value or an erro
 **Examples**
 
 ```
-127.0.0.1:6379> RG.CONFIGGET ProfileExecutions
+redis> RG.CONFIGGET ProfileExecutions
 1) (integer) 0
-127.0.0.1:6379> RG.CONFIGGET foo
+redis> RG.CONFIGGET foo
 1) (error) (error) Unsupported config parameter: foo
 ```
 
@@ -103,11 +104,11 @@ An array with an entry per key. The entry is simple 'OK' string, or an error if 
 **Examples**
 
 ```
-127.0.0.1:6379> RG.CONFIGSET ProfileExecutions 1
+redis> RG.CONFIGSET ProfileExecutions 1
 1) OK
-127.0.0.1:6379> RG.CONFIGSET foo bar
+redis> RG.CONFIGSET foo bar
 1) OK - value was saved in extra config dictionary
-127.0.0.1:6379> RG.CONFIGGET foo
+redis> RG.CONFIGGET foo
 1) "bar"
 ```
 
@@ -131,7 +132,7 @@ A simple 'OK' if successful, or an error if the execution does not exist or is s
 **Examples**
 
 ```
-127.0.0.1:6379> RG.DROPEXECUTION 0000000000000000000000000000000000000000-1
+redis> RG.DROPEXECUTION 0000000000000000000000000000000000000000-1
 OK
 ```
 
@@ -154,7 +155,7 @@ An array with an entry per execution. Each entry is made of alternating key name
 **Examples**
 
 ```
-127.0.0.1:6379> RG.DUMPEXECUTIONS
+redis> RG.DUMPEXECUTIONS
 1) 1) "executionId"
    2) "0000000000000000000000000000000000000000-0"
    3) "status"
@@ -194,7 +195,7 @@ An array with an entry per registration. Each entry is made of alternating key n
 **Examples**
 
 ```
-127.0.0.1:6379> RG.DUMPREGISTRATIONS
+redis> RG.DUMPREGISTRATIONS
 1)  1) "id"
     2) "0000000000000000000000000000000000000000-2"
     3) "reader"
@@ -265,9 +266,9 @@ An array if successful, or an error if the execution does not exist or is still 
 **Examples**
 
 ```
-127.0.0.1:6379> RG.PYEXECUTE "GB().run()" UNBLOCKING
+redis> RG.PYEXECUTE "GB().run()" UNBLOCKING
 "0000000000000000000000000000000000000000-4"
-127.0.0.1:6379> RG.GETEXECUTION 0000000000000000000000000000000000000000-4
+redis> RG.GETEXECUTION 0000000000000000000000000000000000000000-4
 1) 1) "shard_id"
    2) "0000000000000000000000000000000000000000"
    3) "execution_plan"
@@ -332,7 +333,7 @@ An array if successful, or an error if the execution does not exist or is still 
 **Examples**
 
 ```
-127.0.0.1:6379> RG.GETRESULTS 0000000000000000000000000000000000000000-4
+redis> RG.GETRESULTS 0000000000000000000000000000000000000000-4
 1) (empty list or set)
 2) (empty list or set)
 ```
@@ -357,7 +358,7 @@ An array of if successful, or an error if the execution does not exist. The repl
 **Examples**
 
 ```
-127.0.0.1:6379> RG.GETRESULTS 0000000000000000000000000000000000000000-4
+redis> RG.GETRESULTS 0000000000000000000000000000000000000000-4
 1) (empty list or set)
 2) (empty list or set)
 ```
@@ -446,7 +447,7 @@ RG.PYEXECUTE "<function>" [REQUIREMENTS "<dep> ..."] [UNBLOCKING]
 
 _Arguments_
 
-* _function-definition_: the Python function
+* _function_: the Python function
 * _REQUIREMENTS_: this argument ensures that list of dependencies it is given as an argument is installed on each shard before execution
 * _UNBLOCKING_: doesn't block the client during execution
 
@@ -463,7 +464,7 @@ A simple 'OK' string is returned if the function has no output (i.e. it doesn't 
 **Examples**
 
 ```
-127.0.0.1:6379> RG.PYEXECUTE "GB().run()"
+redis> RG.PYEXECUTE "GB().run()"
 1) (empty list or set)
 2) (empty list or set)
 ```
@@ -488,7 +489,7 @@ An array that consists of alternating key name and value entries as follows:
 **Examples**
 
 ```
-127.0.0.1:6379> RG.PYSTATS
+redis> RG.PYSTATS
 1) "TotalAllocated"
 2) (integer) 113803317
 3) "PeakAllocated"
@@ -516,8 +517,35 @@ A simple 'OK' string.
 **Examples**
 
 ```
-127.0.0.1:6379> RG.REFRESHCLUSTER
+redis> RG.REFRESHCLUSTER
 OK
+```
+
+## RG.TRIGGER
+The **RG.TRIGGER** command triggers the execution of a registered [CommandReader](readers.md#commandreader) function.
+
+**Redis API**
+
+```
+RG.TRIGGER <trigger> [arg ...]
+```
+
+_Arguments_
+
+* **trigger**: the trigger's name
+* **arg**: any additional arguments
+
+_Return_
+
+An array containing the function's output records.
+
+**Examples**
+
+```
+redis> RG.PYEXECUTE "GB('CommandReader').register(trigger='mytrigger')"
+OK
+redis> RG.TRIGGER mytrigger foo bar
+1) "['mytrigger', 'foo', 'bar']"
 ```
 
 ## RG.UNREGISTER

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -203,35 +203,21 @@ The **Register** action registers a function as an event handler. The function i
 
 **Python API**
 ```python
-class GearsBuilder.register(regex='*', mode='async', batch=1, duration=0,
-  eventTypes=None, keyTypes=None, onRegistered=None, onFailedPolicy="continue",
-  onFailedRetryInterval=1, trigger=None)
+class GearsBuilder.register(convertToStr=True, collect=True, mode='async', onRegistered=None)
 ```
 
 _Arguments_
 
-* _regex_: An optional argument that's passed to the reader as its _defaultArg_. It means the following:
-    * A key prefix for the [KeysReader](readers.md#keysreader) and [KeysOnlyReader](readers.md#keysonlyreaders) readers
-    * A key name or prefix for the [StreamReader](readers.md#streamreader) reader
+* _convertToStr_: when `True` adds a [map](operations.md#map) operation to the flow's end that stringifies records
+* _collect_: when `True` adds a [collect](operations.md#collect) operation to flow's end
+
 * _mode_: the execution mode of the triggered function. Can be one of:
     * **'async'**: execution will be asynchronous across the entire cluster
     * **'async_local'**: execution will be asynchronous and restricted to the handling shard
     * **'sync'**: execution will be synchronous and local
-* _batch_: the batch size that triggers execution for the [StreamReader](readers.md#streamreader) reader
-* _duration_: the interval between executions for the [StreamReader](readers.md#streamreader) reader (takes precedence over the _batch_ argument)
-* _eventTypes_: A whitelist of event types that trigger for the [KeysReader](readers.md#keysreader) or [KeysOnlyReader](readers.md#keysonlyreaders) readers. The list may contain one or more:
-    * Any Redis or module command
-    * Any [Redis event](https://redis.io/topics/notifications)
-* _keyTypes_: A whitelist of key types that trigger execution for the [KeysReader](readers.md#keysreader) or [KeysOnlyReader](readers.md#keysonlyreaders) readers. The list may contain one or more from the following:
-    * Redis core types: 'string', 'hash', 'list', 'set', 'zset' or 'stream'
-    * For module data types: 'module'
 * _onRegistered_: A function [callback](operations.md#callback) that's called on each shard upon function registration. It is a good place to initialize non-serializable objects such as network connections.
-* _onFailedPolicy_: A policy for handling failures of the function when using the [StreamReader](readers.md#streamreader) reader. It can be set to one of the following:
-    * **'continue'**: ignores a failure and continues to the next execution
-    * **'abort'**: stops further executions
-    * **'retry'**: retries the execution after an interval specified with _onFailedRetryInterval_
-* _onFailedRetryInterval_: the interval in seconds between retries of failed executions of a function that uses the [StreamReader](readers.md#streamreader) reader
-* _trigger_: the trigger's name for a function that uses the [CommandReader](readers.md#commandreader) reader.
+
+Notice that more argumets can be passed to the register function, those arguments are depends on the reader and specified for each reader on the [readers](readers.md) page.
 
 **Examples**
 ```python

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -205,7 +205,7 @@ The **Register** action registers a function as an event handler. The function i
 ```python
 class GearsBuilder.register(regex='*', mode='async', batch=1, duration=0,
   eventTypes=None, keyTypes=None, onRegistered=None, onFailedPolicy="continue",
-  onFailedRetryInterval=1)
+  onFailedRetryInterval=1, trigger=None)
 ```
 
 _Arguments_
@@ -231,6 +231,7 @@ _Arguments_
     * **'abort'**: stops further executions
     * **'retry'**: retries the execution after an interval specified with _onFailedRetryInterval_
 * _onFailedRetryInterval_: the interval in seconds between retries of failed executions of a function that uses the [StreamReader](readers.md#streamreader) reader
+* _trigger_: the trigger's name for a function that uses the [CommandReader](readers.md#commandreader) reader.
 
 **Examples**
 ```python

--- a/docs/readers.md
+++ b/docs/readers.md
@@ -66,8 +66,8 @@ class GearsBuilder('KeysReader', defaultArg='*').run(noScan=False, readValue=Tru
 _Arguments_
 
 * _defaultArg_: a glob-like pattern of key names
-* _noScan_: if True search for the given pattern as is and do not perform any keys scan, default False
-* _readValue_: if False will not read the key value (the **'type'** and **'value'** fields will not be suplied), default True.
+* _noScan_: if True search for the given pattern as is and do not perform any keys scan
+* _readValue_: if False will not read the key value (the **'type'** and **'value'** fields will not be suplied)
 
 **_Event Mode_**
 
@@ -78,7 +78,7 @@ class GearsBuilder('KeysReader').register(prefix='*', eventTypes=None,
 
 _Arguments_
 
-* _prefix_: a prefix of key names, default '*'
+* _prefix_: a prefix of key names
 * _eventTypes_: a whitelist of event types that trigger execution when the [KeysReader](readers.md#keysreader) are used. The list may contain one or more:
     * Any Redis or module command
     * Any [Redis event](https://redis.io/topics/notifications)
@@ -86,7 +86,7 @@ _Arguments_
 * _keyTypes_: a whitelist of key types that trigger execution when using the [KeysReader](readers.md#keysreader) or [KeysOnlyReader](readers.md#keysonlyreaders) readers. The list may contain one or more from the following:
     * Redis core types: 'string', 'hash', 'list', 'set', 'zset' or 'stream'
     * Redis module types: 'module'
-* _readValue_: if False will not read the key value (the **'type'** and **'value'** fields will not be suplied), default True.
+* _readValue_: if False will not read the key value (the **'type'** and **'value'** fields will not be suplied)
 
 _Return_
 
@@ -150,10 +150,10 @@ Not supported.
 ```python
 class GearsBuilder('KeysOnlyReader').run(pattern='*', count=1000, noScan=False, patternGenerator=None)
 ```
-* _pattern_: pattern of keys to return, default '*'
-* _count_: count argument to give to the scan command, default '1000'
+* _pattern_: pattern of keys to return
+* _count_: count argument to give to the scan command
 * _noScan_: do not use scan only read the key as given by the _pattern_ argument
-* patternGenerator: a callbacks to generate different pattern on each shard. If given, the callback will run on each shard and the return tuple (pattern, isPattern) will be used. If this argument is given the pattern and noScan arguments are ignored.
+* _patternGenerator_: a callbacks to generate different pattern on each shard. If given, the callback will run on each shard and the return tuple (pattern, isPattern) will be used. If this argument is given the pattern and noScan arguments are ignored.
 
 
 ## StreamReader
@@ -180,7 +180,7 @@ The reader reads the Stream from the beginning to the last message in it. Each m
 Its operation can be controlled with the following:
 
   * Key name: the name of the key storing the Stream
-  * fromId: message id from which to start read messages, default '0-0'
+  * fromId: message id from which to start read messages
 
 **Event Mode**
 
@@ -195,7 +195,7 @@ Its operation can be controlled with the following:
     * **'continue'**: ignores a failure and continues to the next execution. This is the default policy.
     * **'abort'**: stops further executions.
     * **'retry'**: retries the execution after an interval specified with onFailedRetryInterval (default is one second).
-  * trimStream: if True the stream will automatically be trimmed after executions will finished, default True.
+  * trimStream: if True the stream will automatically be trimmed after executions will finished
   
 **Python API**
 
@@ -208,7 +208,7 @@ class GearsBuilder('StreamReader', defaultArg='*').run(fromId='0-0')
 _Arguments_
 
 * _defaultArg_: the name or prefix of keys that store Streams
-* _fromId_: message id from which to start read messages, default '0-0'
+* _fromId_: message id from which to start read messages
 
 **_Event Mode_**
 
@@ -223,7 +223,7 @@ _Arguments_
 * _durration_: the time to wait before execution is triggered, regardless of the batch size (0 for no durration)
 * _onFailedPolicy_: the policy for handling execution failures, values should be as describe above
 * _onFailedRetryInterval_: the interval (im miliseconads) in which to retry in case _onFailedPolicy_ is **'retry'**
-* _trimStream_: if True the stream will automatically be trimmed after executions will finished, default True.
+* _trimStream_: if True the stream will automatically be trimmed after executions will finished
 
 _Return_
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -28,7 +28,7 @@ The `GearsBuilder` class is imported to the runtime's environment by default.
 
 It exposes the functionality of the function's [context builder](functions.md#context-builder).
 
-## Execute
+## execute
 The `execute()` function is imported to the runtime's environment by default.
 
 This function executes an arbitrary Redis command.
@@ -39,6 +39,7 @@ This function executes an arbitrary Redis command.
       * [Redis commands](https://redis.io/commands)
 
 **Python API**
+
 ```python
 def execute(command, *args)
 ```
@@ -49,8 +50,26 @@ _Arguments_
 * _args_: the command's arguments
 
 **Examples**
+
 ```python
 {{ include('runtime/execute.py') }}
+```
+
+## atomic
+The `atomic()` Python context is imported to the runtime's environment by default.
+
+The context ensures that all operations in it are executed atomically by blocking the main Redis process.
+
+**Python API**
+
+```python
+class atomic()
+```
+
+**Examples**
+
+```python
+{{ include('runtime/atomic.py') }}
 ```
 
 ## ConfigGet
@@ -59,6 +78,7 @@ The `ConfigGet()` function is imported to the runtime's environment by default.
 This function fetches the current value of a RedisGears [configuration](#configuration.md) option.
 
 **Python API**
+
 ```python
 def ConfigGet(key)
 ```
@@ -68,6 +88,7 @@ _Arguments_
 * _key_: the configuration option key
 
 **Examples**
+
 ```python
 {{ include('runtime/configget.py') }}
 ```
@@ -78,6 +99,7 @@ The `GearsConfigGet()` function is imported to the runtime's environment by defa
 This function fetches the current value of a RedisGears [configuration](configuration.md) option and returns a default value if that key does not exist.
 
 **Python API**
+
 ```python
 def GearsConfigGet(key, default=None)
 ```
@@ -88,21 +110,24 @@ _Arguments_
 * _default_: a default value
 
 **Examples**
+
 ```python
 {{ include('runtime/gearsconfigget.py') }}
 ```
 
-## Hashtag
+## hashtag
 The `hashtag()` function is imported to the runtime's environment by default.
 
 This function returns a hashtag that maps to the lowest hash slot served by the local engine's shard. Put differently, it is useful as a hashtag for partitioning in a cluster.
 
 **Python API**
+
 ```python
 def hashtag()
 ```
 
 **Examples**
+
 ```python
 {{ include('runtime/hashtag.py') }}
 ```
@@ -113,6 +138,7 @@ The `Log()` function is imported to the runtime's environment by default.
 This function prints a message to Redis' log.
 
 **Python API**
+
 ```python
 def Log(message, level='notice')
 ```
@@ -127,6 +153,7 @@ _Arguments_
     * **'warning'**
 
 **Examples**
+
 ```python
 {{ include('runtime/log.py') }}
 ```

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -114,17 +114,17 @@ This function prints a message to Redis' log.
 
 **Python API**
 ```python
-def Log(level='notice', message)
+def Log(message, level='notice')
 ```
 
 _Arguments_
 
+* _message_: the message to output
 * _level_: the message's log level can be one of these:
     * **'debug'**
     * **'verbose'**
     * **'notice'**
     * **'warning'**
-* _message_: the message to output
 
 **Examples**
 ```python

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -72,15 +72,15 @@ class atomic()
 {{ include('runtime/atomic.py') }}
 ```
 
-## ConfigGet
-The `ConfigGet()` function is imported to the runtime's environment by default.
+## configGet
+The `configGet()` function is imported to the runtime's environment by default.
 
 This function fetches the current value of a RedisGears [configuration](#configuration.md) option.
 
 **Python API**
 
 ```python
-def ConfigGet(key)
+def configGet(key)
 ```
 
 _Arguments_
@@ -93,15 +93,15 @@ _Arguments_
 {{ include('runtime/configget.py') }}
 ```
 
-## GearsConfigGet
-The `GearsConfigGet()` function is imported to the runtime's environment by default.
+## gearsConfigGet
+The `gearsConfigGet()` function is imported to the runtime's environment by default.
 
 This function fetches the current value of a RedisGears [configuration](configuration.md) option and returns a default value if that key does not exist.
 
 **Python API**
 
 ```python
-def GearsConfigGet(key, default=None)
+def gearsConfigGet(key, default=None)
 ```
 
 _Arguments_
@@ -132,15 +132,15 @@ def hashtag()
 {{ include('runtime/hashtag.py') }}
 ```
 
-## Log
-The `Log()` function is imported to the runtime's environment by default.
+## log
+The `log()` function is imported to the runtime's environment by default.
 
 This function prints a message to Redis' log.
 
 **Python API**
 
 ```python
-def Log(message, level='notice')
+def log(message, level='notice')
 ```
 
 _Arguments_

--- a/docs/snippets/readers/commandreader-register.py
+++ b/docs/snippets/readers/commandreader-register.py
@@ -1,0 +1,4 @@
+# This CommandReader will return the number of arguments provided to it
+gb = GB('CommandReader')
+gb.map(lambda x: f'{x[0]} got {len(x)-1} arguments! Ah ah ah!')
+gb.register(trigger='CountVonCount')

--- a/docs/snippets/readers/streamreader-register.py
+++ b/docs/snippets/readers/streamreader-register.py
@@ -1,3 +1,3 @@
 # StreamReader will be triggered on new messages in 'iot:'-prefixed keys
 gb = GB('StreamReader')
-gb.register('iot:')
+gb.register('iot:*')

--- a/docs/snippets/runtime/atomic.py
+++ b/docs/snippets/runtime/atomic.py
@@ -1,0 +1,9 @@
+# Increments two keys atomically
+def transaction(_):
+    with atomic():
+        execute('INCR', f'{{{hashtag()}}}:foo')
+        execute('INCR', f'{{{hashtag()}}}:bar')
+
+gb = GB('ShardsIDReader')
+gb.foreach(transaction)
+gb.run()

--- a/docs/snippets/runtime/log.py
+++ b/docs/snippets/runtime/log.py
@@ -1,2 +1,2 @@
 # Dumps every datum in the DB to the log for "debug" purposes
-GB().foreach(lambda x: Log('debug', str(x))).run()
+GB().foreach(lambda x: Log(str(x), level='debug')).run()

--- a/docs/snippets/test_snippets.py
+++ b/docs/snippets/test_snippets.py
@@ -88,8 +88,10 @@ def standalone(image):
         ('docs/snippets/readers/shardidreader-run.py', [[1], []]),
         ('docs/snippets/readers/streamreader-register.py', b'OK'),
         ('docs/snippets/readers/streamreader-run.py', [[], []]),
+        ('docs/snippets/readers/commandreader-register.py', b'OK'),
         ('docs/snippets/runtime/configget.py', b'OK'),
         ('docs/snippets/runtime/execute.py', b'OK'),
+        ('docs/snippets/runtime/atomic.py', [[1], []]),
         ('docs/snippets/runtime/gearsconfigget.py', b'OK'),
         ('docs/snippets/runtime/hashtag.py', b'OK'),
         ('docs/snippets/runtime/log.py', [[], []]),
@@ -99,6 +101,7 @@ def standalone(image):
 def test_snippet(standalone, snippet, expected):
     with open(snippet, 'rb') as f:
         src = f.read()
+    standalone.flushall()
     r = standalone.execute_command('RG.PYEXECUTE', src)
     if type(expected) is list:
         assert len(expected[0]) == len(r[0])

--- a/pytest/test_basics.py
+++ b/pytest/test_basics.py
@@ -78,7 +78,7 @@ class testBasic:
         res = self.env.cmd('rg.getresultsblocking', id)
         res = [yaml.load(r) for r in res[0]]
         for i in range(100):
-            self.env.assertContains({'value': str(i), 'key': str(i)}, res)
+            self.env.assertContains({'value': str(i), 'type': 'string', 'event': 'None', 'key': str(i)}, res)
         self.env.cmd('rg.dropexecution', id)
 
     def testBasicFilterQuery(self):
@@ -86,7 +86,7 @@ class testBasic:
         res = self.env.cmd('rg.getresultsblocking', id)
         res = [yaml.load(r) for r in res[0]]
         for i in range(50, 100):
-            self.env.assertContains({'value': str(i), 'key': str(i)}, res)
+            self.env.assertContains({'value': str(i), 'type': 'string', 'event': 'None', 'key': str(i)}, res)
         self.env.cmd('rg.dropexecution', id)
 
     def testBasicMapQuery(self):
@@ -215,7 +215,7 @@ def testBasicWithRun(env):
                                   "run('stream')")
     env.assertEqual(len(res[0]), 1)
     res = eval(res[0][0])
-    env.assertEqual(res['test'], '1')
+    env.assertEqual(res['value']['test'], '1')
 
 def testTimeEvent(env):
     conn = getConnectionByEnv(env)
@@ -622,3 +622,42 @@ def Loop(r):
 GB('ShardsIDReader').map(Loop).run()
 '''
     env.expect('RG.PYEXECUTE', longExecution).equal([['1'], ['Execution max idle reached']])
+
+def testStreamReaderFromId(env):
+    conn = getConnectionByEnv(env)
+
+    id1 = conn.execute_command('XADD', 's', '*', 'foo', 'bar', 'foo1', 'bar1')
+    id2 = conn.execute_command('XADD', 's', '*', 'foo2', 'bar2', 'foo3', 'bar3')
+
+    res = env.cmd('RG.PYEXECUTE', "GB('StreamReader').run('s')")
+
+    res = [eval(r) for r in res[0]]
+
+    env.assertEqual([r['value'] for r in res], [{'foo': 'bar', 'foo1': 'bar1'}, {'foo2': 'bar2', 'foo3': 'bar3'}])
+
+    res = env.cmd('RG.PYEXECUTE', "GB('StreamReader').run('s', fromId='%s')" % id1)
+
+    res = [eval(r) for r in res[0]]
+
+    env.assertEqual([r['value'] for r in res], [{'foo2': 'bar2', 'foo3': 'bar3'}])
+
+def testKeysReaderKeyType(env):
+    conn = getConnectionByEnv(env)
+    conn.execute_command('set', 'r', '1')
+    conn.execute_command('lpush', 'l', '1', '2', '3')
+    conn.execute_command('sadd', 's', '1', '2', '3')
+    conn.execute_command('hset', 'h', 'key', 'val')
+    conn.execute_command('zadd', 'z', '1', 'm')
+
+    env.expect('RG.PYEXECUTE', 'GB().map(lambda x: x["type"]).sort().run()').equal([['hash', 'list', 'set', 'string', 'zset'],[]])
+
+def testKeysReaderNoScan(env):
+    conn = getConnectionByEnv(env)
+    env.expect('RG.PYEXECUTE', "GB().map(lambda x: x['type']).distinct().run('test', noScan=True)").equal([['empty'],[]])
+
+def testKeysReaderDontReadValue(env):
+    conn = getConnectionByEnv(env)
+    conn.execute_command('set', 'x', '1')
+    res = env.cmd('RG.PYEXECUTE', "GB().run(readValue=False)")
+    res = [eval(r) for r in res[0]]
+    env.assertEqual(res, [{'key':'x', 'event': None}])

--- a/pytest/test_errors.py
+++ b/pytest/test_errors.py
@@ -293,6 +293,15 @@ class testStepsWrongArgs:
     def testKeysReadeReadValueBadValue(self):
         self.env.expect('rg.pyexecute', 'GearsBuilder().register(readValue=1)').error()
 
+    def testKeysOnlyReadeBadCount(self):
+        res = self.env.cmd('rg.pyexecute', 'GearsBuilder("KeysOnlyReader").run(count="noNunber")')
+        self.env.assertContains('value is not an integer', res[1][0])
+
+    def testKeysOnlyReadeBadPatternGenerator(self):
+        res = self.env.cmd('rg.pyexecute', 'GearsBuilder("KeysOnlyReader").run(patternGenerator="adwaw")')
+        self.env.assertContains('object is not callable', res[1][0])
+
+
 class testGetExecutionErrorReporting:
     def __init__(self):
         self.env = Env()

--- a/pytest/test_errors.py
+++ b/pytest/test_errors.py
@@ -246,7 +246,7 @@ class testStepsWrongArgs:
         self.env.expect('rg.pyexecute', 'GB("PythonReader").run("*")').error().contains('pyreader argument must be a functio')
         self.env.expect('rg.pyexecute', 'GB("PythonReader").run()').error().contains('pyreader argument must be a functio')
         self.env.expect('rg.pyexecute', 'GB("PythonReader", "*").run()').error().contains('pyreader argument must be a functio')
-        self.env.expect('rg.pyexecute', 'GB("PythonReader", ShardReaderCallback).run("*")').error().contains('pyreader argument must be a functio')
+        self.env.expect('rg.pyexecute', 'GB("PythonReader", shardReaderCallback).run("*")').error().contains('pyreader argument must be a functio')
 
     def testStreamReaderBadFromIdFormat(self):
         self.conn.execute_command('XADD', 's', '*', 'foo', 'bar', 'foo1', 'bar1')

--- a/pytest/test_errors.py
+++ b/pytest/test_errors.py
@@ -89,9 +89,9 @@ GB('StreamReader').map(test).run()
 class testStepsErrors:
     def __init__(self):
         self.env = Env()
-        conn = getConnectionByEnv(self.env)
-        conn.execute_command('set', 'x', '1')
-        conn.execute_command('set', 'y', '1')
+        self.conn = getConnectionByEnv(self.env)
+        self.conn.execute_command('set', 'x', '1')
+        self.conn.execute_command('set', 'y', '1')
 
     def testForEachError(self):
         res = self.env.cmd('rg.pyexecute', 'GearsBuilder().foreach(lambda x: notexists(x)).collect().run()')
@@ -140,31 +140,43 @@ class testStepsErrors:
         res = self.env.cmd('rg.pyexecute', 'GearsBuilder().repartition(lambda x: notexists(x)).repartition(lambda x: notexists(x)).collect().run()')
         self.env.assertLessEqual(1, res[1])
 
+
 def testCommandReaderWithRun(env):
     env.expect('rg.pyexecute', 'GB("CommandReader").run()').error().contains('reader do not support run')
 
 def testCommandReaderWithBadArgs(env):
-    env.expect('rg.pyexecute', 'GB("CommandReader").register("bla")').error().contains('command argument is not string')
+    env.expect('rg.pyexecute', 'GB("CommandReader").register("test")').error().contains('trigger argument was not given')
+    env.expect('rg.pyexecute', 'GB("CommandReader").register(trigger=1)').error().contains('trigger argument is not string')
 
 def testCommandReaderRegisterSameCommand(env):
     env.expect('rg.pyexecute', 'GB("CommandReader").register(trigger="command")').ok()
-    env.expect('rg.pyexecute', 'GB("CommandReader").register(trigger="command")').error().contains('Command already registered')
+    env.expect('rg.pyexecute', 'GB("CommandReader").register(trigger="command")').error().contains('trigger already registered')
 
 def testCommandReaderRegisterWithExcpetionCommand(env):
     env.expect('rg.pyexecute', 'GB("CommandReader").foreach(lambda x: noexists).register(trigger="command")').ok()
     env.expect('rg.trigger', 'command').error().contains("'noexists' is not defined")
 
+def testNoSerializableRegistrationWithAllReaders(env):
+    script = '''
+import redis
+r = redis.Redis()
+GB('%s').map(lambda x: r).register(trigger='test')
+    '''
+    env.expect('RG.PYEXECUTE', script % 'KeysReader', 'REQUIREMENTS', 'redis').error()
+    env.expect('RG.PYEXECUTE', script % 'StreamReader', 'REQUIREMENTS', 'redis').error()
+    env.expect('RG.PYEXECUTE', script % 'CommandReader', 'REQUIREMENTS', 'redis').error()
 
 class testStepsWrongArgs:
     def __init__(self):
         self.env = Env()
+        self.conn = getConnectionByEnv(self.env)
 
     def testRegisterWithWrongRegexType(self):
         self.env.expect('rg.pyexecute', 'GB().register(1)').error().contains('regex argument must be a string')
 
     def testRegisterWithWrongEventKeysTypesList(self):
-        self.env.expect('rg.pyexecute', 'GB().register(regex="*", eventTypes=1)').error().contains('object is not iterable')
-        self.env.expect('rg.pyexecute', 'GB().register(regex="*", keyTypes=1)').error().contains('object is not iterable')
+        self.env.expect('rg.pyexecute', 'GB().register(regex="*", eventTypes=1)').error().contains('not iterable')
+        self.env.expect('rg.pyexecute', 'GB().register(regex="*", keyTypes=1)').error().contains('not iterable')
         self.env.expect('rg.pyexecute', 'GB().register(regex="*", eventTypes=[1, 2, 3])').error().contains('type is not string')
         self.env.expect('rg.pyexecute', 'GB().register(regex="*", keyTypes=[1, 2, 3])').error().contains('type is not string')
 
@@ -235,6 +247,51 @@ class testStepsWrongArgs:
         self.env.expect('rg.pyexecute', 'GB("PythonReader").run()').error().contains('pyreader argument must be a functio')
         self.env.expect('rg.pyexecute', 'GB("PythonReader", "*").run()').error().contains('pyreader argument must be a functio')
         self.env.expect('rg.pyexecute', 'GB("PythonReader", ShardReaderCallback).run("*")').error().contains('pyreader argument must be a functio')
+
+    def testStreamReaderBadFromIdFormat(self):
+        self.conn.execute_command('XADD', 's', '*', 'foo', 'bar', 'foo1', 'bar1')
+        self.env.expect('rg.pyexecute', 'GearsBuilder("StreamReader").run("s", fromId="test")').equal([[], ['ERR Invalid stream ID specified as stream command argument']])
+
+    def testStreamReaderBadFromId(self):
+        self.env.expect('rg.pyexecute', 'GearsBuilder("StreamReader").run("s", fromId=1)').error()
+
+    def testKeysReaderNoScanBadValue(self):
+        self.env.expect('rg.pyexecute', 'GearsBuilder().run(noScan=1)').error()
+
+    def testKeysReaderReadValueBadValue(self):
+        self.env.expect('rg.pyexecute', 'GearsBuilder().run(readValue=1)').error()
+
+    def testOnRegisteredBadValue(self):
+        self.env.expect('rg.pyexecute', 'GearsBuilder().register(onRegistered=1)').error()
+
+    def testRegisterModeBadValue(self):
+        self.env.expect('rg.pyexecute', 'GearsBuilder().register(mode=1)').error()
+        self.env.expect('rg.pyexecute', 'GearsBuilder().register(mode="test")').error()
+
+    def testRegisterPrefixBadValue(self):
+        self.env.expect('rg.pyexecute', 'GearsBuilder().register(prefix=1)').error()
+
+    def testStreamReaderBatchBadValue(self):
+        self.env.expect('rg.pyexecute', 'GearsBuilder("StreamReader").register(batch="test")').error()
+
+    def testStreamReaderBatchBadValue(self):
+        self.env.expect('rg.pyexecute', 'GearsBuilder("StreamReader").register(batch="test")').error()
+
+    def testStreamReaderDurationBadValue(self):
+        self.env.expect('rg.pyexecute', 'GearsBuilder("StreamReader").register(duration="test")').error()
+
+    def testStreamReaderOnFailedPolicyBadValue(self):
+        self.env.expect('rg.pyexecute', 'GearsBuilder("StreamReader").register(onFailedPolicy="test")').error()
+        self.env.expect('rg.pyexecute', 'GearsBuilder("StreamReader").register(onFailedPolicy=1)').error()
+
+    def testStreamReaderOnFailedRetryIntervalBadValue(self):
+        self.env.expect('rg.pyexecute', 'GearsBuilder("StreamReader").register(onFailedRetryInterval="test")').error()
+
+    def testStreamReaderTrimStreamBadValue(self):
+        self.env.expect('rg.pyexecute', 'GearsBuilder("StreamReader").register(trimStream="test")').error()
+        
+    def testKeysReadeReadValueBadValue(self):
+        self.env.expect('rg.pyexecute', 'GearsBuilder().register(readValue=1)').error()
 
 class testGetExecutionErrorReporting:
     def __init__(self):

--- a/src/GearsBuilder.py
+++ b/src/GearsBuilder.py
@@ -104,7 +104,7 @@ class GearsBuilder():
                                              lambda a, r: (a[0] + r, a[1] + 1),
                                              lambda a, r: (a[0] + r[0], a[1] + r[1])).map(lambda x: x[0] / x[1])
 
-    def run(self, arg=None, convertToStr=True, collect=True):
+    def run(self, arg=None, convertToStr=True, collect=True, *args, **kargs):
         '''
         Starting the execution
         '''
@@ -115,7 +115,7 @@ class GearsBuilder():
         arg = arg if arg else self.defaultArg
         if(self.realReader == 'ShardsIDReader'):
             arg = ShardReaderCallback
-        self.gearsCtx.run(arg)
+        self.gearsCtx.run(arg, *args, **kargs)
 
     def register(self,
                  regex='*',

--- a/src/GearsBuilder.py
+++ b/src/GearsBuilder.py
@@ -15,14 +15,12 @@ globals()['str'] = str
 
 redisgears._saveGlobals()
 
-'''
-'''
-def CreateKeysOnlyReader(pattern='*', count=1000, exactMatch=False, patternGenerator=None):
+def CreateKeysOnlyReader(pattern='*', count=1000, noScan=False, patternGenerator=None):
     '''
     Create a KeysOnlyReader callback as a python reader
     pattern          - keys pattern to return
     count            - count parameter given to scan command (ignored if isPattern is false)
-    exactMatch       - boolean indicating if exact match is require, i.e, do not use scan and just return the
+    noScan           - boolean indicating if exact match is require, i.e, do not use scan and just return the
                        give pattern
     patternGenerator - a callbacks to generate different pattern on each shard. If given, the callback
                        will run on each shard and the return tuple (pattern, isPattern) will be used.
@@ -31,12 +29,13 @@ def CreateKeysOnlyReader(pattern='*', count=1000, exactMatch=False, patternGener
     def KeysOnlyReader():
         nonlocal pattern
         nonlocal count
-        nonlocal exactMatch
+        nonlocal noScan
         nonlocal patternGenerator
         if patternGenerator is not None:
-            pattern, exactMatch = patternGenerator()
-        if exactMatch:
-            yield pattern
+            pattern, noScan = patternGenerator()
+        if noScan:
+            if execute('exists', pattern) == 1:
+                yield pattern
         else:
             count = str(count)
             cursor, keys = execute('scan', '0', 'MATCH', str(pattern), 'COUNT', count)

--- a/src/GearsBuilder.py
+++ b/src/GearsBuilder.py
@@ -24,7 +24,7 @@ def CreateKeysOnlyReader(pattern='*', count=1000, noScan=False, patternGenerator
                        give pattern
     patternGenerator - a callbacks to generate different pattern on each shard. If given, the callback
                        will run on each shard and the return tuple (pattern, isPattern) will be used.
-                       If this argument is given the pattern and isPattern arguments are ignored.
+                       If this argument is given the pattern and noScan arguments are ignored.
     '''
     def KeysOnlyReader():
         nonlocal pattern

--- a/src/execution_plan.c
+++ b/src/execution_plan.c
@@ -1253,6 +1253,9 @@ static Record* ExecutionPlan_NextRecord(ExecutionPlan* ep, ExecutionStep* step, 
     	    r = step->reader.r->next(&ectx, step->reader.r->ctx);
             GETTIME(&_te);
     	    step->executionDuration += DURATION;
+    	    if(!r && ectx.err){
+    	        r = RG_ErrorRecordCreate(ectx.err, strlen(ectx.err) + 1);
+    	    }
     	}
         break;
     case MAP:

--- a/src/execution_plan.c
+++ b/src/execution_plan.c
@@ -2316,6 +2316,7 @@ int FlatExecutionPlan_Register(FlatExecutionPlan* fep, ExecutionMode mode, void*
     int res = FlatExecutionPlan_Serialize(&bw, fep, err);
     if(res != REDISMODULE_OK){
         Gears_BufferFree(buff);
+        callbacks->freeTriggerArgs(args);
         return 0;
     }
 

--- a/src/module.c
+++ b/src/module.c
@@ -225,24 +225,24 @@ static void RG_StreamReaderCtxFree(StreamReaderCtx* readerCtx){
     StreamReaderCtx_Free(readerCtx);
 }
 
-static KeysReaderCtx* RG_KeysReaderCtxCreate(const char* match, bool readValue, const char* event, bool isPattern){
-    return KeysReaderCtx_Create(match, readValue, event, isPattern);
+static KeysReaderCtx* RG_KeysReaderCtxCreate(const char* match, bool readValue, const char* event, bool noScan){
+    return KeysReaderCtx_Create(match, readValue, event, noScan);
 }
 
 static void RG_KeysReaderCtxFree(KeysReaderCtx* readerCtx){
     KeysReaderCtx_Free(readerCtx);
 }
 
-static StreamReaderTriggerArgs* RG_StreamReaderTriggerArgsCreate(const char* streamName, size_t batchSize, size_t durationMS, OnFailedPolicy onFailedPolicy, size_t retryInterval, bool trimStream){
-    return StreamReaderTriggerArgs_Create(streamName, batchSize, durationMS, onFailedPolicy, retryInterval, trimStream);
+static StreamReaderTriggerArgs* RG_StreamReaderTriggerArgsCreate(const char* prefix, size_t batchSize, size_t durationMS, OnFailedPolicy onFailedPolicy, size_t retryInterval, bool trimStream){
+    return StreamReaderTriggerArgs_Create(prefix, batchSize, durationMS, onFailedPolicy, retryInterval, trimStream);
 }
 
 static void RG_StreamReaderTriggerArgsFree(StreamReaderTriggerArgs* args){
     return StreamReaderTriggerArgs_Free(args);
 }
 
-static KeysReaderTriggerArgs* RG_KeysReaderTriggerArgsCreate(const char* regex, char** eventTypes, int* keyTypes){
-    return KeysReaderTriggerArgs_Create(regex, eventTypes, keyTypes);
+static KeysReaderTriggerArgs* RG_KeysReaderTriggerArgsCreate(const char* prefix, char** eventTypes, int* keyTypes, bool readValue){
+    return KeysReaderTriggerArgs_Create(prefix, eventTypes, keyTypes, readValue);
 }
 
 static CommandReaderTriggerArgs* RG_CommandReaderTriggerArgsCreate(const char* trigger){

--- a/src/module.c
+++ b/src/module.c
@@ -225,6 +225,14 @@ static void RG_StreamReaderCtxFree(StreamReaderCtx* readerCtx){
     StreamReaderCtx_Free(readerCtx);
 }
 
+static KeysReaderCtx* RG_KeysReaderCtxCreate(const char* match, bool readValue, const char* event, bool isPattern){
+    return KeysReaderCtx_Create(match, readValue, event, isPattern);
+}
+
+static void RG_KeysReaderCtxFree(KeysReaderCtx* readerCtx){
+    KeysReaderCtx_Free(readerCtx);
+}
+
 static StreamReaderTriggerArgs* RG_StreamReaderTriggerArgsCreate(const char* streamName, size_t batchSize, size_t durationMS, OnFailedPolicy onFailedPolicy, size_t retryInterval, bool trimStream){
     return StreamReaderTriggerArgs_Create(streamName, batchSize, durationMS, onFailedPolicy, retryInterval, trimStream);
 }
@@ -576,6 +584,8 @@ static int RedisGears_RegisterApi(RedisModuleCtx* ctx){
     REGISTER_API(GetReader, ctx);
     REGISTER_API(StreamReaderCtxCreate, ctx);
     REGISTER_API(StreamReaderCtxFree, ctx);
+    REGISTER_API(KeysReaderCtxCreate, ctx);
+    REGISTER_API(KeysReaderCtxFree, ctx);
     REGISTER_API(StreamReaderTriggerArgsCreate, ctx);
     REGISTER_API(StreamReaderTriggerArgsFree, ctx);
     REGISTER_API(KeysReaderTriggerArgsCreate, ctx);

--- a/src/module.c
+++ b/src/module.c
@@ -743,7 +743,6 @@ int RedisGears_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     Cluster_Init();
 
     RGM_RegisterReader(KeysReader);
-    RGM_RegisterReader(KeysOnlyReader);
     RGM_RegisterReader(StreamReader);
     RGM_RegisterReader(CommandReader);
     RGM_RegisterReader(ShardIDReader);

--- a/src/readers/command_reader.c
+++ b/src/readers/command_reader.c
@@ -164,7 +164,7 @@ static int CommandReader_RegisrterTrigger(FlatExecutionPlan* fep, ExecutionMode 
     CommandReaderTriggerArgs* crtArgs = args;
     CommandReaderTriggerCtx* crtCtx = Gears_dictFetchValue(CommandRegistrations, crtArgs->trigger);
     if(crtCtx){
-        *err = RG_STRDUP("Command already registered");
+        *err = RG_STRDUP("trigger already registered");
         return REDISMODULE_ERR;
     }
 

--- a/src/readers/keys_reader.h
+++ b/src/readers/keys_reader.h
@@ -15,12 +15,12 @@ int KeysReader_Initialize(RedisModuleCtx* ctx);
  * eventTypes - array of events types to filter, function takes ownership on this value, the caller should not use it anymore
  * keyTypes - array of keys types to filter, function takes ownership on this value, the caller should not use it anymore
  */
-KeysReaderTriggerArgs* KeysReaderTriggerArgs_Create(const char* regex, char** eventTypes, int* keyTypes);
+KeysReaderTriggerArgs* KeysReaderTriggerArgs_Create(const char* prefix, char** eventTypes, int* keyTypes, bool readValue);
 
 void KeysReaderTriggerArgs_Free(KeysReaderTriggerArgs* args);
 
 
-KeysReaderCtx* KeysReaderCtx_Create(const char* match, bool readValue, const char* event, bool isPattern);
+KeysReaderCtx* KeysReaderCtx_Create(const char* match, bool readValue, const char* event, bool exactMatch);
 void KeysReaderCtx_Free(void* ctx);
 
 #endif /* SRC_KEYS_READER_H_ */

--- a/src/readers/keys_reader.h
+++ b/src/readers/keys_reader.h
@@ -20,4 +20,7 @@ KeysReaderTriggerArgs* KeysReaderTriggerArgs_Create(const char* regex, char** ev
 void KeysReaderTriggerArgs_Free(KeysReaderTriggerArgs* args);
 
 
+KeysReaderCtx* KeysReaderCtx_Create(const char* match, bool readValue, const char* event, bool isPattern);
+void KeysReaderCtx_Free(void* ctx);
+
 #endif /* SRC_KEYS_READER_H_ */

--- a/src/readers/keys_reader.h
+++ b/src/readers/keys_reader.h
@@ -5,7 +5,6 @@
 #include "redisgears.h"
 
 extern RedisGears_ReaderCallbacks KeysReader;
-extern RedisGears_ReaderCallbacks KeysOnlyReader;
 
 int KeysReader_Initialize(RedisModuleCtx* ctx);
 

--- a/src/readers/streams_reader.c
+++ b/src/readers/streams_reader.c
@@ -389,7 +389,7 @@ static void StreamReader_ReadRecords(RedisModuleCtx* ctx, StreamReaderCtx* reade
 
         Record* valRecord = RedisGears_StringRecordCreate(idCStr, len);
         Record* keyRecord = RedisGears_StringRecordCreate(RG_STRDUP(readerCtx->streamKeyName), strlen(readerCtx->streamKeyName));
-        RedisGears_HashSetRecordSet(r, "msg_id", valRecord);
+        RedisGears_HashSetRecordSet(r, "id", valRecord);
         RedisGears_HashSetRecordSet(r, "value", recordValues);
         RedisGears_HashSetRecordSet(r, "key", keyRecord);
         RedisModuleCallReply *values = RedisModule_CallReplyArrayElement(element, 1);

--- a/src/readers/streams_reader.c
+++ b/src/readers/streams_reader.c
@@ -35,7 +35,7 @@ typedef struct StreamReaderCtx{
 typedef struct StreamReaderTriggerArgs{
     size_t batchSize;
     size_t durationMS;
-    char* stream;
+    char* streamPrefix;
     OnFailedPolicy onFailedPolicy;
     size_t retryInterval;
     bool trimStream;
@@ -132,9 +132,9 @@ static StreamId StreamReader_ParseStreamId(const char* streamId){
     return ret;
 }
 
-StreamReaderTriggerArgs* StreamReaderTriggerArgs_Create(const char* streamName, size_t batchSize, size_t durationMS, OnFailedPolicy onFailedPolicy, size_t retryInterval, bool trimStream){
+StreamReaderTriggerArgs* StreamReaderTriggerArgs_Create(const char* streamPrefix, size_t batchSize, size_t durationMS, OnFailedPolicy onFailedPolicy, size_t retryInterval, bool trimStream){
     StreamReaderTriggerArgs* readerArgs = RG_ALLOC(sizeof(StreamReaderTriggerArgs));
-    readerArgs->stream = RG_STRDUP(streamName);
+    readerArgs->streamPrefix = RG_STRDUP(streamPrefix);
     readerArgs->batchSize = batchSize;
     readerArgs->durationMS = durationMS;
     readerArgs->onFailedPolicy = onFailedPolicy;
@@ -144,7 +144,7 @@ StreamReaderTriggerArgs* StreamReaderTriggerArgs_Create(const char* streamName, 
 }
 
 void StreamReaderTriggerArgs_Free(StreamReaderTriggerArgs* args){
-    RG_FREE(args->stream);
+    RG_FREE(args->streamPrefix);
     RG_FREE(args);
 }
 
@@ -343,6 +343,18 @@ static void StreamReader_ReadRecords(RedisModuleCtx* ctx, StreamReaderCtx* reade
     }else{
         assert(readerCtx->streamId);
         reply = RedisModule_Call(ctx, "XREAD", "ccc", "STREAMS", readerCtx->streamKeyName, readerCtx->streamId);
+        if(RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_ERROR){
+            LockHandler_Release(ctx);
+            size_t errorLen;
+            const char* errorRecord = RedisModule_CallReplyStringPtr(reply, &errorLen);
+            char* errorStr = RG_ALLOC((errorLen + 1)* sizeof(char));
+            memcpy(errorStr, errorRecord, errorLen);
+            errorStr[errorLen] = '\0';
+            Record* errorRecrod = RG_ErrorRecordCreate(errorStr, errorLen);
+            Gears_listAddNodeHead(readerCtx->records, errorRecrod);
+            RedisModule_FreeCallReply(reply);
+            return;
+        }
     }
     LockHandler_Release(ctx);
     if(!StreamReader_VerifyCallReply(ctx, reply, NULL, NULL)){
@@ -359,6 +371,7 @@ static void StreamReader_ReadRecords(RedisModuleCtx* ctx, StreamReaderCtx* reade
     assert(RedisModule_CallReplyType(elements) == REDISMODULE_REPLY_ARRAY);
     for(size_t i = 0 ; i < RedisModule_CallReplyLength(elements) ; ++i){
         Record* r = RedisGears_HashSetRecordCreate();
+        Record* recordValues = RedisGears_HashSetRecordCreate();
         RedisModuleCallReply *element = RedisModule_CallReplyArrayElement(elements, i);
         assert(RedisModule_CallReplyType(element) == REDISMODULE_REPLY_ARRAY);
         RedisModuleCallReply *id = RedisModule_CallReplyArrayElement(element, 0);
@@ -375,7 +388,10 @@ static void StreamReader_ReadRecords(RedisModuleCtx* ctx, StreamReaderCtx* reade
         }
 
         Record* valRecord = RedisGears_StringRecordCreate(idCStr, len);
-        RedisGears_HashSetRecordSet(r, "streamId", valRecord);
+        Record* keyRecord = RedisGears_StringRecordCreate(RG_STRDUP(readerCtx->streamKeyName), strlen(readerCtx->streamKeyName));
+        RedisGears_HashSetRecordSet(r, "msg_id", valRecord);
+        RedisGears_HashSetRecordSet(r, "value", recordValues);
+        RedisGears_HashSetRecordSet(r, "key", keyRecord);
         RedisModuleCallReply *values = RedisModule_CallReplyArrayElement(element, 1);
         assert(RedisModule_CallReplyType(values) == REDISMODULE_REPLY_ARRAY);
         assert(RedisModule_CallReplyLength(values) % 2 == 0);
@@ -391,7 +407,7 @@ static void StreamReader_ReadRecords(RedisModuleCtx* ctx, StreamReaderCtx* reade
             memcpy(valCStr, valStr, len);
             valCStr[len] = '\0';
             Record* valRecord = RedisGears_StringRecordCreate(valCStr, len);
-            RedisGears_HashSetRecordSet(r, keyCStr, valRecord);
+            RedisGears_HashSetRecordSet(recordValues, keyCStr, valRecord);
         }
         Gears_listAddNodeHead(readerCtx->records, r);
     }
@@ -785,7 +801,7 @@ static int StreamReader_OnKeyTouched(RedisModuleCtx *ctx, int type, const char *
             // we ignore stopped executions
             continue;
         }
-        if(StreamReader_IsKeyMatch(srctx->args->stream, keyName)){
+        if(StreamReader_IsKeyMatch(srctx->args->streamPrefix, keyName)){
             SingleStreamReaderCtx* ssrctx = Gears_dictFetchValue(srctx->singleStreamData, (char*)keyName);
             if(!ssrctx){
                 ssrctx = SingleStreamReaderCtx_Create(ctx, keyName, srctx);
@@ -848,7 +864,7 @@ static void* StreamReader_ScanForStreams(void* pd){
         // we do not use the lockhandler cause this thread is temporary
         // and we do not want to allocate any unneeded extra data.
         RedisModule_ThreadSafeContextLock(staticCtx);
-        RedisModuleCallReply *reply = RedisModule_Call(staticCtx, "SCAN", "lcccc", cursor, "COUNT", "10000", "MATCH", srctx->args->stream);
+        RedisModuleCallReply *reply = RedisModule_Call(staticCtx, "SCAN", "lcccc", cursor, "COUNT", "10000", "MATCH", srctx->args->streamPrefix);
         RedisModule_ThreadSafeContextUnlock(staticCtx);
 
         bool ret = StreamReader_VerifyCallReply(staticCtx, reply, "Failed scanning keys on background", "warning");
@@ -954,7 +970,7 @@ static Reader* StreamReader_Create(void* arg){
 
 static void StreamReader_SerializeArgs(void* args, Gears_BufferWriter* bw){
     StreamReaderTriggerArgs* triggerArgs = args;
-    RedisGears_BWWriteString(bw, triggerArgs->stream);
+    RedisGears_BWWriteString(bw, triggerArgs->streamPrefix);
     RedisGears_BWWriteLong(bw, triggerArgs->batchSize);
     RedisGears_BWWriteLong(bw, triggerArgs->durationMS);
     RedisGears_BWWriteLong(bw, triggerArgs->onFailedPolicy);
@@ -1007,7 +1023,7 @@ static void StreamReader_DumpRegistrationData(RedisModuleCtx* ctx, FlatExecution
     RedisModule_ReplyWithStringBuffer(ctx, "durationMS", strlen("durationMS"));
     RedisModule_ReplyWithLongLong(ctx, srctx->args->durationMS);
     RedisModule_ReplyWithStringBuffer(ctx, "stream", strlen("stream"));
-    RedisModule_ReplyWithStringBuffer(ctx, srctx->args->stream, strlen(srctx->args->stream));
+    RedisModule_ReplyWithStringBuffer(ctx, srctx->args->streamPrefix, strlen(srctx->args->streamPrefix));
     RedisModule_ReplyWithStringBuffer(ctx, "status", strlen("status"));
     switch(srctx->status){
     case StreamRegistrationStatus_OK:

--- a/src/readers/streams_reader.h
+++ b/src/readers/streams_reader.h
@@ -13,7 +13,7 @@
 extern RedisGears_ReaderCallbacks StreamReader;
 StreamReaderCtx* StreamReaderCtx_Create(const char* streamName, const char* streamId);
 void StreamReaderCtx_Free(StreamReaderCtx* readerCtx);
-StreamReaderTriggerArgs* StreamReaderTriggerArgs_Create(const char* streamName, size_t batchSize, size_t durationMS, OnFailedPolicy onFailedPolicy, size_t retryInterval, bool trimStream);
+StreamReaderTriggerArgs* StreamReaderTriggerArgs_Create(const char* streamPrefix, size_t batchSize, size_t durationMS, OnFailedPolicy onFailedPolicy, size_t retryInterval, bool trimStream);
 void StreamReaderTriggerArgs_Free(StreamReaderTriggerArgs* args);
 
 #endif /* SRC_STREAMS_READER_H_ */

--- a/src/record.c
+++ b/src/record.c
@@ -71,6 +71,9 @@ void RG_FreeRecord(Record* record){
     Gears_dictIterator *iter;
     Gears_dictEntry *entry;
     Record* temp;
+    if(!record){
+        return;
+    }
     switch(record->type){
     case STRING_RECORD:
     case ERROR_RECORD:

--- a/src/redisgears.h
+++ b/src/redisgears.h
@@ -181,13 +181,13 @@ typedef struct CommandReaderTriggerArgs CommandReaderTriggerArgs;
 StreamReaderCtx* MODULE_API_FUNC(RedisGears_StreamReaderCtxCreate)(const char* streamName, const char* streamId);
 void MODULE_API_FUNC(RedisGears_StreamReaderCtxFree)(StreamReaderCtx*);
 
-KeysReaderCtx* MODULE_API_FUNC(RedisGears_KeysReaderCtxCreate)(const char* match, bool readValue, const char* event, bool isPattern);
+KeysReaderCtx* MODULE_API_FUNC(RedisGears_KeysReaderCtxCreate)(const char* match, bool readValue, const char* event, bool noScan);
 void MODULE_API_FUNC(RedisGears_KeysReaderCtxFree)(KeysReaderCtx*);
 
-StreamReaderTriggerArgs* MODULE_API_FUNC(RedisGears_StreamReaderTriggerArgsCreate)(const char* streamName, size_t batchSize, size_t durationMS, OnFailedPolicy onFailedPolicy, size_t retryInterval, bool trimStream);
+StreamReaderTriggerArgs* MODULE_API_FUNC(RedisGears_StreamReaderTriggerArgsCreate)(const char* prefix, size_t batchSize, size_t durationMS, OnFailedPolicy onFailedPolicy, size_t retryInterval, bool trimStream);
 void MODULE_API_FUNC(RedisGears_StreamReaderTriggerArgsFree)(StreamReaderTriggerArgs* args);
 
-KeysReaderTriggerArgs* MODULE_API_FUNC(RedisGears_KeysReaderTriggerArgsCreate)(const char* regex, Arr(char*) eventTypes, Arr(int) keyTypes);
+KeysReaderTriggerArgs* MODULE_API_FUNC(RedisGears_KeysReaderTriggerArgsCreate)(const char* prefix, Arr(char*) eventTypes, Arr(int) keyTypes, bool readValue);
 void MODULE_API_FUNC(RedisGears_KeysReaderTriggerArgsFree)(KeysReaderTriggerArgs* args);
 
 CommandReaderTriggerArgs* MODULE_API_FUNC(RedisGears_CommandReaderTriggerArgsCreate)(const char* trigger);

--- a/src/redisgears.h
+++ b/src/redisgears.h
@@ -181,6 +181,9 @@ typedef struct CommandReaderTriggerArgs CommandReaderTriggerArgs;
 StreamReaderCtx* MODULE_API_FUNC(RedisGears_StreamReaderCtxCreate)(const char* streamName, const char* streamId);
 void MODULE_API_FUNC(RedisGears_StreamReaderCtxFree)(StreamReaderCtx*);
 
+KeysReaderCtx* MODULE_API_FUNC(RedisGears_KeysReaderCtxCreate)(const char* match, bool readValue, const char* event, bool isPattern);
+void MODULE_API_FUNC(RedisGears_KeysReaderCtxFree)(KeysReaderCtx*);
+
 StreamReaderTriggerArgs* MODULE_API_FUNC(RedisGears_StreamReaderTriggerArgsCreate)(const char* streamName, size_t batchSize, size_t durationMS, OnFailedPolicy onFailedPolicy, size_t retryInterval, bool trimStream);
 void MODULE_API_FUNC(RedisGears_StreamReaderTriggerArgsFree)(StreamReaderTriggerArgs* args);
 
@@ -442,6 +445,8 @@ static int RedisGears_Initialize(RedisModuleCtx* ctx){
     REDISGEARS_MODULE_INIT_FUNCTION(ctx, GetReader);
     REDISGEARS_MODULE_INIT_FUNCTION(ctx, StreamReaderCtxCreate);
     REDISGEARS_MODULE_INIT_FUNCTION(ctx, StreamReaderCtxFree);
+    REDISGEARS_MODULE_INIT_FUNCTION(ctx, KeysReaderCtxCreate);
+    REDISGEARS_MODULE_INIT_FUNCTION(ctx, KeysReaderCtxFree);
     REDISGEARS_MODULE_INIT_FUNCTION(ctx, StreamReaderTriggerArgsCreate);
     REDISGEARS_MODULE_INIT_FUNCTION(ctx, StreamReaderTriggerArgsFree);
     REDISGEARS_MODULE_INIT_FUNCTION(ctx, KeysReaderTriggerArgsCreate);

--- a/src/redisgears.h
+++ b/src/redisgears.h
@@ -97,7 +97,6 @@ typedef struct Reader{
  * Default readers to use
  */
 #define KeysReader KeysReader
-#define KeysOnlyReader KeysOnlyReader
 #define StreamReader StreamReader
 #define CommandReader CommandReader
 #define ShardIDReader ShardIDReader

--- a/src/redisgears_python.c
+++ b/src/redisgears_python.c
@@ -1211,6 +1211,7 @@ typedef struct PyAtomic{
 static PyObject* atomicEnter(PyObject *self, PyObject *args){
     PyAtomic* pyAtomic = (PyAtomic*)self;
     LockHandler_Acquire(pyAtomic->ctx);
+    RedisModule_Replicate(pyAtomic->ctx, "multi", "");
     Py_INCREF(self);
     return self;
 }
@@ -1218,6 +1219,7 @@ static PyObject* atomicEnter(PyObject *self, PyObject *args){
 static PyObject* atomicExit(PyObject *self, PyObject *args){
     PyAtomic* pyAtomic = (PyAtomic*)self;
     LockHandler_Release(pyAtomic->ctx);
+    RedisModule_Replicate(pyAtomic->ctx, "exec", "");
     Py_INCREF(self);
     return self;
 }

--- a/src/redisgears_python.c
+++ b/src/redisgears_python.c
@@ -1440,7 +1440,7 @@ static PyObject* RedisConfigGet(PyObject *cls, PyObject *args){
 }
 
 static PyObject* RedisLog(PyObject *cls, PyObject *args, PyObject *kargs){
-    PyObject* logLevel = PyDict_GetItemString(kargs, "level");
+    PyObject* logLevel = kargs? PyDict_GetItemString(kargs, "level") : NULL;
     PyObject* logMsg = NULL;
     if(PyTuple_Size(args) < 1 || PyTuple_Size(args) > 2){
         PyErr_SetString(GearsError, "log function must get a log message as input");

--- a/src/redisgears_python.c
+++ b/src/redisgears_python.c
@@ -89,6 +89,10 @@ typedef struct PythonSessionCtx{
     PythonRequirementCtx** requirements;
 }PythonSessionCtx;
 
+static PyObject* GearsPyDict_GetItemString(PyObject* dict, const char* key){
+    return (dict ? PyDict_GetItemString(dict, key) : NULL);
+}
+
 static bool PythonRequirementCtx_DownloadRequirement(PythonRequirementCtx* req){
 #define RETRY 3
 #define RETRY_SLEEP_IN_SEC 1
@@ -791,7 +795,7 @@ static void dropExecutionOnDone(ExecutionPlan* ep, void* privateData){
 static void* runCreateStreamReaderArgs(const char* pattern, PyObject *kargs){
     const char* defaultFromIdStr = "0-0";
     const char* fromIdStr = defaultFromIdStr;
-    PyObject* pyFromId = PyDict_GetItemString(kargs, "fromId");
+    PyObject* pyFromId = GearsPyDict_GetItemString(kargs, "fromId");
     if(pyFromId){
         if(!PyUnicode_Check(pyFromId)){
             PyErr_SetString(GearsError, "fromId argument must be a string");
@@ -804,7 +808,7 @@ static void* runCreateStreamReaderArgs(const char* pattern, PyObject *kargs){
 
 static void* runCreateKeysReaderArgs(const char* pattern, PyObject *kargs){
     bool noScan = false;
-    PyObject* pyNoScan = PyDict_GetItemString(kargs, "noScan");
+    PyObject* pyNoScan = GearsPyDict_GetItemString(kargs, "noScan");
     if(pyNoScan){
         if(!PyBool_Check(pyNoScan)){
             PyErr_SetString(GearsError, "exactMatch value is not boolean");
@@ -815,7 +819,7 @@ static void* runCreateKeysReaderArgs(const char* pattern, PyObject *kargs){
         }
     }
     bool readValue = true;
-    PyObject* pyReadValue = PyDict_GetItemString(kargs, "readValue");
+    PyObject* pyReadValue = GearsPyDict_GetItemString(kargs, "readValue");
     if(pyReadValue){
         if(!PyBool_Check(pyReadValue)){
             PyErr_SetString(GearsError, "readValue value is not boolean");
@@ -937,7 +941,7 @@ static void* registerCreateKeysArgs(PyObject *kargs, const char* prefix, Executi
     Arr(int) keyTypes = NULL;
 
     // getting even types white list (no list == all event types)
-    PyObject* pyEventTypes = PyDict_GetItemString(kargs, "eventTypes");
+    PyObject* pyEventTypes = GearsPyDict_GetItemString(kargs, "eventTypes");
     if(pyEventTypes && pyEventTypes != Py_None){
         PyObject* eventTypesIterator = PyObject_GetIter(pyEventTypes);
         if(!eventTypesIterator){
@@ -961,7 +965,7 @@ static void* registerCreateKeysArgs(PyObject *kargs, const char* prefix, Executi
     }
 
     // getting key types white list (no list == all key types)
-    PyObject* pyKeyTypes = PyDict_GetItemString(kargs, "keyTypes");
+    PyObject* pyKeyTypes = GearsPyDict_GetItemString(kargs, "keyTypes");
     if(pyKeyTypes && pyKeyTypes != Py_None){
         PyObject* keyTypesIterator = PyObject_GetIter(pyKeyTypes);
         if(!keyTypesIterator){
@@ -993,7 +997,7 @@ static void* registerCreateKeysArgs(PyObject *kargs, const char* prefix, Executi
     }
 
     bool readValue = true;
-    PyObject* pyReadValue = PyDict_GetItemString(kargs, "readValue");
+    PyObject* pyReadValue = GearsPyDict_GetItemString(kargs, "readValue");
     if(pyReadValue){
         if(!PyBool_Check(pyReadValue)){
             PyErr_SetString(GearsError, "readValue is not boolean");
@@ -1022,7 +1026,7 @@ static OnFailedPolicy getOnFailedPolicy(const char* onFailurePolicyStr){
 
 static void* registerCreateStreamArgs(PyObject *kargs, const char* prefix, ExecutionMode mode){
     size_t batch = 1;
-    PyObject* pyBatch = PyDict_GetItemString(kargs, "batch");
+    PyObject* pyBatch = GearsPyDict_GetItemString(kargs, "batch");
     if(pyBatch){
         if(PyNumber_Check(pyBatch)){
             batch = PyNumber_AsSsize_t(pyBatch, NULL);
@@ -1033,7 +1037,7 @@ static void* registerCreateStreamArgs(PyObject *kargs, const char* prefix, Execu
     }
 
     size_t durationMS = 0;
-    PyObject* pydurationInSec = PyDict_GetItemString(kargs, "duration");
+    PyObject* pydurationInSec = GearsPyDict_GetItemString(kargs, "duration");
     if(pydurationInSec){
         if(PyNumber_Check(pydurationInSec)){
             durationMS = PyNumber_AsSsize_t(pydurationInSec, NULL);
@@ -1044,7 +1048,7 @@ static void* registerCreateStreamArgs(PyObject *kargs, const char* prefix, Execu
     }
 
     OnFailedPolicy onFailedPolicy = OnFailedPolicyContinue;
-    PyObject* pyOnFailedPolicy = PyDict_GetItemString(kargs, "onFailedPolicy");
+    PyObject* pyOnFailedPolicy = GearsPyDict_GetItemString(kargs, "onFailedPolicy");
     if(pyOnFailedPolicy){
         if(PyUnicode_Check(pyOnFailedPolicy)){
             const char* onFailedPolicyStr = PyUnicode_AsUTF8AndSize(pyOnFailedPolicy, NULL);
@@ -1064,7 +1068,7 @@ static void* registerCreateStreamArgs(PyObject *kargs, const char* prefix, Execu
     }
 
     size_t retryInterval = 1;
-    PyObject* pyRetryInterval = PyDict_GetItemString(kargs, "onFailedRetryInterval");
+    PyObject* pyRetryInterval = GearsPyDict_GetItemString(kargs, "onFailedRetryInterval");
     if(pyRetryInterval){
         if(PyNumber_Check(pyRetryInterval)){
             retryInterval = PyNumber_AsSsize_t(pyRetryInterval, NULL);
@@ -1075,7 +1079,7 @@ static void* registerCreateStreamArgs(PyObject *kargs, const char* prefix, Execu
     }
 
     bool trimStream = true;
-    PyObject* pyTrimStream = PyDict_GetItemString(kargs, "trimStream");
+    PyObject* pyTrimStream = GearsPyDict_GetItemString(kargs, "trimStream");
     if(pyTrimStream){
         if(PyBool_Check(pyTrimStream)){
             if(Py_True == pyTrimStream){
@@ -1094,7 +1098,7 @@ static void* registerCreateStreamArgs(PyObject *kargs, const char* prefix, Execu
 
 static void* registerCreateCommandArgs(PyObject *kargs){
     const char* trigger = NULL;
-    PyObject* pyTrigger = PyDict_GetItemString(kargs, "trigger");
+    PyObject* pyTrigger = GearsPyDict_GetItemString(kargs, "trigger");
     if(!pyTrigger){
         PyErr_SetString(GearsError, "trigger argument was not given");
         return NULL;
@@ -1115,7 +1119,7 @@ static void* registerCreateArgs(FlatExecutionPlan* fep, PyObject *kargs, Executi
 
     char* defaultPrefixStr = "*";
     const char* prefixStr = defaultPrefixStr;
-    PyObject* prefix = PyDict_GetItemString(kargs, "prefix");
+    PyObject* prefix = GearsPyDict_GetItemString(kargs, "prefix");
     if(prefix){
         if(PyUnicode_Check(prefix)){
             prefixStr = PyUnicode_AsUTF8AndSize(prefix, NULL);
@@ -1125,8 +1129,7 @@ static void* registerCreateArgs(FlatExecutionPlan* fep, PyObject *kargs, Executi
         }
     }
 
-    if (strcmp(reader, "KeysReader") == 0 ||
-            strcmp(reader, "KeysOnlyReader") == 0) {
+    if (strcmp(reader, "KeysReader")){
         return registerCreateKeysArgs(kargs, prefixStr, mode);
     }else if (strcmp(reader, "StreamReader") == 0){
         return registerCreateStreamArgs(kargs, prefixStr, mode);
@@ -1144,7 +1147,7 @@ static PyObject* registerExecution(PyObject *self, PyObject *args, PyObject *kar
         return NULL;
     }
 
-    PyObject* pymode = PyDict_GetItemString(kargs, "mode");
+    PyObject* pymode = GearsPyDict_GetItemString(kargs, "mode");
     ExecutionMode mode = ExecutionModeAsync;
     if(pymode){
         if(PyUnicode_Check(pymode)){
@@ -1165,7 +1168,7 @@ static PyObject* registerExecution(PyObject *self, PyObject *args, PyObject *kar
         }
     }
 
-    PyObject* onRegistered = PyDict_GetItemString(kargs, "onRegistered");
+    PyObject* onRegistered = GearsPyDict_GetItemString(kargs, "onRegistered");
     if(onRegistered && onRegistered != Py_None){
         if(!PyFunction_Check(onRegistered)){
             PyErr_SetString(GearsError, "OnRegistered argument must be a function");
@@ -1440,7 +1443,7 @@ static PyObject* RedisConfigGet(PyObject *cls, PyObject *args){
 }
 
 static PyObject* RedisLog(PyObject *cls, PyObject *args, PyObject *kargs){
-    PyObject* logLevel = kargs? PyDict_GetItemString(kargs, "level") : NULL;
+    PyObject* logLevel = GearsPyDict_GetItemString(kargs, "level");
     PyObject* logMsg = NULL;
     if(PyTuple_Size(args) < 1 || PyTuple_Size(args) > 2){
         PyErr_SetString(GearsError, "log function must get a log message as input");

--- a/src/redisgears_python.c
+++ b/src/redisgears_python.c
@@ -1129,7 +1129,7 @@ static void* registerCreateArgs(FlatExecutionPlan* fep, PyObject *kargs, Executi
         }
     }
 
-    if (strcmp(reader, "KeysReader")){
+    if (strcmp(reader, "KeysReader") == 0){
         return registerCreateKeysArgs(kargs, prefixStr, mode);
     }else if (strcmp(reader, "StreamReader") == 0){
         return registerCreateStreamArgs(kargs, prefixStr, mode);


### PR DESCRIPTION
Introduce the following api changes:

1. KeysOnlyReader is implemented as python reader and support the following arguments:
```
	def CreateKeysOnlyReader(pattern='*', count=1000, exactMatch=False, patternGenerator=None):
    	'''
    	Create a KeysOnlyReader callback as a python reader
    	pattern          - keys pattern to return
    	count            - count parameter given to scan command (ignored if isPattern is false)
    	exactMatch       - boolean indicating if exact match is require, i.e, do not use scan and just return the
                       give pattern
    	patternGenerator - a callbacks to generate different pattern on each shard. If given, the callback
                       will run on each shard and the return tuple (pattern, isPattern) will be used.
                       If this argument is given the pattern and isPattern arguments are ignored.
    	'''
```
2. KeysReader format was changed to (notice there is no backword issues here): {'key':..., 'value':..., 'type':..., 'event':...}
   * key - the key name (string)
   * value - the key value (type is depends on the key type)
   * type - the key type (string, hash, set, ...)
   * event - the event that trigger the exection (SET, HSET, ..), None on batch executions


   In addition the KeysReader introduce the following new/changed capabilities:
   * on 'run':
      * readValue - if False only the 'key' and the 'event' values will be provided (default True)
      * noScan - if True read the exect pattern given without performing scan operation (default False)
   * on 'register':
      * readValue - same as read value on 'run'
      * regex argument was depricated and changed to prefix

3. StreamReader format was changed to (notice there is a backword compatability): {'key':..., 'msg_id':..., 'value':{'k':'v',...}}
   * key - the stream key (string)
   * msg_id - the current message id (string)
   * value - the message value (dictionary)


   In addition the StreamReader introduce the following new/changed capabilities:
   * on 'run':
      * fronId - the id from which to start read messages from the stream (default 0-0)
   * on 'register':
      * regex argument was depricated and changed to prefix

4. the 'Log' function was changed to 'Log(msg, level='notice')'.
   If old argument format is used a depricated message is added to the log file

5. Pytest was added to cover all the new arguments

Still left to do:
- [x] Add tests for KeysOnlyReader
- [x] Document all the changes
- [x] Delete the KeysOnlyReader from Keys_reader.c
- [x] Change msg_id to just id

@itamarhaber FYI