### PR TITLE
Fixes a false deprecation warning

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -58,6 +58,20 @@ An input Redis Stream is stored under the "mystream" key.
 {{ include('examples/stream-logger.py') }}
 ```
 
+## Automatic Expiry
+
+Sets the time to live (TTL) for every updated key to one hour.
+
+**Author: [RedisLabs](https://redislabs.com/)**
+
+**Python API**
+
+```python
+{{ include('examples/automatic-expire.py') }}
+```
+
+**Author: [RedisLabs](https://redislabs.com/)**
+
 ## Distributed Monte Carlo Estimation of Pi's Value
 
 Estimate Pi by throwing darts at a carefully-constructed dartboard.

--- a/docs/snippets/examples/automatic-expire.py
+++ b/docs/snippets/examples/automatic-expire.py
@@ -1,3 +1,3 @@
 gb = GB()
 gb.foreach(lambda x: execute('EXPIRE', x['key'], 3600))
-gb.register('*', readValue=False)
+gb.register('*', mode='sync', readValue=False)

--- a/docs/snippets/examples/automatic-expire.py
+++ b/docs/snippets/examples/automatic-expire.py
@@ -1,0 +1,3 @@
+gb = GB()
+gb.foreach(lambda x: execute('EXPIRE', x['key'], 3600))
+gb.register('*', readValue=False)

--- a/docs/snippets/runtime/configget.py
+++ b/docs/snippets/runtime/configget.py
@@ -1,2 +1,2 @@
 # Gets the current value for 'ProfileExecutions'
-foo = ConfigGet('ProfileExecutions')
+foo = configGet('ProfileExecutions')

--- a/docs/snippets/runtime/gearsconfigget.py
+++ b/docs/snippets/runtime/gearsconfigget.py
@@ -1,2 +1,2 @@
 # Gets the 'foo' configuration option key and defaults to 'bar'
-foo = GearsConfigGet('foo', default='bar')
+foo = gearsConfigGet('foo', default='bar')

--- a/docs/snippets/test_snippets.py
+++ b/docs/snippets/test_snippets.py
@@ -40,6 +40,7 @@ def standalone(image):
 @pytest.mark.parametrize(
     'snippet,expected',
     [
+        ('docs/snippets/examples/automatic-expire.py', b'OK'),
         ('docs/snippets/examples/del-by-prefix.py', [[], []]),
         ('docs/snippets/examples/monte-carlo-pi.py', [[b'foo'], []]),
         ('docs/snippets/examples/stream-logger.py', b'OK'),

--- a/src/GearsBuilder.py
+++ b/src/GearsBuilder.py
@@ -61,7 +61,7 @@ class GearsBuilder():
         if(reader == 'ShardsIDReader'):
             reader = 'PythonReader'
         if(reader == 'KeysOnlyReader'):
-            reader = 'PythonReader'    
+            reader = 'PythonReader'
         self.reader = reader
         self.gearsCtx = gearsCtx(self.reader, desc)
         self.defaultArg = defaultArg
@@ -186,7 +186,7 @@ def RunGearsRemoteBuilder(pipe, globalsDict):
         s.AddToGB(gb, globalsDict)
 
 def gearsConfigGet(key, default=None):
-    val = ConfigGet(key)
+    val = configGet(key)
     return val if val is not None else default
 
 def genDeprecated(deprecatedName, name, target):


### PR DESCRIPTION
When calling gearsConfigGet the warning gets printed.

Also, updates docs API snippets so these use the non-deprecated config methods and adds an example for automatically expiring keys.