### PR TITLE
Bumps Redis version in docker images to 5.0.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # BUILD redisfab/redisgears-${OSNICK}:M.m.b-${ARCH}
 
-ARG REDIS_VER=5.0.7
+ARG REDIS_VER=5.0.8
 
 # OSNICK=bionic|stretch|buster
 ARG OSNICK=buster

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -7,7 +7,7 @@ ARG OSNICK=buster
 ARG ARCH=arm64v8
 
 #----------------------------------------------------------------------------------------------
-FROM redisfab/redis-${ARCH}-${OSNICK}-xbuild:5.0.5 AS builder
+FROM redisfab/redis-${ARCH}-${OSNICK}-xbuild:5.0.8 AS builder
 
 RUN [ "cross-build-start" ]
 
@@ -26,7 +26,7 @@ RUN if [ "$TEST" = "1" ]; then TEST= make test; fi
 RUN [ "cross-build-end" ]
 
 #----------------------------------------------------------------------------------------------
-FROM redisfab/redis-${ARCH}-${OSNICK}-xbuild:5.0.5
+FROM redisfab/redis-${ARCH}-${OSNICK}-xbuild:5.0.8
 
 RUN [ "cross-build-start" ]
 


### PR DESCRIPTION
@rafie I think these should use :latest, for your consideration