### PR TITLE
Remove PyIter_Check in createTensorFromValues

### DIFF
--- a/src/redisgears_python.c
+++ b/src/redisgears_python.c
@@ -2020,11 +2020,11 @@ static PyObject* createTensorFromValues(PyObject *cls, PyObject *args){
     }
 
     PyObject* values = PyTuple_GetItem(args, 2);
-    if(!PyIter_Check(values)){
+    PyObject* valuesIter = PyObject_GetIter(values);
+    if(valuesIter == NULL){
         PyErr_SetString(GearsError, "values argument must be iterable");
         goto error;
     }
-    PyObject* valuesIter = PyObject_GetIter(values);
     PyObject* currValue = NULL;
     size_t index = 0;
     while((currValue = PyIter_Next(valuesIter)) != NULL){


### PR DESCRIPTION
When calling: `redisAI.createTensorFromValues('FLOAT', [1, 3], [0, 1, 2])`, RedisGear is throwing error:
```
'spam.error: values argument must be iterable\n'
```

This is due to the `PyIter_Check` that is being removed in this PR, rather we are checking whether the iterator is NULL like the rest of the places.

> `PyIter_Check` is for checking whether an object **is** an iterator, not whether it can *provide* one. ([ref](https://stackoverflow.com/a/59145186/4135289))