### PR TITLE
Fix: fix epel install failure

### DIFF
--- a/system-setup.py
+++ b/system-setup.py
@@ -58,7 +58,7 @@ class RedisGearsSetup(paella.Setup):
         self.install("libatomic file")
 
         self.run("wget -q -O /tmp/epel-release-latest-7.noarch.rpm http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm")
-        self.run("rpm -Uv /tmp/epel-release-latest-7.noarch.rpm ")
+        self.run("rpm -Uv /tmp/epel-release-latest-7.noarch.rpm --replacepkgs ")
 
         self.run("""
             dir=$(mktemp -d /tmp/tar.XXXXXX)


### PR DESCRIPTION
package may exist because last install.  Add `--replacepkgs ` and try to reinstall the package if package has already install otherwise self.run will return exceptions.  

```
$sudo rpm -Uv /tmp/epel-release-latest-7.noarch.rpm
warning: /tmp/epel-release-latest-7.noarch.rpm: Header V3 RSA/SHA256 Signature, key ID 352c64e5: NOKEY
warning: Unable to get systemd shutdown inhibition lock: Unit is masked.
Preparing packages...
	package epel-release-7-12.noarch is already installed

[011158133251 /home/code/RedisGears]
$echo $?
1
```
```
$sudo rpm -Uv /tmp/epel-release-latest-7.noarch.rpm --force
warning: /tmp/epel-release-latest-7.noarch.rpm: Header V3 RSA/SHA256 Signature, key ID 352c64e5: NOKEY
warning: Unable to get systemd shutdown inhibition lock: Unit is masked.
Preparing packages...
epel-release-7-12.noarch

[011158133251 /home/code/RedisGears]
$echo $?
0

```