### PR TITLE
Better Redis-Enterprise cluster integration

### DIFF
--- a/pytest/test_network.py
+++ b/pytest/test_network.py
@@ -399,7 +399,7 @@ def testSendTopology(env):
         conn = shardMock.GetConnection(sendHelloResponse=False)
 
         # should recieve the topology
-        env.assertEqual(conn.read_request(), ['rg.clustersetfromshard', 'NO-USED', 'NO-USED', 'NO-USED', 'NO-USED', 'NO-USED', '0000000000000000000000000000000000000002', 'NO-USED', '2', 'NO-USED', '1', 'NO-USED', '0', '8192', 'NO-USED', 'password@localhost:6379', 'NO-USED', 'NO-USED', '2', 'NO-USED', '8193', '16383', 'NO-USED', 'password@localhost:10000'])
+        env.assertEqual(conn.read_request(), ['RG.CLUSTERSETFROMSHARD', 'NO-USED', 'NO-USED', 'NO-USED', 'NO-USED', 'NO-USED', '0000000000000000000000000000000000000002', 'NO-USED', '2', 'NO-USED', '1', 'NO-USED', '0', '8192', 'NO-USED', 'password@localhost:6379', 'NO-USED', 'NO-USED', '2', 'NO-USED', '8193', '16383', 'NO-USED', 'password@localhost:10000'])
 
 
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -14,6 +14,8 @@
 #include "config.h"
 #include <libevent.h>
 
+#define CLUSTER_SET_MY_ID_INDEX 6
+
 // forward declaration
 static void RG_HelloResponseArrived(struct redisAsyncContext* c, void* a, void* b);
 
@@ -37,6 +39,7 @@ typedef struct Node{
     NodeStatus status;
     struct event *reconnectEvent;
     struct event *resendHelloMessage;
+    bool sendClusterTopologyOnNextConnect;
 }Node;
 
 Gears_dict* nodesMsgIds;
@@ -47,6 +50,8 @@ typedef struct Cluster{
     bool isClusterMode;
     Gears_dict* nodes;
     Node* slots[MAX_SLOT];
+    size_t clusterSetCommandSize;
+    char** clusterSetCommand;
 }Cluster;
 
 Gears_dict* RemoteCallbacks;
@@ -75,6 +80,7 @@ typedef struct ClusterSetMsg{
     RedisModuleBlockedClient* bc;
     RedisModuleString** argv;
     int argc;
+    bool force;
 }ClusterSetMsg;
 
 typedef struct Msg{
@@ -192,6 +198,7 @@ static Node* CreateNode(const char* id, const char* ip, unsigned short port, con
             .maxSlot = maxSlot,
             .isMe = false,
             .status = NodeStatus_Disconnected,
+            .sendClusterTopologyOnNextConnect = false,
     };
     n->reconnectEvent = event_new(main_base, -1, 0, Cluster_Reconnect, n);
     n->resendHelloMessage = event_new(main_base, -1, 0, Cluster_ResendHelloMessage, n);
@@ -217,6 +224,15 @@ static void Cluster_Free(){
         Gears_dictRelease(CurrCluster->nodes);
     }
 
+    if(CurrCluster->clusterSetCommand){
+        for(int i = 1 ; i < CurrCluster->clusterSetCommandSize ; ++i){
+            if(CurrCluster->clusterSetCommand){
+                RG_FREE(CurrCluster->clusterSetCommand[i]);
+            }
+        }
+        RG_FREE(CurrCluster->clusterSetCommand);
+    }
+
     RG_FREE(CurrCluster);
     CurrCluster = NULL;
 }
@@ -233,6 +249,12 @@ static void OnResponseArrived(struct redisAsyncContext* c, void* a, void* b){
         return;
     }
     Node* n = (Node*)b;
+    if(reply->type == REDIS_REPLY_ERROR && strncmp(reply->str, CLUSTER_ERROR, strlen(CLUSTER_ERROR)) == 0){
+        n->sendClusterTopologyOnNextConnect = true;
+        RedisModule_Log(NULL, "warning", "Received ERRCLUSTER reply from shard %s, will send cluster topology to the shard on next connect", n->id);
+        redisAsyncDisconnect(c);
+        return;
+    }
     if(reply->type != REDIS_REPLY_STATUS){
         RedisModule_Log(NULL, "warning", "Received an invalid status reply from shard %s, will disconnect and try to reconnect. This is usually because the Redis server's 'proto-max-bulk-len' configuration setting is too low.", n->id);
         redisAsyncDisconnect(c);
@@ -332,6 +354,12 @@ static void Cluster_ConnectCallback(const struct redisAsyncContext* c, int statu
         if(n->password){
             redisAsyncCommand((redisAsyncContext*)c, NULL, NULL, "AUTH %s", n->password);
         }
+        if(n->sendClusterTopologyOnNextConnect && CurrCluster->clusterSetCommand){
+            CurrCluster->clusterSetCommand[CLUSTER_SET_MY_ID_INDEX] = RG_STRDUP(n->id);
+            redisAsyncCommandArgv((redisAsyncContext*)c, NULL, NULL, CurrCluster->clusterSetCommandSize, (const char**)CurrCluster->clusterSetCommand, NULL);
+            RG_FREE(CurrCluster->clusterSetCommand[CLUSTER_SET_MY_ID_INDEX]);
+            CurrCluster->clusterSetCommand[CLUSTER_SET_MY_ID_INDEX] = NULL;
+        }
         redisAsyncCommand((redisAsyncContext*)c, RG_HelloResponseArrived, n, "RG.HELLO");
         n->status = NodeStatus_HelloSent;
     }
@@ -382,8 +410,22 @@ static void Cluster_Set(RedisModuleCtx* ctx, RedisModuleString** argv, int argc)
 
     CurrCluster = RG_ALLOC(sizeof(*CurrCluster));
 
+    CurrCluster->clusterSetCommand = RG_ALLOC(sizeof(char*) * argc);
+    CurrCluster->clusterSetCommandSize = argc;
+
+    CurrCluster->clusterSetCommand[0] = RG_STRDUP(RG_CLUSTER_SET_FROM_SHARD_COMMAND);
+
+    for(int i = 1 ; i < argc ; ++i){
+        if(i == CLUSTER_SET_MY_ID_INDEX){
+            // we do not save myid, will be set per shard.
+            continue;
+        }
+        const char* arg = RedisModule_StringPtrLen(argv[i], NULL);
+        CurrCluster->clusterSetCommand[i] = RG_STRDUP(arg);
+    }
+
     size_t myIdLen;
-    const char* myId = RedisModule_StringPtrLen(argv[6], &myIdLen);
+    const char* myId = RedisModule_StringPtrLen(argv[CLUSTER_SET_MY_ID_INDEX], &myIdLen);
     CurrCluster->myId = RG_ALLOC(REDISMODULE_NODE_ID_LEN + 1);
     size_t zerosPadding = REDISMODULE_NODE_ID_LEN - myIdLen;
     memset(CurrCluster->myId, '0', zerosPadding);
@@ -455,6 +497,9 @@ static void Cluster_Refresh(RedisModuleCtx* ctx){
     }
 
     CurrCluster = RG_ALLOC(sizeof(*CurrCluster));
+
+    CurrCluster->clusterSetCommand = NULL;
+    CurrCluster->clusterSetCommandSize = 0;
 
     if(!(RedisModule_GetContextFlags(ctx) & REDISMODULE_CTX_FLAGS_CLUSTER)){
         CurrCluster->isClusterMode = false;
@@ -599,7 +644,11 @@ static void Cluster_MsgArrive(evutil_socket_t s, short what, void *arg){
     case CLUSTER_SET_MSG:
         ctx = RedisModule_GetThreadSafeContext(msg->clusterSet.bc);
         LockHandler_Acquire(ctx);
-        Cluster_Set(ctx, msg->clusterSet.argv, msg->clusterSet.argc);
+        if(msg->clusterSet.force || !CurrCluster){
+            // we will update the cluster topology only if we are not aware
+            // to the cluster topology yet or we are forced to do it
+            Cluster_Set(ctx, msg->clusterSet.argv, msg->clusterSet.argc);
+        }
         RedisModule_ReplyWithSimpleString(ctx, "OK");
         RedisModule_UnblockClient(msg->clusterRefresh.bc, NULL);
         LockHandler_Release(ctx);
@@ -636,16 +685,17 @@ void Cluster_RegisterMsgReceiver(char* function, RedisModuleClusterMessageReceiv
 
 void Cluster_SendClusterRefresh(RedisModuleCtx *ctx){
     Msg* msgStruct = RG_ALLOC(sizeof(*msgStruct));
-    msgStruct->clusterRefresh.bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 2000000);
+    msgStruct->clusterRefresh.bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
     msgStruct->type = CLUSTER_REFRESH_MSG;
     write(notify[1], &msgStruct, sizeof(Msg*));
 }
 
-void Cluster_SendClusterSet(RedisModuleCtx *ctx, RedisModuleString** argv, int argc){
+void Cluster_SendClusterSet(RedisModuleCtx *ctx, RedisModuleString** argv, int argc, bool force){
     Msg* msgStruct = RG_ALLOC(sizeof(*msgStruct));
-    msgStruct->clusterSet.bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 2000000);
+    msgStruct->clusterSet.bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
     msgStruct->clusterSet.argv = argv;
     msgStruct->clusterSet.argc = argc;
+    msgStruct->clusterSet.force = force;
     msgStruct->type = CLUSTER_SET_MSG;
     write(notify[1], &msgStruct, sizeof(Msg*));
 }
@@ -664,6 +714,20 @@ void Cluster_SendMsg(const char* id, char* function, char* msg, size_t len){
     msgStruct->sendMsg.msgLen = len;
     msgStruct->type = SEND_MSG;
     write(notify[1], &msgStruct, sizeof(Msg*));
+}
+
+bool Cluster_IsInitialized(){
+    if(!IsEnterprise()){
+        // on open source, the user need to send cluster refresh.
+        // if no cluster refresh was sent we assume single shard database.
+        return true;
+    }
+    // on enterprise we will always get the cluster set command so until we get it
+    // we assume cluster is not initialized.
+    // when cluster is not initialized we will not allow almost all operations.
+    // the only operations we will allows are sync registrations that can not be
+    // postpond.
+    return CurrCluster? true : false;
 }
 
 bool Cluster_IsClusterMode(){
@@ -685,6 +749,12 @@ char* Cluster_GetMyId(){
 }
 
 const char* Cluster_GetMyHashTag(){
+    if(RedisModule_ShardingGetSlotRange){
+        int first, last;
+        RedisModule_ShardingGetSlotRange(&first, &last);
+        return slot_table[first];
+    }
+
     if(!Cluster_IsClusterMode()){
         return slot_table[0];
     }
@@ -779,6 +849,12 @@ int Cluster_OnMsgArrive(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     if(argc != 5){
         return RedisModule_WrongArity(ctx);
     }
+
+    if(!Cluster_IsInitialized()){
+        RedisModule_Log(ctx, "warning", "Got msg from another shard while cluster is not initialized");
+        return RedisModule_ReplyWithError(ctx, "ERRCLUSTER Uninitialized cluster state");
+    }
+
     RedisModuleString* senderId = argv[1];
     RedisModuleString* functionToCall = argv[2];
     RedisModuleString* msg = argv[3];
@@ -832,6 +908,15 @@ int Cluster_ClusterSet(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
         RedisModule_ReplyWithError(ctx, "Could not parse cluster set arguments");
         return REDISMODULE_OK;
     }
-    Cluster_SendClusterSet(ctx, argv, argc);
+    Cluster_SendClusterSet(ctx, argv, argc, true);
+    return REDISMODULE_OK;
+}
+
+int Cluster_ClusterSetFromShard(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
+    if(argc < 10){
+        RedisModule_ReplyWithError(ctx, "Could not parse cluster set arguments");
+        return REDISMODULE_OK;
+    }
+    Cluster_SendClusterSet(ctx, argv, argc, false);
     return REDISMODULE_OK;
 }

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -13,6 +13,9 @@
 
 #define MAX_SLOT 16384
 #define RG_INNER_MSG_COMMAND "RG.INNERMSGCOMMAND"
+#define RG_CLUSTER_SET_FROM_SHARD_COMMAND "RG.CLUSTERSETFROMSHARD"
+
+#define CLUSTER_ERROR "ERRCLUSTER"
 
 void Cluster_SendMsg(const char* id, char* function, char* msg, size_t len);
 #define Cluster_SendMsgM(id, function, msg, len) Cluster_SendMsg(id, #function, msg, len);
@@ -24,12 +27,14 @@ void Cluster_Init();
 char* Cluster_GetMyId();
 const char* Cluster_GetMyHashTag();
 bool Cluster_IsMyId(const char* id);
+bool Cluster_IsInitialized();
 const char* Cluster_GetNodeIdByKey(const char* key);
 int Cluster_GetClusterInfo(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int Cluster_RedisGearsHello(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int Cluster_OnMsgArrive(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int Cluster_RefreshCluster(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int Cluster_ClusterSet(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+int Cluster_ClusterSetFromShard(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 
 #endif /* SRC_CLUSTER_H_ */

--- a/src/commands.c
+++ b/src/commands.c
@@ -142,6 +142,8 @@ int Command_DropExecution(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
 		return RedisModule_WrongArity(ctx);
 	}
 
+	VERIFY_CLUSTER_INITIALIZE(ctx);
+
 	const char* id = RedisModule_StringPtrLen(argv[1], NULL);
 	ExecutionPlan* gearsCtx = RedisGears_GetExecution(id);
 
@@ -181,6 +183,8 @@ int Command_AbortExecution(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     if(argc != 2){
         return RedisModule_WrongArity(ctx);
     }
+
+    VERIFY_CLUSTER_INITIALIZE(ctx);
 
     RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
 

--- a/src/common.h
+++ b/src/common.h
@@ -10,6 +10,7 @@
 
 #include "utils/dict.h"
 #include "redismodule.h"
+#include "cluster.h"
 #include <stdio.h>
 #include <stdbool.h>
 
@@ -41,6 +42,8 @@ extern bool gearsIsCrdt;
 static inline int IsEnterprise() {
   return gearsRlecMajorVersion != -1;
 }
+
+#define VERIFY_CLUSTER_INITIALIZE(c) if(!Cluster_IsInitialized()) return RedisModule_ReplyWithError(c, CLUSTER_ERROR" Uninitialized cluster state")
 
 int GearsCheckSupportedVestion();
 void GearsGetRedisVersion();

--- a/src/execution_plan.c
+++ b/src/execution_plan.c
@@ -17,6 +17,7 @@
 #include "lock_handler.h"
 #include "utils/thpool.h"
 #include "version.h"
+#include "common.h"
 
 #define INIT_TIMER  struct timespec _ts = {0}, _te = {0}; \
                     bool timerInitialized = false;
@@ -3470,6 +3471,7 @@ int ExecutionPlan_InnerUnregisterExecution(RedisModuleCtx *ctx, RedisModuleStrin
 }
 
 int ExecutionPlan_UnregisterExecution(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
+    VERIFY_CLUSTER_INITIALIZE(ctx);
     return ExecutionPlan_UnregisterCommon(ctx, argv, argc, true);
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -1135,7 +1135,7 @@ int RedisGears_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     }
 
     if (RedisModule_CreateCommand(ctx, RG_CLUSTER_SET_FROM_SHARD_COMMAND, Cluster_ClusterSetFromShard, "readonly", 0, 0, -1) != REDISMODULE_OK) {
-        RedisModule_Log(ctx, "warning", "could not register command rg.clustersetfromshard");
+        RedisModule_Log(ctx, "warning", "could not register command "RG_CLUSTER_SET_FROM_SHARD_COMMAND);
         return REDISMODULE_ERR;
     }
 

--- a/src/module.c
+++ b/src/module.c
@@ -255,6 +255,10 @@ static ExecutionPlan* RG_Run(FlatExecutionPlan* fep, ExecutionMode mode, void* a
         *err = RG_STRDUP("Can only run execution when redis GIL is taken");
         return NULL;
     }
+    if(mode == ExecutionModeAsync && !Cluster_IsInitialized()){
+        *err = RG_STRDUP("Cluster is not initialized, can not start executions.");
+        return NULL;
+    }
     return FlatExecutionPlan_Run(fep, mode, arg, callback, privateData, worker, err);
 }
 
@@ -1127,6 +1131,11 @@ int RedisGears_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     if (RedisModule_CreateCommand(ctx, "rg.clusterset", Cluster_ClusterSet, "readonly", 0, 0, -1) != REDISMODULE_OK) {
         RedisModule_Log(ctx, "warning", "could not register command rg.refreshcluster");
+        return REDISMODULE_ERR;
+    }
+
+    if (RedisModule_CreateCommand(ctx, RG_CLUSTER_SET_FROM_SHARD_COMMAND, Cluster_ClusterSetFromShard, "readonly", 0, 0, -1) != REDISMODULE_OK) {
+        RedisModule_Log(ctx, "warning", "could not register command rg.clustersetfromshard");
         return REDISMODULE_ERR;
     }
 

--- a/src/readers/command_reader.c
+++ b/src/readers/command_reader.c
@@ -442,6 +442,10 @@ static int CommandReader_Trigger(RedisModuleCtx *ctx, RedisModuleString **argv, 
         return REDISMODULE_OK;
     }
 
+    if(crtCtx->mode == ExecutionModeAsync){
+        VERIFY_CLUSTER_INITIALIZE(ctx);
+    }
+
     char* err = NULL;
     CommandReaderArgs* args = CommandReaderArgs_Create(argv + 1, argc - 1);
     ExecutionPlan* ep = RedisGears_Run(crtCtx->fep, crtCtx->mode, args, CommandReader_OnDone,

--- a/src/redisgears_python.c
+++ b/src/redisgears_python.c
@@ -3381,6 +3381,8 @@ int RedisGearsPy_Execute(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
         return RedisModule_WrongArity(ctx);
     }
 
+    VERIFY_CLUSTER_INITIALIZE(ctx);
+
     const char* script = RedisModule_StringPtrLen(argv[1], NULL);
     bool isBlocking = true;
     size_t requirementsArg = 3;
@@ -4399,6 +4401,8 @@ static int RedisGearsPy_DumpRequirements(RedisModuleCtx *ctx, RedisModuleString 
 }
 
 static int RedisGearsPy_ImportRequirement(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
+    VERIFY_CLUSTER_INITIALIZE(ctx);
+
     Gears_Buffer* buff = Gears_BufferCreate();
 
     for(size_t i = 1 ; i < argc ; i++){


### PR DESCRIPTION
1. The following is not allow if cluster is not yet initalized:
   * RG.PYEXECUTE
   * RG.DROPEXECUTION
   * RG.ABORTEXECUTION
   * RG.UNREGISTER
2. Import python requirement will not be allowed if cluster is not yet initalized.
3. RG.TRIGGER that triggered distributed execution will return error if cluster
   is not yet initalized.
4. Key space notification that trigger a distributed execution will failed.
5. A shard that did not yet recieve the cluster topology will send 'ERRCLUSTER'
   error, a shard that gets this error will send the cluster topology to the
   other shard so the cluster will get back to functional state faster
   and we will be able to continue running executions.
6. hashtag() function will use RedisModule_ShardingGetSlotRange RedisModule API
   (if available) to not be depends on ClusterSet command they might arrive later.