### PR TITLE
TensorGetValue APIs fix - for 1.0

### DIFF
--- a/src/redisgears_python.c
+++ b/src/redisgears_python.c
@@ -1832,9 +1832,9 @@ static PyObject *PyTensor_ToFlatList(PyTensor * pyt){
         PyObject *pyVal = NULL;
         double doubleVal;
         long long longVal;
-        if(RedisAI_TensorGetValueAsDouble(pyt->t, j, &doubleVal)){
+        if(RedisAI_TensorGetValueAsDouble(pyt->t, j, &doubleVal) == REDISMODULE_OK){
             pyVal = PyFloat_FromDouble(doubleVal);
-        }else if(RedisAI_TensorGetValueAsLongLong(pyt->t, j, &longVal)){
+        }else if(RedisAI_TensorGetValueAsLongLong(pyt->t, j, &longVal) == REDISMODULE_OK){
             pyVal = PyLong_FromLongLong(longVal);
         }else{
             PyErr_SetString(GearsError, "Failed converting tensor to flat list");


### PR DESCRIPTION
Following a change in RedisAI_TensorGetValueAsDouble/LongLong in RedisAI - fix the use in these APIs in PyTensor_ToFlatList: if it returns 0(=REDISMODULE_OK) it succeeded, and otherwise it failed (unlike before when it was the other way around)