### PR TITLE
Removing pre-defined compiler settings (gcc)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,6 @@ include build/hiredis/Makefile.defs
 
 #----------------------------------------------------------------------------------------------
 
-CC=gcc
 SRCDIR=src
 
 define _SOURCES:=


### PR DESCRIPTION
Using gcc (as in: the default version which is 10) on Hirsute breaks the build due to linker errors when compiling the final module. The RC for this a compiler standard for symbol visibility, using gcc-9 (make CC=gcc-9) is a work-around. Regression on hirsute with this work-around checks out.