### PR TITLE
Used python decorator to perform cleanups after tests

### DIFF
--- a/plugins/python/redisgears_python.c
+++ b/plugins/python/redisgears_python.c
@@ -579,8 +579,8 @@ static int PythonRequirementCtx_Serialize(PythonRequirementCtx* req, Gears_Buffe
 
         FILE *f = fopen(filePath, "rb");
         if(!f){
-            RG_FREE(filePath);
             RedisGears_ASprintf(err, "Could not open file %s", filePath);
+            RG_FREE(filePath);
             RedisModule_Log(staticCtx, "warning", "%s", *err);
             return REDISMODULE_ERR;
         }
@@ -591,9 +591,9 @@ static int PythonRequirementCtx_Serialize(PythonRequirementCtx* req, Gears_Buffe
         char *data = RG_ALLOC(fsize);
         size_t readData = fread(data, 1, fsize, f);
         if(readData != fsize){
+            RedisGears_ASprintf(err, "Could read data from file %s", filePath);
             RG_FREE(data);
             RG_FREE(filePath);
-            RedisGears_ASprintf(err, "Could read data from file %s", filePath);
             RedisModule_Log(staticCtx, "warning", "%s", *err);
             return REDISMODULE_ERR;
         }

--- a/pytest/common.py
+++ b/pytest/common.py
@@ -1,6 +1,41 @@
 import signal
 from includes import *
 from threading import Thread
+from RLTest import Env
+import inspect
+
+class Colors(object):
+    @staticmethod
+    def Cyan(data):
+        return '\033[36m' + data + '\033[0m'
+
+    @staticmethod
+    def Yellow(data):
+        return '\033[33m' + data + '\033[0m'
+
+    @staticmethod
+    def Bold(data):
+        return '\033[1m' + data + '\033[0m'
+
+    @staticmethod
+    def Bred(data):
+        return '\033[31;1m' + data + '\033[0m'
+
+    @staticmethod
+    def Gray(data):
+        return '\033[30;1m' + data + '\033[0m'
+
+    @staticmethod
+    def Lgray(data):
+        return '\033[30;47m' + data + '\033[0m'
+
+    @staticmethod
+    def Blue(data):
+        return '\033[34m' + data + '\033[0m'
+
+    @staticmethod
+    def Green(data):
+        return '\033[32m' + data + '\033[0m'
 
 class Background(object):
     """
@@ -62,3 +97,63 @@ GB('ShardsIDReader').map(lambda x: len(execute('RG.DUMPREGISTRATIONS'))).collect
             env.assertTrue(False, message='Registrations Integrity failed, %s' % str(e))
 
         env.assertTrue(env.isUp())
+
+def dropRegistrationsAndExecutions(env):
+    try:
+        with TimeLimit(20):
+            while True:
+
+                try:
+                    executions = env.cmd('RG.DUMPEXECUTIONS')
+                    for e in executions:
+                        env.cmd('RG.DROPEXECUTION', e[1])
+
+                    registrations = env.cmd('RG.DUMPREGISTRATIONS')
+                    for r in registrations:
+                        env.expect('RG.UNREGISTER', r[1]).equal('OK')
+                except Exception as e:
+                    print(Colors.Gray(str(e)))
+                    time.sleep(0.5)
+                    continue
+
+                script1 = '''
+GB('ShardsIDReader').map(lambda x: len(execute('RG.DUMPREGISTRATIONS'))).filter(lambda x: x > 0).run()
+'''
+                script2 = '''
+GB('ShardsIDReader').map(lambda x: len(execute('RG.DUMPEXECUTIONS'))).filter(lambda x: x > 0).run()
+'''
+                res1 = env.cmd('RG.PYEXECUTE', script1)
+                res2 = env.cmd('RG.PYEXECUTE', script2)
+
+                if len(res1[0]) == 0 and len(res2[0]):
+                    break
+                time.sleep(0.5)
+    except Exception as e:
+        print(Colors.Bred(str(e)))
+        env.assertTrue(False, message='Registrations/Executions dropping failed')
+
+def restoreDefaultConfig(env):
+    env.broadcast('RG.CONFIGSET', 'MaxExecutions', '1000')
+    env.broadcast('RG.CONFIGSET', 'MaxExecutionsPerRegistration', '100')
+    env.broadcast('RG.CONFIGSET', 'MaxExecutionsPerRegistration', '100')
+    env.broadcast('RG.CONFIGSET', 'ProfileExecutions', '0')
+    env.broadcast('RG.CONFIGSET', 'PythonAttemptTraceback', '1')
+    env.broadcast('RG.CONFIGSET', 'ExecutionMaxIdleTime', '5000')
+    env.broadcast('RG.CONFIGSET', 'PythonInstallReqMaxIdleTime', '30000')
+    env.broadcast('RG.CONFIGSET', 'SendMsgRetries', '3')
+
+def gearsTest(skipTest=False, envArgs={}):
+    def test_func_generator(test_function):
+        def test_func():
+            test_name = '%s %s' % (inspect.getfile(test_function), test_function.__name__)
+            print(Colors.Cyan('\tRunning: %s' % test_name))
+            if skipTest:
+                print('\tskipping test : %s' % test_name)
+                return
+            env = Env(testName = test_function.__name__, **envArgs)
+            getConnectionByEnv(env)
+            test_function(env)
+            dropRegistrationsAndExecutions(env)
+            restoreDefaultConfig(env)
+        return test_func
+    return test_func_generator

--- a/pytest/common.py
+++ b/pytest/common.py
@@ -166,9 +166,7 @@ def gearsTest(skipTest=False,
             env = Env(testName = test_function.__name__, **envArgs)
             getConnectionByEnv(env)
             test_function(env)
-            if Env.RTestInstance is not None and not skipCleanups:
-                # We do the cleanup only if we might reuse the env
-                # and skipCleanups is not true
+            if not skipCleanups:
                 dropRegistrationsAndExecutions(env)
                 restoreDefaultConfig(env)
         return test_func

--- a/pytest/common.py
+++ b/pytest/common.py
@@ -166,7 +166,9 @@ def gearsTest(skipTest=False,
             env = Env(testName = test_function.__name__, **envArgs)
             getConnectionByEnv(env)
             test_function(env)
-            if not skipCleanups:
+            if Env.RTestInstance is not None and not skipCleanups:
+                # We do the cleanup only if we might reuse the env
+                # and skipCleanups is not true
                 dropRegistrationsAndExecutions(env)
                 restoreDefaultConfig(env)
         return test_func

--- a/pytest/includes.py
+++ b/pytest/includes.py
@@ -12,8 +12,8 @@ except:
 
 def getConnectionByEnv(env):
     conn = None
+    env.broadcast('rg.refreshcluster')
     if env.env == 'oss-cluster' and env.shardsCount > 1:
-        env.broadcast('rg.refreshcluster')
         conn = env.envRunner.getClusterConnection()
         for s in range(1, env.shardsCount + 1):
             while True:

--- a/pytest/test_async.py
+++ b/pytest/test_async.py
@@ -3,9 +3,11 @@ from common import getConnectionByEnv
 from common import TimeLimit
 from common import verifyRegistrationIntegrity
 from common import Background
+from common import gearsTest
 import time
 from includes import *
 
+@gearsTest()
 def testSimpleAsync(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -57,6 +59,7 @@ GB().foreach(ForEach).register(mode='async_local')
     except Exception as e:  
         env.assertTrue(False, message='Failed waiting for WaitForKeyChange to reach unblock')
 
+@gearsTest()
 def testSimpleAsyncWithNoneAsyncResult(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -181,6 +184,7 @@ GB().foreach(ForEachFailed).register('y', mode='async_local')
         except Exception as e:  
             env.assertTrue(False, message='Failed waiting for WaitForKeyChange to reach unblock')
 
+@gearsTest()
 def testCreateAsyncRecordMoreThenOnceRaiseError(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -234,6 +238,7 @@ GB().foreach(ForEach).register(mode='async_local')
     except Exception as e:
         env.assertTrue(False, message='Failed waiting for WaitForKeyChange to reach unblock')
 
+@gearsTest()
 def testCreateAsyncWithoutFree(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -249,6 +254,7 @@ GB('CommandReader').map(WaitForKeyChangeReturnSame).register(trigger='WaitForKey
 
     env.expect('RG.TRIGGER', 'WaitForKeyChangeMap').error().contains('Async record did not called continue')
 
+@gearsTest()
 def testSetFutureResultsBeforeReturnIt(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -265,6 +271,7 @@ GB('CommandReader').map(test).register(trigger='test', mode='async_local')
 
     env.expect('RG.TRIGGER', 'test').error().contains('Can not handle future untill it returned from the callback')
 
+@gearsTest()
 def testSetFutureErrorOnAggregateByResultsBeforeReturnIt(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -320,6 +327,7 @@ GB().foreach(ForEachFailed).register('y', mode='async_local')
     except Exception as e:  
         env.assertTrue(False, message='Failed waiting for WaitForKeyChange to reach unblock')
 
+@gearsTest()
 def testSimpleAsyncOnSyncExecution(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -375,6 +383,7 @@ GB('CommandReader').map(unbc).register(trigger='unblock', mode='async_local')
     except Exception as e:
         env.assertTrue(False, message='Failed waiting to reach unblock')
 
+@gearsTest()
 def testStreamReaderAsync(env):
     env.skipOnCluster()
     conn = getConnectionByEnv(env)
@@ -443,6 +452,7 @@ GB('StreamReader').map(bc).foreach(lambda x: execute('set', x['value']['key'], x
     except Exception as e:
         env.assertTrue(False, message='Failed waiting to reach unblock')
 
+@gearsTest()
 def testKeysReaderAsync(env):
     env.skipOnCluster()
     conn = getConnectionByEnv(env)
@@ -515,6 +525,7 @@ GB().map(bc).foreach(lambda x: execute('del', x)).register(mode='async_local', r
     for r in registrations:
          env.expect('RG.UNREGISTER', r[1]).equal('OK')
 
+@gearsTest()
 def testAsyncWithRepartition(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -569,7 +580,7 @@ GB('CommandReader').map(unbc).register(trigger='unblock')
         print(e)
         env.assertTrue(False, message='Failed waiting to reach unblock')
 
-
+@gearsTest()
 def testAsyncWithRepartition2(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -627,6 +638,7 @@ GB('CommandReader').map(unbc).register(trigger='unblock')
     except Exception as e:
         env.assertTrue(False, message='Failed waiting to reach unblock')
 
+@gearsTest()
 def testSimpleAsyncOnFilter(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -687,6 +699,7 @@ GB('CommandReader').map(unbc).register(trigger='unblock')
     except Exception as e:
         env.assertTrue(False, message='Failed waiting to reach unblock')
 
+@gearsTest()
 def testSimpleAsyncOnFlatMap(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -740,6 +753,7 @@ GB('CommandReader').map(unbc).register(trigger='unblock')
         print(e)
         env.assertTrue(False, message='Failed waiting to reach unblock')
 
+@gearsTest()
 def testSimpleAsyncOnForeach(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -793,6 +807,7 @@ GB('CommandReader').map(unbc).register(trigger='unblock')
         print(e)
         env.assertTrue(False, message='Failed waiting to reach unblock')
 
+@gearsTest()
 def testSimpleAsyncOnAggregate(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -846,6 +861,7 @@ GB('CommandReader').map(unbc).register(trigger='unblock')
         print(e)
         env.assertTrue(False, message='Failed waiting to reach unblock')
 
+@gearsTest()
 def testSimpleAsyncOnAggregateBy(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -910,6 +926,7 @@ GB('CommandReader').map(unbc).register(trigger='unblock')
         print(e)
         env.assertTrue(False, message='Failed waiting to reach unblock')
 
+@gearsTest()
 def testAsyncError(env):
     conn = getConnectionByEnv(env)
 
@@ -920,6 +937,7 @@ def testAsyncError(env):
     res = env.cmd('RG.PYEXECUTE', "GB('ShardsIDReader').batchgroupby(lambda x: x, lambda k, l: gearsFuture()).run()")[1][0]
     env.assertContains('Step does not support async', res)
 
+@gearsTest()
 def testAsyncAwait(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -934,6 +952,7 @@ GB('ShardsIDReader').map(c).flatmap(c).foreach(c).filter(c).count().run()
 
     env.expect('RG.PYEXECUTE', script).equal([[str(env.shardsCount)], []])
 
+@gearsTest()
 def testAsyncAwaitOnUnallowRepartitionStep(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -949,6 +968,7 @@ GB('ShardsIDReader').map(c).flatmap(c).foreach(c).filter(c).repartition(c).run()
     res = env.cmd('RG.PYEXECUTE', script)[1][0]
     env.assertContains('coroutine are not allow on', res)
 
+@gearsTest()
 def testAsyncAwaitOnUnallowReduceStep(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -968,6 +988,7 @@ GB('ShardsIDReader').map(c).flatmap(c).foreach(c).filter(c).batchgroupby(lambda 
     res = env.cmd('RG.PYEXECUTE', script)[1][0]
     env.assertContains('coroutine are not allow on', res)
 
+@gearsTest()
 def testAsyncAwaitThatRaiseException(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -984,7 +1005,9 @@ GB('ShardsIDReader').map(c).run()
     res = env.cmd('RG.PYEXECUTE', script)[1][0]
     env.assertContains('failed', res)
 
+@gearsTest()
 def testUnregisterDuringAsyncExectuion(env):
+    env.skipOnCluster()
     script = '''
 import asyncio
 
@@ -999,10 +1022,12 @@ GB("CommandReader").map(doTest).register(trigger='test')
     '''
 
     env.cmd('rg.pyexecute', script)
+    verifyRegistrationIntegrity(env)
     env.expect('rg.trigger', 'test').equal(["['test']"])
 
     env.expect('RG.DUMPREGISTRATIONS').equal([])
 
+@gearsTest()
 def testAbortDuringAsyncExectuion(env):
     script = '''
 import asyncio
@@ -1024,6 +1049,7 @@ GB("ShardsIDReader").map(doTest).run()
     # let wait for the coro to continue, make sure there is no issues.
     time.sleep(2)
 
+@gearsTest()
 def testAsyncExecutionOnMulti(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -1042,7 +1068,7 @@ GB('CommandReader').map(c).register(trigger='test')
     res = env.cmd('EXEC')
     env.assertIn('can not run a none sync execution inside MULTI/LUA', str(res[0]))
     
-
+@gearsTest()
 def testAsyncWithoutWait(env):
     conn = getConnectionByEnv(env)
     script = '''

--- a/pytest/test_basics.py
+++ b/pytest/test_basics.py
@@ -3,6 +3,7 @@ import os
 from RLTest import Env
 import yaml
 import time
+from common import gearsTest
 from common import TimeLimit, verifyRegistrationIntegrity
 from includes import *
 
@@ -106,20 +107,21 @@ class testBasic:
         self.env.assertEqual(sum([a for a in range(100)]), int(res[0]))
         self.env.cmd('rg.dropexecution', id)
 
+@gearsTest()
 def testBytes(env):
     conn = getConnectionByEnv(env)
     conn.set("x", 1)
     conn.execute_command('rg.pyexecute', 'GB().repartition(lambda x: "y").foreach(lambda x: execute("set", "y", bytes([1,2,3]))).run("x")')
     env.assertTrue(conn.exists("y"))
 
-
+@gearsTest()
 def testBytearray(env):
     conn = getConnectionByEnv(env)
     conn.set("x", 1)
     conn.execute_command('rg.pyexecute', 'GB().repartition(lambda x: "y").foreach(lambda x: execute("set", "y", bytearray([1,2,3]))).run("x")')
     env.assertTrue(conn.exists("y"))
 
-
+@gearsTest()
 def testKeysOnlyReader(env):
     conn = getConnectionByEnv(env)
 
@@ -154,7 +156,7 @@ def testKeysOnlyReader(env):
     res = env.cmd('rg.pyexecute', 'GB("KeysOnlyReader").run("xx")')[0]
     env.assertEqual(set(res), set(['xx']))
 
-
+@gearsTest()
 def testFlatMap(env):
     conn = getConnectionByEnv(env)
     conn.execute_command('lpush', 'l', '1', '2', '3')
@@ -165,7 +167,7 @@ def testFlatMap(env):
     env.assertEqual(set(res[0]), set(['1', '2', '3']))
     env.cmd('rg.dropexecution', id)
 
-
+@gearsTest()
 def testLimit(env):
     conn = getConnectionByEnv(env)
     conn.execute_command('lpush', 'l', '1', '2', '3')
@@ -176,7 +178,7 @@ def testLimit(env):
     env.assertEqual(len(res[0]), 1)
     env.cmd('rg.dropexecution', id)
 
-
+@gearsTest()
 def testLimitWithOffset(env):
     conn = getConnectionByEnv(env)
     conn.execute_command('lpush', 'l', '1', '2', '3', '4', '5')
@@ -187,7 +189,7 @@ def testLimitWithOffset(env):
     env.assertEqual(res[0], ['4'])
     env.cmd('rg.dropexecution', id)
 
-
+@gearsTest()
 def testRepartitionAndWriteOption(env):
     conn = getConnectionByEnv(env)
     conn.execute_command('set', 'x', '1')
@@ -209,7 +211,7 @@ def testRepartitionAndWriteOption(env):
     env.assertEqual(conn.execute_command('get', '3'), 'z')
     env.cmd('rg.dropexecution', id)
 
-
+@gearsTest()
 def testBasicWithRun(env):
     conn = getConnectionByEnv(env)
     conn.execute_command('xadd', 'stream', '*', 'test', '1')
@@ -219,7 +221,9 @@ def testBasicWithRun(env):
     res = eval(res[0][0])
     env.assertEqual(res['value']['test'], '1')
 
+@gearsTest()
 def testTimeEvent(env):
+    env.skipOnCluster()
     conn = getConnectionByEnv(env)
     conn.set('x', '1')
     conn.set('y', '1')
@@ -229,9 +233,9 @@ def func(x):
     var = int(redisgears.executeCommand('get',x['key'])) + 1
     redisgears.executeCommand('set',x['key'], var)
 def OnTime():
-    GearsBuilder().foreach(func).collect().run()
+    GearsBuilder().filter(lambda x: x['key'] != 'key1').foreach(func).collect().run()
 def start():
-    redisgears.registerTimeEvent(2, OnTime)
+    redisgears.registerTimeEvent(2, OnTime, 'key1')
 start()
     '''
     env.cmd('rg.pyexecute', script)
@@ -243,7 +247,7 @@ start()
     env.assertTrue(int(conn.get('y')) >= 2)
     env.assertTrue(int(conn.get('z')) >= 2)
 
-
+@gearsTest()
 def testTimeEventSurrviveRestart(env):
     env.skipOnCluster()
     env.execute_command('set', 'x', '1')
@@ -270,7 +274,7 @@ redisgears.registerTimeEvent(1, func, 'timeEvent')
     res2 = env.cmd('get', 'x')
     env.assertTrue(int(res2) >= int(res1))
 
-
+@gearsTest()
 def testExecuteCommandWithNullTerminated(env):
     env.skipOnCluster()
     env.expect('set', 'x', 'test\x00test').equal(True)
@@ -278,16 +282,16 @@ def testExecuteCommandWithNullTerminated(env):
     env.cmd('RG.PYEXECUTE', "GearsBuilder().foreach(lambda x: redisgears.executeCommand('SET', 'bar', str(x['value']))).map(lambda x: str(x)).run()")
     env.expect('get', 'bar').equal('test\x00test')
 
-
+@gearsTest()
 def testKeyWithUnparsedValue(env):
     conn = getConnectionByEnv(env)
     conn.execute_command('sadd', 'x', '1', '2', '3')
     env.expect('RG.PYEXECUTE', "GB().map(lambda x: execute('smembers', x['key'])).flatmap(lambda x:x).sort().run()").contains(['1', '2', '3'])
 
-def testMaxExecutions():
+@gearsTest(envArgs={'moduleArgs': 'MaxExecutions 3'})
+def testMaxExecutions(env):
     ## todo: currently there is a problem with MaxExecutions which might cause running executions to be drop and the redis server
     ##       to crash, this is why I increased the sleep interval, we should fix it ASAP.
-    env = Env(moduleArgs="MaxExecutions 3")
     conn = getConnectionByEnv(env)
     conn.execute_command('RG.PYEXECUTE', "GearsBuilder().map(lambda x: str(x)).register('*')", 'UNBLOCKING')
     time.sleep(1)
@@ -310,6 +314,7 @@ def testMaxExecutions():
     for r in registrations:
          env.expect('RG.UNREGISTER', r[1]).equal('OK')
 
+@gearsTest()
 def testOneKeyScan(env):
     env.skipOnCluster()
     conn = getConnectionByEnv(env)
@@ -322,6 +327,7 @@ def testOneKeyScan(env):
     env.expect('rg.pyexecute', "GB().count().run('pref*')").contains(['2000'])
     env.expect('rg.pyexecute', "GB().count().run('x*')").contains(['1'])
 
+@gearsTest()
 def testGlobalsSharedBetweenFunctions(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -342,6 +348,7 @@ GB('ShardsIDReader').map(func1).map(func2).collect().distinct().run()
     env.expect('rg.pyexecute', script).equal([['2'], []])
     env.expect('rg.pyexecute', script).equal([['2'], []])
 
+@gearsTest()
 def testSubinterpreterIsolation(env):
     env.skipOnCluster()
     env.cmd('set', 'x', '1')
@@ -359,8 +366,8 @@ GB().map(returnX).run()
     env.expect('rg.pyexecute', script).equal([['2'], []])
     env.expect('rg.pyexecute', script).equal([['2'], []])
 
-def testAbortExecution():
-    env = Env(moduleArgs='executionThreads 1')
+@gearsTest(envArgs={'moduleArgs': 'executionThreads 1'})
+def testAbortExecution(env):
     env.skipOnCluster()
     infinitScript = '''
 def InfinitLoop(r):
@@ -398,6 +405,7 @@ GB().map(InfinitLoop).run()
     env.expect('rg.dropexecution', executionId1).ok()
     env.expect('rg.dropexecution', executionId2).ok()
 
+@gearsTest()
 def testTimeEventSubinterpreterIsolation(env):
     env.skipOnCluster()
     script1 = '''
@@ -408,7 +416,7 @@ def OnTime():
     x += 1
     execute('set', 'x', str(x))
 def start():
-    redisgears.registerTimeEvent(2, OnTime)
+    redisgears.registerTimeEvent(2, OnTime, 'key1')
 start()
     '''
     script2 = '''
@@ -419,7 +427,7 @@ def OnTime():
     x += 1
     execute('set', 'y', str(x))
 def start():
-    redisgears.registerTimeEvent(2, OnTime)
+    redisgears.registerTimeEvent(2, OnTime, 'key2')
 start()
     '''
     env.cmd('rg.pyexecute', script1)
@@ -532,15 +540,15 @@ class testGetExecution:
         self.env.assertLessEqual(1, len(res))
         self.env.cmd('RG.DROPEXECUTION', id)
 
-def testConfigGet():
-    env = Env(moduleArgs='TestConfig TestVal')
+@gearsTest(envArgs={'moduleArgs': 'TestConfig TestVal'})
+def testConfigGet(env):
     env.skipOnCluster()
     env.expect('RG.PYEXECUTE', "GB('ShardsIDReader')."
                                "map(lambda x: (GearsConfigGet('TestConfig'), GearsConfigGet('NotExists', 'default')))."
                                "collect().distinct().run()").equal([["('TestVal', 'default')"],[]])
 
-def testRecordSerializationFailure():
-    env = Env(moduleArgs='CreateVenv 1')
+@gearsTest(envArgs={'moduleArgs': 'CreateVenv 1'})
+def testRecordSerializationFailure(env):
     if env.shardsCount < 2:  # TODO: RedisGears_IsClusterMode reports false for clusters with 1 shard
         env.skip()
     conn = getConnectionByEnv(env)
@@ -549,6 +557,7 @@ def testRecordSerializationFailure():
                   "collect().distinct().run()", 'REQUIREMENTS', 'redisgraph')
     env.assertEqual(len(res[1]), env.shardsCount - 1) # the initiator will not raise error
 
+@gearsTest()
 def testAtomic(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -560,6 +569,7 @@ GB('ShardsIDReader').foreach(test).flatmap(lambda r: execute('mget', 'x{%s}' % h
     '''
     env.expect('RG.PYEXECUTE', script).equal([['1', '2'],[]])
 
+@gearsTest()
 def testParallelExecutions(env):
     conn = getConnectionByEnv(env)
     infinitScript = '''
@@ -576,6 +586,7 @@ GB('ShardsIDReader').foreach(InifinitLoop).run()
     env.expect('RG.ABORTEXECUTION', executionId).ok()
     env.expect('RG.DROPEXECUTION', executionId).ok()
 
+@gearsTest()
 def testMaxIdle(env):
     if env.shardsCount == 1:
         env.skip()
@@ -598,6 +609,7 @@ GB('ShardsIDReader').map(Loop).run()
 '''
     env.expect('RG.PYEXECUTE', longExecution).equal([['1'], ['Execution max idle reached']])
 
+@gearsTest()
 def testStreamReaderFromId(env):
     conn = getConnectionByEnv(env)
 
@@ -616,6 +628,7 @@ def testStreamReaderFromId(env):
 
     env.assertEqual([r['value'] for r in res], [{'foo2': 'bar2', 'foo3': 'bar3'}])
 
+@gearsTest()
 def testKeysReaderKeyType(env):
     conn = getConnectionByEnv(env)
     conn.execute_command('set', 'r', '1')
@@ -626,10 +639,12 @@ def testKeysReaderKeyType(env):
 
     env.expect('RG.PYEXECUTE', 'GB().map(lambda x: x["type"]).sort().run()').equal([['hash', 'list', 'set', 'string', 'zset'],[]])
 
+@gearsTest()
 def testKeysReaderNoScan(env):
     conn = getConnectionByEnv(env)
     env.expect('RG.PYEXECUTE', "GB().map(lambda x: x['type']).distinct().run('test', noScan=True)").equal([['empty'],[]])
 
+@gearsTest()
 def testKeysReaderDontReadValue(env):
     conn = getConnectionByEnv(env)
     conn.execute_command('set', 'x', '1')
@@ -637,6 +652,7 @@ def testKeysReaderDontReadValue(env):
     res = [eval(r) for r in res[0]]
     env.assertEqual(res, [{'key':'x', 'event': None}])
 
+@gearsTest()
 def testKeysOnlyReader(env):
     conn = getConnectionByEnv(env)
     conn.execute_command('set', 'x', '1')
@@ -644,6 +660,7 @@ def testKeysOnlyReader(env):
     conn.execute_command('set', 'y', '1')
     env.expect('RG.PYEXECUTE', "GB('KeysOnlyReader').sort().run()").equal([['x', 'y', 'z'],[]])
 
+@gearsTest()
 def testKeysOnlyReaderWithPattern(env):
     conn = getConnectionByEnv(env)
     conn.execute_command('set', 'x', '1')
@@ -651,6 +668,7 @@ def testKeysOnlyReaderWithPattern(env):
     conn.execute_command('set', 'y', '1')
     env.expect('RG.PYEXECUTE', "GB('KeysOnlyReader').sort().run('x')").equal([['x'],[]])
 
+@gearsTest()
 def testKeysOnlyReaderWithCount(env):
     conn = getConnectionByEnv(env)
     conn.execute_command('set', 'x', '1')
@@ -658,6 +676,7 @@ def testKeysOnlyReaderWithCount(env):
     conn.execute_command('set', 'y', '1')
     env.expect('RG.PYEXECUTE', "GB('KeysOnlyReader').sort().run(count=1)").equal([['x', 'y', 'z'],[]])
 
+@gearsTest()
 def testKeysOnlyReaderWithNoScan(env):
     conn = getConnectionByEnv(env)
     conn.execute_command('set', 'x', '1')
@@ -665,6 +684,7 @@ def testKeysOnlyReaderWithNoScan(env):
     conn.execute_command('set', 'x2', '1')
     env.expect('RG.PYEXECUTE', "GB('KeysOnlyReader').run('x', noScan=True)").equal([['x'],[]])
 
+@gearsTest()
 def testKeysOnlyReaderWithPatternGenerator(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -675,6 +695,7 @@ GB('KeysOnlyReader').count().run(patternGenerator=Generator)
     env.cmd('RG.PYEXECUTE', "GB('ShardsIDReader').foreach(lambda x: execute('set', 'x{%s}' % hashtag(), '1')).run()")
     env.expect('RG.PYEXECUTE', script).equal([[str(env.shardsCount)],[]])
 
+@gearsTest()
 def testWithMultiExec(env):
     env.skipOnCluster()
     conn = getConnectionByEnv(env)
@@ -686,6 +707,7 @@ def testWithMultiExec(env):
     except Exception:
         env.assertTrue(True, message='Got error when running gear in multi exec')
 
+@gearsTest()
 def testAggregateWithSameZeroValue(env):
     conn = getConnectionByEnv(env)
     conn.execute_command('set', 'x', '1')
@@ -707,7 +729,7 @@ GB().map(lambda x: int(x['value'])).aggregate({'sum':0, 'mul':1}, SumMulLocal, S
     '''
     res = env.expect('RG.PYEXECUTE', script).equal([["('mul', 6)", "('sum', 6)"], []])
 
-
+@gearsTest()
 def testAggregateByWithSameZeroValue(env):
     conn = getConnectionByEnv(env)
     conn.execute_command('set', 'x1', '1')
@@ -732,6 +754,7 @@ GB().aggregateby(lambda r: r['key'][0], {'sum':0, 'mul':1}, SumMulLocal, SumMulG
     '''
     env.expect('RG.PYEXECUTE', script).equal([["{'key': 'x', 'value': {'sum': 6, 'mul': 6}}", "{'key': 'y', 'value': {'sum': 6, 'mul': 6}}"], []])
 
+@gearsTest()
 def testClusterRefreshOnOnlySingleNode(env):
     if env.shardsCount <= 1:
         env.skip()
@@ -745,6 +768,7 @@ def testClusterRefreshOnOnlySingleNode(env):
     except Exception as e:  
         env.assertTrue(False, message='Failed waiting for execution to finish')
 
+@gearsTest()
 def testAccumulateNotCrashingOnEPReuse(env):
     if env.shardsCount <= 1:
         env.skip()
@@ -768,11 +792,12 @@ GB('CommandReader').flatmap(ReverseList).foreach(WaitIfNeeded).count().register(
     env.expect('RG.TRIGGER', 'test', 'error').equal('Execution max idle reached')
     env.expect('RG.TRIGGER', 'test', 'noerror').equal('Execution max idle reached')
 
+@gearsTest()
 def testConfigGetSet(env):
     env.expect('RG.CONFIGSET', 'test', 'test').contains('OK - value was saved in extra config dictionary')
     env.expect('RG.CONFIGGET', 'test').equal(['test'])
 
-
+@gearsTest()
 def testInfo(env):
     env.skipOnCluster()
     env.expect('RG.PYEXECUTE', "GB('CommandReader').foreach(lambda x: __import__('time').sleep(2)).register(trigger='test')", 'REQUIREMENTS', 'redis').equal('OK')
@@ -786,6 +811,7 @@ def testInfo(env):
     env.assertTrue(res.has_key('rg_nexecutions'))
     env.assertTrue(res.has_key('rg_nregistrations'))
 
+@gearsTest()
 def testSlowlogReportOnRun(env):
     info = env.cmd('info')
     redis_version = info['redis_version'].split('.')
@@ -801,6 +827,7 @@ def testSlowlogReportOnRun(env):
     env.assertGreaterEqual(len(res), 1)
     env.assertEqual(res[0][3], ['RG.PYEXECUTE', 'GB("ShardsIDReader").foreach(lambda x: __import__("time").sleep(1)).run()'])
 
+@gearsTest()
 def testSlowlogReportOnCommandReader(env):
     info = env.cmd('info')
     redis_version = info['redis_version'].split('.')
@@ -819,6 +846,7 @@ def testSlowlogReportOnCommandReader(env):
     env.assertGreaterEqual(len(res), 1)
     env.assertEqual(res[0][3], ['RG.TRIGGER', 'test'])
 
+@gearsTest()
 def test1676(env):
     env.skipOnCluster()
     env.expect('RG.PYEXECUTE', "GB('StreamReader').map(lambda x: test()).register(onFailedPolicy='abort')").equal('OK')

--- a/pytest/test_errors.py
+++ b/pytest/test_errors.py
@@ -1,6 +1,7 @@
 from RLTest import Env
 import time
 from includes import *
+from common import gearsTest
 
 
 class testGenericErrors:
@@ -29,7 +30,7 @@ GB().run()
     def testRegistrationFailureOnSerialization(self):
         script1 = '''
 import redis
-r = redis.Redis()
+r = redis.Redis('localhost', '6381')
 
 def test(x):
     r.set('x', '1')
@@ -39,7 +40,7 @@ GB().map(test).register()
 '''
         script2 = '''
 import redis
-r = redis.Redis()
+r = redis.Redis('localhost', '6381')
 
 def test(x):
     r.set('x', '1')
@@ -50,6 +51,7 @@ GB('StreamReader').map(test).register()
         self.env.expect('rg.pyexecute', script1, 'REQUIREMENTS', 'redis').error().contains('Error occured when serialized a python callback')
         self.env.expect('rg.pyexecute', script2, 'REQUIREMENTS', 'redis').error().contains('Error occured when serialized a python callback')
 
+@gearsTest()
 def testRunFailureOnSerialization(env):
     if env.shardsCount < 2:
         env.skip()
@@ -161,32 +163,37 @@ GearsBuilder().aggregateby(lambda x: 'test', 0, secondCallFailed, secondCallFail
         res = self.env.cmd('rg.pyexecute', 'GearsBuilder().repartition(lambda x: notexists(x)).repartition(lambda x: notexists(x)).collect().run()')
         self.env.assertLessEqual(1, res[1])
 
-
+@gearsTest()
 def testCommandReaderWithRun(env):
     env.expect('rg.pyexecute', 'GB("CommandReader").run()').error().contains('reader do not support run')
 
+@gearsTest()
 def testCommandReaderWithBadArgs(env):
     env.expect('rg.pyexecute', 'GB("CommandReader").register("test")').error().contains('no trigger or hook argument was given')
     env.expect('rg.pyexecute', 'GB("CommandReader").register(trigger=1)').error().contains('trigger argument is not string')
 
+@gearsTest()
 def testCommandReaderRegisterSameCommand(env):
     env.expect('rg.pyexecute', 'GB("CommandReader").register(trigger="command")').ok()
     env.expect('rg.pyexecute', 'GB("CommandReader").register(trigger="command")').error().contains('trigger already registered')
 
+@gearsTest()
 def testCommandReaderRegisterWithExcpetionCommand(env):
     env.expect('rg.pyexecute', 'GB("CommandReader").foreach(lambda x: noexists).register(trigger="command")').ok()
     env.expect('rg.trigger', 'command').error().contains("'noexists' is not defined")
 
+@gearsTest()
 def testNoSerializableRegistrationWithAllReaders(env):
     script = '''
 import redis
-r = redis.Redis()
+r = redis.Redis('localhost', 6381)
 GB('%s').map(lambda x: r).register(trigger='test')
     '''
     env.expect('RG.PYEXECUTE', script % 'KeysReader', 'REQUIREMENTS', 'redis').error()
     env.expect('RG.PYEXECUTE', script % 'StreamReader', 'REQUIREMENTS', 'redis').error()
     env.expect('RG.PYEXECUTE', script % 'CommandReader', 'REQUIREMENTS', 'redis').error()
 
+@gearsTest()
 def testExtraUnknownArgumentsReturnError(env):
     env.expect('RG.PYEXECUTE', 'GB().run()', 'exta', 'unknown', 'arguments').error()
 
@@ -361,63 +368,81 @@ class testGetExecutionErrorReporting:
         self.env.cmd('RG.DROPEXECUTION', id)
         self.env.cmd('RG.CONFIGSET', 'PythonAttemptTraceback', 1)
 
+@gearsTest()
 def testCommandReaderWithPrefixRaiseError(env):
     env.expect('rg.pyexecute', 'GB("CommandReader").register(hook="test", keyprefix="foo")').error().contains('Can not override an unexisting command')
 
+@gearsTest()
 def testCommandReaderOverrideCommandWithMovableKeysRaiseError(env):
     env.expect('rg.pyexecute', 'GB("CommandReader").register(hook="xread", keyprefix="foo")').error().contains('Can not override a command with moveable keys by key prefix')
 
+@gearsTest()
 def testCommandReaderOverrideMultiRaiseError(env):
     env.expect('rg.pyexecute', 'GB("CommandReader").register(hook="multi")').error().contains('Can not override a command which are not allowed inside a script')
     
+@gearsTest()
 def testCommandReaderOverrideExecRaiseError(env):
     env.expect('rg.pyexecute', 'GB("CommandReader").register(hook="exec")').error().contains('Can not override a command which are not allowed inside a script')
 
+@gearsTest()
 def testCommandReaderOverrideBlpopRaiseError(env):
     env.expect('rg.pyexecute', 'GB("CommandReader").register(hook="blpop")').error().contains('Can not override a command which are not allowed inside a script')
 
+@gearsTest()
 def testKeysReaderWithUnexistingCommandRaiseError(env):
     env.expect('rg.pyexecute', 'GB().register(commands=["test"])').error().contains('bad reply')
 
+@gearsTest()
 def testKeysReaderOverrideCommandWithMovableKeysRaiseError(env):
     env.expect('rg.pyexecute', 'GB().register(commands=["xread"])').error().contains('Can not hook a command with moveable keys by key prefix')
-
+    
+@gearsTest()
 def testKeysReaderOverrideMultiRaiseError(env):
     env.expect('rg.pyexecute', 'GB().register(commands=["multi"])').error().contains('Can not hook a command which are not allowed inside a script')
-    
+
+@gearsTest()    
 def testKeysReaderOverrideExecRaiseError(env):
     env.expect('rg.pyexecute', 'GB().register(commands=["exec"])').error().contains('Can not hook a command which are not allowed inside a script')
 
+@gearsTest()
 def testKeysReaderOverrideBlpopRaiseError(env):
     env.expect('rg.pyexecute', 'GB().register(commands=["blpop"])').error().contains('Can not hook a command which are not allowed inside a script')
 
+@gearsTest()
 def testCallNextOnMapWrongScopes(env):
     res = env.cmd('rg.pyexecute', "GB('ShardsIDReader').map(lambda r: call_next(r)).run()")
     env.assertIn('Can not get CommandHook ctx', res[1][0])
 
+@gearsTest()
 def testCallNextOnFilterWrongScopes(env):
     res = env.cmd('rg.pyexecute', "GB('ShardsIDReader').filter(lambda r: call_next(r)).run()")
     env.assertIn('Can not get CommandHook ctx', res[1][0])
 
+@gearsTest()
 def testCallNextOnForeachWrongScopes(env):
     res = env.cmd('rg.pyexecute', "GB('ShardsIDReader').foreach(lambda r: call_next(r)).run()")
     env.assertIn('Can not get CommandHook ctx', res[1][0])
 
+@gearsTest()
 def testCallNextOnFlatmapWrongScopes(env):
     res = env.cmd('rg.pyexecute', "GB('ShardsIDReader').flatmap(lambda r: call_next(r)).run()")
     env.assertIn('Can not get CommandHook ctx', res[1][0])
 
+@gearsTest()
 def testCallNextOnAccumulateWrongScopes(env):
     res = env.cmd('rg.pyexecute', "GB('ShardsIDReader').accumulate(lambda a,r: call_next(r)).run()")
     env.assertIn('Can not get CommandHook ctx', res[1][0])
 
+@gearsTest()
 def testCallNextOnAccumulatebyWrongScopes(env):
     res = env.cmd('rg.pyexecute', "GB('ShardsIDReader').groupby(lambda x: x, lambda k,a,r: call_next(r)).run()")
     env.assertIn('Can not get CommandHook ctx', res[1][0])
 
+@gearsTest()
 def testCallNextOnWrongScopes(env):
     env.expect('rg.pyexecute', 'call_next()').error().contains('Can not get CommandHook ctx')
 
+@gearsTest()
 def testCallNextOnCoroWrongScope(env):
     script = '''
 import asyncio
@@ -432,7 +457,7 @@ GB("ShardsIDReader").map(doTest).run()
     err = res[1][0]
     env.assertContains(err, 'Can not get CommandHook ctx')
 
-
+@gearsTest()
 def testAwaitIsNotAllowedInsideAtomicBlock(env):
     script = '''
 import asyncio
@@ -448,6 +473,7 @@ GB("ShardsIDReader").map(doTest).run()
     err = res[1][0]
     env.assertContains(err, 'await is not allow inside atomic block')
 
+@gearsTest()
 def testAwaitIsNotAllowedInsideSyncExecution(env):
     script = '''
 import asyncio
@@ -462,6 +488,7 @@ GB("CommandReader").map(doTest).register(trigger='test', mode='sync')
     env.cmd('rg.pyexecute', script)
     env.expect('rg.trigger', 'test').error().contains('Can not create gearsFuture on sync execution')
 
+@gearsTest()
 def testCommandOverrideWithMoreThenSingleResultReturnError(env):
     script = '''
 GB("CommandReader").flatmap(lambda x: x).register(hook='hset', mode='sync')
@@ -470,6 +497,7 @@ GB("CommandReader").flatmap(lambda x: x).register(hook='hset', mode='sync')
     env.cmd('rg.pyexecute', script)
     env.expect('hset', 'h', 'foo', 'bar').error().contains('Command hook must return exactly one result')
 
+@gearsTest()
 def testCannotOverrideNoneSyncRegisration(env):
     script = '''
 GB("CommandReader").flatmap(lambda x: x).register(hook='hset')

--- a/pytest/test_profile.py
+++ b/pytest/test_profile.py
@@ -1,6 +1,11 @@
 from common import gearsTest
 
-@gearsTest()
+def getSession(env):
+	res = env.cmd('RG.PYDUMPSESSIONS')
+	env.assertEqual(len(res), 1)
+	return res[0][1]
+
+@gearsTest(skipOnCluster=True)
 def testProfile(env):
 	script = '''
 def map_func(r):
@@ -26,13 +31,14 @@ def extractor_func(a):
 
 GB('CommandReader').map(map_func).filter(filter_func).flatmap(flat_map_func).foreach(foreach_func).aggregate(0, aggregate_func, aggregate_func).aggregateby(extractor_func, 0, aggregateby_func, aggregateby_func).register(trigger='test')
 	'''
-	env.skipOnCluster()
 	env.expect('RG.CONFIGSET', 'ProfileExecutions', '1').equal(['OK'])
 	env.expect('RG.PYEXECUTE', script).ok()
 
 	env.cmd('RG.TRIGGER', 'test')
 
-	res = env.cmd('RG.PYPROFILE', 'STATS', '0000000000000000000000000000000000000000-0')
+	sessionId = getSession(env)
+
+	res = env.cmd('RG.PYPROFILE', 'STATS', sessionId)
 	env.assertContains('map_func', res)
 	env.assertContains('filter_func', res)
 	env.assertContains('flat_map_func', res)
@@ -41,7 +47,7 @@ GB('CommandReader').map(map_func).filter(filter_func).flatmap(flat_map_func).for
 	env.assertContains('extractor_func', res)
 	env.assertContains('aggregateby_func', res)
 
-	res = env.cmd('RG.PYPROFILE', 'STATS', '0000000000000000000000000000000000000000-0', 'ncalls')
+	res = env.cmd('RG.PYPROFILE', 'STATS', sessionId, 'ncalls')
 	env.assertContains('map_func', res)
 	env.assertContains('filter_func', res)
 	env.assertContains('flat_map_func', res)
@@ -50,24 +56,23 @@ GB('CommandReader').map(map_func).filter(filter_func).flatmap(flat_map_func).for
 	env.assertContains('extractor_func', res)
 	env.assertContains('aggregateby_func', res)
 
-@gearsTest()
+@gearsTest(skipOnCluster=True)
 def testProfileWithoutProfileInfo(env):
-	env.skipOnCluster()
 	env.expect('RG.CONFIGSET', 'ProfileExecutions', '1').equal(['OK'])
 	env.expect('RG.PYEXECUTE', "GB('CommandReader').register(trigger='test')").ok()
 	env.expect('RG.PYPROFILE', 'STATS', '0000000000000000000000000000000000000000-0').error()
 
-@gearsTest()
+@gearsTest(skipOnCluster=True)
 def testProfileReset(env):
-	env.skipOnCluster()
 	env.expect('RG.CONFIGSET', 'ProfileExecutions', '1').equal(['OK'])
 	env.expect('RG.PYEXECUTE', "GB('CommandReader').register(trigger='test')").ok()
 	env.cmd('RG.TRIGGER', 'test')
-	env.expect('RG.PYPROFILE', 'RESET', '0000000000000000000000000000000000000000-0').ok()
-	env.expect('RG.PYPROFILE', 'STATS', '0000000000000000000000000000000000000000-0').error()
+	sessionId = getSession(env)
+	env.expect('RG.PYPROFILE', 'RESET', sessionId).ok()
+	env.expect('RG.PYPROFILE', 'STATS', sessionId).error()
 
-@gearsTest()
+@gearsTest(skipOnCluster=True)
 def testPyDumpSessions(env):
-	env.skipOnCluster()
 	env.expect('RG.PYEXECUTE', "GB('CommandReader').register(trigger='test')", 'REQUIREMENTS', 'redis==3.5.3').ok()
-	env.expect('RG.PYDUMPSESSIONS').equal([['id', '0000000000000000000000000000000000000000-0', 'refCount', 1L, 'requirementInstallationNeeded', 1L, 'requirements', [['name', 'redis==3.5.3', 'refCount', 2L, 'isDownloaded', 1L, 'isInstalled', 1L, 'wheels', ['redis-3.5.3-py2.py3-none-any.whl']]]]])
+	sessionId = getSession(env)
+	env.expect('RG.PYDUMPSESSIONS').equal([['id', sessionId, 'refCount', 1L, 'requirementInstallationNeeded', 1L, 'requirements', [['name', 'redis==3.5.3', 'refCount', 2L, 'isDownloaded', 1L, 'isInstalled', 1L, 'wheels', ['redis-3.5.3-py2.py3-none-any.whl']]]]])

--- a/pytest/test_register.py
+++ b/pytest/test_register.py
@@ -12,7 +12,7 @@ from common import gearsTest
 
 class testUnregister:
     def __init__(self):
-        self.env = Env()
+        self.env = Env(freshEnv=True)
         self.conn = getConnectionByEnv(self.env)
 
     def cleanUp(self):
@@ -80,6 +80,8 @@ GB().filter(lambda r: r['key'] != 'all_keys').repartition(lambda r: 'all_keys').
         for r in registrations:
             self.env.expect('RG.UNREGISTER', r[1]).equal('OK')
 
+        self.cleanUp()
+
     def testUnregisterWithStreamReader(self):
         res = self.env.cmd('rg.pyexecute', "GearsBuilder('StreamReader')."
                                       "map(lambda x: x['value'])."
@@ -125,6 +127,8 @@ GB().filter(lambda r: r['key'] != 'all_keys').repartition(lambda r: 'all_keys').
         registrations = self.env.cmd('RG.DUMPREGISTRATIONS')
         for r in registrations:
             self.env.expect('RG.UNREGISTER', r[1]).equal('OK')
+
+        self.cleanUp()
 
 @gearsTest(skipOnCluster=True)
 def testMaxExecutionPerRegistrationStreamReader(env):

--- a/pytest/test_register.py
+++ b/pytest/test_register.py
@@ -436,7 +436,7 @@ def testBasicStreamProcessing(env):
     except Exception:
         env.assertTrue(False, message='Failed waiting for keys to updated')
 
-@gearsTest(envArgs={'moduleArgs': 'MaxExecutionsPerRegistrations 1000'})
+@gearsTest()
 def testRegistersOnPrefix(env):
     conn = getConnectionByEnv(env)
     env.cmd('rg.pyexecute', "GB()."

--- a/pytest/test_register.py
+++ b/pytest/test_register.py
@@ -8,7 +8,7 @@ from common import getConnectionByEnv
 from common import TimeLimit
 from common import verifyRegistrationIntegrity
 from common import Background
-
+from common import gearsTest
 
 class testUnregister:
     def __init__(self):
@@ -126,6 +126,7 @@ GB().filter(lambda r: r['key'] != 'all_keys').repartition(lambda r: 'all_keys').
         for r in registrations:
             self.env.expect('RG.UNREGISTER', r[1]).equal('OK')
 
+@gearsTest()
 def testMaxExecutionPerRegistrationStreamReader(env):
     env.skipOnCluster()
     env.cmd('RG.CONFIGSET', 'MaxExecutionsPerRegistration', 1)
@@ -147,6 +148,7 @@ def testMaxExecutionPerRegistrationStreamReader(env):
     for r in registrations:
         env.expect('RG.UNREGISTER', r[1], ).equal('OK')
 
+@gearsTest()
 def testMaxExecutionPerRegistrationKeysReader(env):
     env.skipOnCluster()
     env.cmd('RG.CONFIGSET', 'MaxExecutionsPerRegistration', 1)
@@ -168,8 +170,8 @@ def testMaxExecutionPerRegistrationKeysReader(env):
     for r in registrations:
         env.expect('RG.UNREGISTER', r[1], ).equal('OK')
 
-def testUnregisterKeysReaderWithAbortExecutions():
-    env = Env(moduleArgs='executionThreads 1')
+@gearsTest(envArgs={'moduleArgs': 'executionThreads 1'})
+def testUnregisterKeysReaderWithAbortExecutions(env):
     env.skipOnCluster()
     infinitScript = '''
 counter = 0
@@ -245,8 +247,8 @@ GB().map(InfinitLoop).register('*', mode='async_local')
 
     env.cmd('RG.DROPEXECUTION', eid)
 
-def testUnregisterStreamReaderWithAbortExecutions():
-    env = Env(moduleArgs='executionThreads 1')
+@gearsTest(envArgs={'moduleArgs': 'executionThreads 1'})
+def testUnregisterStreamReaderWithAbortExecutions(env):
     env.skipOnCluster()
     infinitScript = '''
 counter = 0
@@ -335,6 +337,7 @@ GB('StreamReader').map(InfinitLoop).register('s', mode='async_local', onFailedPo
 
     env.cmd('RG.DROPEXECUTION', eid)
 
+@gearsTest()
 def testBasicStream(env):
     conn = getConnectionByEnv(env)
     res = env.cmd('rg.pyexecute', "GearsBuilder()."
@@ -362,7 +365,7 @@ def testBasicStream(env):
     for r in registrations:
          env.expect('RG.UNREGISTER', r[1]).equal('OK')
 
-
+@gearsTest()
 def testBasicStreamRegisterOnPrefix(env):
     conn = getConnectionByEnv(env)
     env.expect('rg.pyexecute', "GearsBuilder('StreamReader')."
@@ -412,7 +415,7 @@ def testBasicStreamRegisterOnPrefix(env):
     time.sleep(0.1) # wait for registration to unregister
     # todo: remove the need for this
 
-
+@gearsTest()
 def testBasicStreamProcessing(env):
     conn = getConnectionByEnv(env)
     res = env.cmd('rg.pyexecute', "GearsBuilder('StreamReader')."
@@ -437,6 +440,7 @@ def testBasicStreamProcessing(env):
     except Exception:
         env.assertTrue(False, message='Failed waiting for keys to updated')
 
+@gearsTest(envArgs={'moduleArgs': 'MaxExecutionsPerRegistrations 1000'})
 def testRegistersOnPrefix(env):
     conn = getConnectionByEnv(env)
     env.cmd('rg.pyexecute', "GB()."
@@ -469,6 +473,7 @@ def testRegistersOnPrefix(env):
     for r in registrations:
          env.expect('RG.UNREGISTER', r[1]).equal('OK')
 
+@gearsTest()
 def testRegistersSurviveRestart(env):
     conn = getConnectionByEnv(env)
     env.cmd('rg.pyexecute', "GB().filter(lambda x: 'NumOfKeys' not in x['key'])."
@@ -506,8 +511,8 @@ def testRegistersSurviveRestart(env):
     for r in registrations:
         env.expect('RG.UNREGISTER', r[1]).equal('OK')
 
-def testRegistersReplicatedToSlave():
-    env = Env(useSlaves=True, env='oss')
+@gearsTest(envArgs={'useSlaves': True, 'env': 'oss'})
+def testRegistersReplicatedToSlave(env):
     if env.envRunner.debugger is not None:
         env.skip() # valgrind is not working correctly with replication
     conn = getConnectionByEnv(env)
@@ -574,6 +579,7 @@ def testRegistersReplicatedToSlave():
     except Exception:
         env.assertTrue(False, message='Failed waiting for registration to unregister on slave')
 
+@gearsTest()
 def testSyncRegister(env):
     env.skipOnCluster()
     conn = getConnectionByEnv(env)
@@ -593,7 +599,8 @@ def testSyncRegister(env):
     registrations = env.cmd('RG.DUMPREGISTRATIONS')
     for r in registrations:
          env.expect('RG.UNREGISTER', r[1]).equal('OK')
-    
+
+@gearsTest()
 def testOnRegisteredCallback(env):
     conn = getConnectionByEnv(env)
     env.cmd('rg.pyexecute', "GB()."
@@ -609,6 +616,7 @@ def testOnRegisteredCallback(env):
     for r in registrations:
          env.expect('RG.UNREGISTER', r[1]).equal('OK')
 
+@gearsTest()
 def testStreamReaderDoNotLoseValues(env):
     env.skipOnCluster()
     conn = getConnectionByEnv(env)
@@ -651,8 +659,8 @@ def testStreamReaderDoNotLoseValues(env):
     for r in registrations:
          env.expect('RG.UNREGISTER', r[1]).equal('OK')
 
-def testStreamReaderWithAof():
-    env = Env(env='oss', useAof=True)
+@gearsTest(envArgs={'useAof': True, 'env': 'oss'})
+def testStreamReaderWithAof(env):
     conn = getConnectionByEnv(env)
     env.cmd('rg.pyexecute', "GB('StreamReader').repartition(lambda x: 'NumOfElements')."
                             "foreach(lambda x: execute('incr', 'NumOfElements'))."
@@ -697,6 +705,7 @@ def testStreamReaderWithAof():
     for r in registrations:
          env.expect('RG.UNREGISTER', r[1]).equal('OK')
 
+@gearsTest()
 def testStreamReaderTrimming(env):
     env.skipOnCluster()
     env.cmd('rg.pyexecute', "GB('StreamReader')."
@@ -725,7 +734,8 @@ def testStreamReaderTrimming(env):
     for r in registrations:
          env.expect('RG.UNREGISTER', r[1]).equal('OK')
 
-def testStreamReaderRestartOnSlave():
+@gearsTest(envArgs={'useSlaves': True, 'env': 'oss'})
+def testStreamReaderRestartOnSlave(env):
     script = '''
 import time
 def FailedOnMaster(r):
@@ -734,13 +744,11 @@ def FailedOnMaster(r):
     if currNum is not None:
         currNum = int(currNum)
     if currNum == 5 and numSlaves == 1:
-        execute('set', 'inside_loop', '1')    
-        while True:
-            time.sleep(1)
+        execute('set', 'inside_loop', '1')
+        raise Exception('stop')
     execute('incr', 'NumOfElements')
-GB('StreamReader').foreach(FailedOnMaster).register(regex='stream', batch=3)
+GB('StreamReader').foreach(FailedOnMaster).register(regex='stream', batch=3, onFailedPolicy='abort')
 '''
-    env = Env(env='oss', useSlaves=True)
     if env.envRunner.debugger is not None:
         env.skip() # valgrind is not working correctly with replication
     slaveConn = env.getSlaveConnection()
@@ -787,6 +795,7 @@ GB('StreamReader').foreach(FailedOnMaster).register(regex='stream', batch=3)
     except Exception as e:
         env.assertTrue(False, message='Failed waiting for NumOfElements to reach 8 on slave')
 
+@gearsTest()
 def testKeysReaderEventTypeFilter(env):
     conn = getConnectionByEnv(env)
 
@@ -832,6 +841,7 @@ def testKeysReaderEventTypeFilter(env):
     for r in registrations:
          env.expect('RG.UNREGISTER', r[1]).equal('OK')
 
+@gearsTest()
 def testKeysReaderKeyTypeFilter(env):
     conn = getConnectionByEnv(env)
 
@@ -876,6 +886,7 @@ def testKeysReaderKeyTypeFilter(env):
     for r in registrations:
          env.expect('RG.UNREGISTER', r[1]).equal('OK')
 
+@gearsTest()
 def testSteamReaderAbortOnFailure(env):
     env.skipOnCluster()
 
@@ -900,6 +911,7 @@ def testSteamReaderAbortOnFailure(env):
     for r in registrations:
          env.expect('RG.UNREGISTER', r[1]).equal('OK')
 
+@gearsTest()
 def testStreamTrimming(env):
     conn = getConnectionByEnv(env)
 
@@ -945,6 +957,7 @@ def testStreamTrimming(env):
     for r in registrations:
          env.expect('RG.UNREGISTER', r[1]).equal('OK')
 
+@gearsTest()
 def testCommandReaderBasic(env):
     conn = getConnectionByEnv(env)
     env.expect('RG.PYEXECUTE', "GB('CommandReader').flatmap(lambda x: x).distinct().sort().register(trigger='test1')").ok()
@@ -954,11 +967,13 @@ def testCommandReaderBasic(env):
     env.expect('RG.PYEXECUTE', "GB('CommandReader').flatmap(lambda x: x).distinct().sort().register(trigger='test3', mode='async_local')").ok()
     env.expect('RG.TRIGGER', 'test3', 'this', 'is', 'a', 'test').equal(['a', 'is', 'test', 'test3', 'this'])
 
+@gearsTest()
 def testCommandReaderCluster(env):
     conn = getConnectionByEnv(env)
     env.expect('RG.PYEXECUTE', "GB('CommandReader').count().register(trigger='GetNumShard')").ok()
     env.expect('RG.TRIGGER', 'GetNumShard').equal([str(env.shardsCount)])
 
+@gearsTest()
 def testCommandReaderWithCountBy(env):
     env.skipOnCluster()
     env.expect('RG.PYEXECUTE', "GB('CommandReader').flatmap(lambda x: x[1:]).countby(lambda x: x).register(trigger='test1')").ok()
@@ -967,6 +982,7 @@ def testCommandReaderWithCountBy(env):
     # we need to check twice to make sure the execution reset are not causing issues
     env.expect('RG.TRIGGER', 'test1', 'a', 'a', 'a').equal(["{'key': 'a', 'value': 3}"])
 
+@gearsTest()
 def testKeyReaderRegisterDontReadValues(env):
     conn = getConnectionByEnv(env)
     env.expect('RG.PYEXECUTE', "GB('KeysReader').foreach(lambda x: x.pop('event', None)).repartition(lambda x: 'l').foreach(lambda x: execute('lpush', 'l', str(x))).register(readValue=False, eventTypes=['set'])").ok()
@@ -988,6 +1004,7 @@ def testKeyReaderRegisterDontReadValues(env):
     except Exception as e:
         env.assertTrue(False, message='Failed waiting for list to popultae')
 
+@gearsTest()
 def testCommandOverrideHset(env):
     conn = getConnectionByEnv(env)
     script = '''
@@ -1014,6 +1031,7 @@ GB("CommandReader").map(doHset).register(hook="hset", mode="sync")
     res = conn.execute_command('hget', 'h3', '__time')
     env.assertNotEqual(res, None)
 
+@gearsTest()
 def testCommandOverrideHsetMultipleTimes(env):
     conn = getConnectionByEnv(env)
     script1 = '''
@@ -1058,6 +1076,7 @@ GB("CommandReader").map(doHset).register(hook="hset", mode="sync")
     res = conn.execute_command('hget', 'h3', '__time2')
     env.assertNotEqual(res, None)
 
+@gearsTest()
 def testCommandOverrideHsetByKeyPrefix(env):
     conn = getConnectionByEnv(env)
     script1 = '''
@@ -1109,6 +1128,7 @@ GB("CommandReader").map(doHset).register(hook="hset", mode="sync", keyprefix='h'
     res = conn.execute_command('hget', 'b1', '__time2')
     env.assertEqual(res, None)
 
+@gearsTest()
 def testAwaitOnAnotherExcecution(env):
     script = '''
 async def doTest(x):
@@ -1130,9 +1150,8 @@ GB("CommandReader").map(doTest).flatmap(lambda x: x).sort().register(trigger="te
 
     env.expect('rg.trigger', 'test').equal(['x', 'y', 'z'])
 
-
+@gearsTest(envArgs={'useSlaves': True, 'env': 'oss'})
 def testHookNotTriggerOnReplicationLink(env):
-    env = Env(useSlaves=True, env='oss')
     if env.envRunner.debugger is not None:
         env.skip() # valgrind is not working correctly with replication
     script = '''
@@ -1160,6 +1179,7 @@ GB("CommandReader").map(doHset).register(hook="hset", convertToStr=False)
     except Exception as e:
         env.assertTrue(False, message='Failed waiting for data to sync to slave')
 
+@gearsTest()
 def testMultipleRegistrationsSameBuilderWithKeysReader(env):
     script = '''
 gb = GB().foreach(lambda x: execute('del', x['key']))
@@ -1176,6 +1196,7 @@ gb.register(prefix='bar', readValue=False, mode='sync')
     env.assertEqual(conn.execute_command('get', 'foo'), None)
     env.assertEqual(conn.execute_command('get', 'bar'), None)
 
+@gearsTest()
 def testMultipleRegistrationsSameBuilderWithStreamReader(env):
     script = '''
 gb = GB('StreamReader').foreach(lambda x: execute('hset', '{%s}_hash' % x['key'], *sum([[k,v] for k,v in x['value'].items()], [])))
@@ -1192,6 +1213,7 @@ gb.register(prefix='bar', mode='sync')
     env.assertEqual(conn.execute_command('hgetall', '{foo}_hash'), {'x': '1'})
     env.assertEqual(conn.execute_command('hgetall', '{bar}_hash'), {'x': '1'})
 
+@gearsTest()
 def testMultipleRegistrationsSameBuilderWithCommandReader(env):
     script = '''
 import time
@@ -1210,6 +1232,7 @@ gb.register(hook='hmset', mode='sync')
     env.assertNotEqual(conn.execute_command('hget', 'h1', '_time'), None)
     env.assertNotEqual(conn.execute_command('hget', 'h2', '_time'), None)
 
+@gearsTest()
 def testDeleteStreamDurringRun(env):
     env.skipOnCluster()
     script = '''
@@ -1367,6 +1390,7 @@ GB().foreach(OverrideReply).register(prefix='test*', eventTypes=['keymiss'], com
         res = self.conn.execute_command('get', 'test1')
         self.env.assertEqual(res, 2)
 
+@gearsTest()
 def testCommandReaderInOrder(env):
     env.skipOnCluster()
     script = '''
@@ -1428,6 +1452,7 @@ GB('CommandReader').foreach(SleepIfNeeded).map(lambda x: execute('lpush', x[1], 
 
         env.cmd('flushall')
 
+@gearsTest()
 def testStreamReaderNotTriggerEventsOnReplica(env):
     env.skipOnCluster()
     env.expect('RG.PYEXECUTE', "GB('StreamReader').map(lambda x: x['error']).register(onFailedPolicy='retry', onFailedRetryInterval=1)").equal('OK')
@@ -1461,6 +1486,7 @@ def testStreamReaderNotTriggerEventsOnReplica(env):
 
     env.cmd('SLAVEOF', 'no', 'one')
 
+@gearsTest()
 def testMOD1960(env):
     env.skipOnCluster()
     env.cmd('xadd', 's', '*', 'foo', 'bar')

--- a/pytest/test_register.py
+++ b/pytest/test_register.py
@@ -1520,7 +1520,10 @@ def testStreamReaderOnUninitializedCluster(env):
         with TimeLimit(1):
             while True:
                 res = conn2.execute_command('RG.DUMPEXECUTIONS')
-                env.assertEqual(len(res), 0)
+                if len(res) != 0:
+                    print(res)
+                    env.assertEqual(len(res), 0)
+                    break
     except Exception as e:
         pass
 

--- a/pytest/test_requirements.py
+++ b/pytest/test_requirements.py
@@ -97,7 +97,7 @@ def testDependenciesReplicatedToSlave(env):
     except Exception:
         env.assertTrue(False, message='Failed waiting for requirement to reach slave')
 
-@gearsTest(envArgs={'moduleArgs': 'CreateVenv 1'})
+@gearsTest(envArgs={'moduleArgs': 'CreateVenv 1', 'freshEnv': True})
 def testDependenciesSavedToRDB(env):
     conn = getConnectionByEnv(env)
     env.expect('RG.PYEXECUTE', "import redisgraph", 'REQUIREMENTS', 'redisgraph').ok()

--- a/src/readers/streams_reader.c
+++ b/src/readers/streams_reader.c
@@ -746,8 +746,7 @@ static void StreamReader_RunOnEvent(SingleStreamReaderCtx* ssrctx, size_t batch,
         }
         return;
     }
-    RedisModule_Assert(srtctx->mode != ExecutionModeSync || EPIsFlagOn(ep, EFDone));
-    if(EPIsFlagOn(ep, EFIsLocal) && EPIsFlagOff(ep, EFDone)){
+    if(srtctx->mode != ExecutionModeSync && EPIsFlagOn(ep, EFIsLocal) && EPIsFlagOff(ep, EFDone)){
         // execution is local
         // If execution is SYNC it will be added to localDoneExecutions on done
         // Otherwise, save it to the registration pending execution list.


### PR DESCRIPTION
Cleanup performed:
1. deleted all registration
2. delete all executions

This should cleanup occasional valgrind failure and in the future will allow us to run the tests with env-reuse flag and speed them up even more.