### PR TITLE
Upgrade pytest version to 6.2.5

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,5 @@ mkdocs-material==6.2.2
 -e git+https://github.com/RedisLabs/mkdocs-versions-menu.git#egg=mkdocs-versions-menu
 -e git+https://github.com/RedisLabs/mkdocs-modules-template.git#egg=mkdocs-modules-template
 redis==3.4.1
-pytest==5.3.5
+pytest==6.2.5
 docker==4.2.0


### PR DESCRIPTION
After this github action error: https://github.com/RedisGears/RedisGears/runs/4234637668?check_suite_focus=true
Try to solve this based on: https://stackoverflow.com/questions/69528842/an-error-while-trying-to-execute-tests-on-python-3-10-with-pytest 