### PR TITLE
Add redisai docs to nav bar and home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ In broad strokes, the following diagram depicts RedisGears' components:
 ## Where Next?
   * The [Introduction](intro.md) is the recommended starting point
   * The [Overview](glossary.md) page summarizes important RedisGears concepts
-  * The reference pages describe RedisGears' [Runtime](runtime.md), [Functions](functions.md), [Readers](readers.md) and [Operations](operations.md)
+  * The reference pages describe RedisGears' [Runtime](runtime.md), [Functions](functions.md), [Readers](readers.md), [Operations](operations.md) and integration with [RedisAI](redisai.md)
   * The RedisGears [Commands](commands.md) reference describes all commands
   * The [Quickstart](quickstart.md) page provides information about getting, building, installing, and running RedisGears
   * There are interesting RedisGears uses cases and recipes on the [Examples](examples.md) page

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
     - 'Readers': 'readers.md'
     - 'Operations': 'operations.md'
     - 'Commands': 'commands.md'
+    - 'RedisAI': 'redisai.md'
     - 'Configuration': 'configuration.md'
   - 'Examples': 'examples.md'
   - 'Clients': 'clients.md'


### PR DESCRIPTION
After uploading RedisAI docs, I noticed that it is not accessible from the website. This PR should address this. 