### PR TITLE
Fix #558, wait for cluster to be initialized when reading stream data

### DIFF
--- a/pytest/test_register.py
+++ b/pytest/test_register.py
@@ -1474,3 +1474,56 @@ def testMOD1960(env):
                 time.sleep(0.1)
     except Exception as e:
         env.assertTrue(False, message='Failed waiting for x to be updated')
+
+def testStreamReaderOnUninitializedCluster(env):
+    if env.shardsCount != 3:
+        env.skip()
+
+    conn = getConnectionByEnv(env)
+
+    # we know that s3 goes to the second shard
+    conn.execute_command('xadd', 's3', '*', 'foo', 'bar')
+
+    env.broadcast('CONFIG', 'set', 'cluster-node-timeout', '100')
+
+    conn1 = env.getConnection(shardId=1)
+    conn2 = env.getConnection(shardId=2)
+
+    # close shard 1 to get cluster to a down state
+    env.envRunner.shards[0].stopEnv()
+
+    try:
+        with TimeLimit(1):
+            while True:
+                res = conn2.execute_command('CLUSTER', 'INFO')
+                if 'cluster_state:fail' in str(res):
+                    break
+                time.sleep(0.1)
+    except Exception as e:
+        env.assertTrue(False, message='Failed waiting for down cluster state (%s)' % (str(e)))
+
+    conn2.execute_command('RG.PYEXECUTE', "GB('StreamReader').register()")
+
+    # make sure no executions are created
+    try:
+        with TimeLimit(1):
+            while True:
+                res = conn2.execute_command('RG.DUMPEXECUTIONS')
+                env.assertEqual(len(res), 0)
+    except Exception as e:
+        pass
+
+    # restart the shard
+    env.envRunner.shards[0].startEnv()
+    conn1.execute_command('RG.REFRESHCLUSTER')
+
+    # make sure execution is eventually created
+    try:
+        with TimeLimit(5):
+            while True:
+                res = conn2.execute_command('RG.DUMPEXECUTIONS')
+                if len(res) == 1:
+                    break
+                time.sleep(0.1)
+    except Exception as e:
+        env.assertTrue(False, message='Failed waiting for execution to start (%s)' % (str(e)))

--- a/src/readers/streams_reader.c
+++ b/src/readers/streams_reader.c
@@ -9,6 +9,8 @@
 #include "record.h"
 #include "config.h"
 #include <pthread.h>
+#include <errno.h>
+#include <unistd.h>
 
 #define STREAM_REGISTRATION_INIT_SIZE 10
 static Gears_list* streamsRegistration = NULL;
@@ -92,7 +94,7 @@ static bool StreamReader_VerifyCallReply(RedisModuleCtx* ctx, RedisModuleCallRep
         if(reply && RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_ERROR){
             err = RedisModule_CallReplyStringPtr(reply, NULL);
         }
-        RedisModule_Log(staticCtx, logLevel, "%s : %s", msgPrefix, err);
+        RedisModule_Log(staticCtx, logLevel, "%s : %s (errno=%d, errono_str=%s)", msgPrefix, err, errno, strerror(errno));
         if(reply) RedisModule_FreeCallReply(reply);
         return false;
     }
@@ -153,10 +155,11 @@ static StreamReaderTriggerCtx* StreamReaderTriggerCtx_GetShallowCopy(StreamReade
     return srtctx;
 }
 
-static void StreamReader_ReadLastId(RedisModuleCtx *rctx, SingleStreamReaderCtx* ssrctx){
+static int StreamReader_ReadLastId(RedisModuleCtx *rctx, SingleStreamReaderCtx* ssrctx){
     RedisModuleCallReply *reply = RedisModule_Call(rctx, "XINFO", "cc", "STREAM", ssrctx->keyName);
-    bool ret = StreamReader_VerifyCallReply(rctx, reply, "Failed on XINFO command", "warning");
-    RedisModule_Assert(ret);
+    if(!StreamReader_VerifyCallReply(rctx, reply, "Failed on XINFO command", "warning")){
+    	return false;
+    }
     RedisModule_Assert(RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_ARRAY);
     size_t lastGeneratedIdIndex = 0;
     for(size_t i = 0 ; i < RedisModule_CallReplyLength(reply) ; i+=2){
@@ -174,6 +177,7 @@ static void StreamReader_ReadLastId(RedisModuleCtx *rctx, SingleStreamReaderCtx*
     const char* idStr = RedisModule_CallReplyStringPtr(idReply, NULL);
     ssrctx->lastId = StreamReader_ParseStreamId(idStr);
     RedisModule_FreeCallReply(reply);
+    return true;
 }
 
 #define GEARS_CONSUMER_GROUP "__gears_consumer_group__"
@@ -194,7 +198,11 @@ static SingleStreamReaderCtx* SingleStreamReaderCtx_Create(RedisModuleCtx* ctx,
     ssrctx->keyName = RG_STRDUP(keyName);
     ssrctx->timerIsSet = false;
     ssrctx->freeOnNextTimeEvent = false;
-    StreamReader_ReadLastId(ctx, ssrctx);
+    if(!StreamReader_ReadLastId(ctx, ssrctx)){
+    	RG_FREE(ssrctx->keyName);
+    	RG_FREE(ssrctx);
+    	return NULL;
+    }
     Gears_dictAdd(srtctx->singleStreamData, (char*)keyName, ssrctx);
 
     // The moment we create the SingleStreamReaderCtx we must trigger execution to read
@@ -827,6 +835,7 @@ static int StreamReader_OnKeyTouched(RedisModuleCtx *ctx, int type, const char *
             SingleStreamReaderCtx* ssrctx = Gears_dictFetchValue(srctx->singleStreamData, (char*)keyName);
             if(!ssrctx){
                 ssrctx = SingleStreamReaderCtx_Create(ctx, keyName, srctx);
+                RedisModule_Assert(ssrctx);
             }
             if(srctx->args->batchSize <= ++ssrctx->numTriggered){
                 StreamReader_RunOnEvent(ssrctx, srctx->args->batchSize, false);
@@ -886,6 +895,14 @@ static bool StreamReader_IsStream(RedisModuleKey *kp){
 static void* StreamReader_ScanForStreams(void* pd){
     RedisGears_LockHanlderRegister();
     StreamReaderTriggerCtx* srctx = pd;
+    while (!Cluster_IsInitialized()) {
+    	/* Wait until cluster is initialized,
+    	 * Notice that there might be an adge case
+    	 * where cluster will be initialized here but
+    	 * will get uninitialized when we try to read
+    	 * the stream, for this we also have retry mechanism */
+    	sleep(1);
+    }
     long long cursor = 0;
     do{
         // we do not use the lockhandler cause this thread is temporary
@@ -935,7 +952,20 @@ static void* StreamReader_ScanForStreams(void* pd){
                 const char* keyName = RedisModule_StringPtrLen(key, NULL);
                 SingleStreamReaderCtx* ssrctx = Gears_dictFetchValue(srctx->singleStreamData, (char*)keyName);
                 if(!ssrctx){
-                    ssrctx = SingleStreamReaderCtx_Create(staticCtx, keyName, srctx);
+                	size_t retries = 0;
+                    while(!(ssrctx = SingleStreamReaderCtx_Create(staticCtx, keyName, srctx))) {
+                    	// creating stream reader ctx can failed if cluster is not initialized.
+                    	// sleep for 1 second and retry (but not more than 10 retries)
+                    	if(++retries > 10) {
+                    		RedisModule_Log(staticCtx, "warning", "Failed creating stream reader ctx for key %s, for more than 10 times, abort.", keyName);
+                    		break;
+                    	}
+                    	LockHandler_Release(staticCtx);
+                    	RedisModule_Log(staticCtx, "warning", "Failed creating stream reader ctx for key %s, will retry in 5 seconds.", keyName);
+                    	sleep(5);
+                    	LockHandler_Acquire(staticCtx);
+
+                    }
                 }
             }
             RedisModule_FreeString(staticCtx, key);


### PR DESCRIPTION
On oss cluster, if cluster is not initialized, read commands will failed and return an error. On stream reader, we assert that we read the stream successfully, such assertion will failed on uninitialized cluster and will cause a crash.

Solution:
1. Before start scaning for streams, wait for cluster to be initialized.
2. '1' is not enough, by the time we find a stream to read the cluster might get uninitialized again. To solve this, if we failed to read    the stream we retry after 5 seconds. We retry up to 10 times and than abort.

todo:

- [ ] Cherrypick to 1.0