### PR TITLE
add gears_python.so to quickstart docs

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -87,11 +87,11 @@ make all
 You will find the compiled binary under `bin/linux-x64-release/redisgears.so` with a symbolic link to it in the main directory (called `redisgears.os`).
 
 ## Loading
-To load the module on the same server it was compiled on, use the `--loadmodule` command line switch, the `loadmodule` configuration directive, or the [Redis `MODULE LOAD` command](https://redis.io/commands/module-load) with the path to module's library.
+To load the module on the same server it was compiled on, use the `--loadmodule` command line switch, the `loadmodule` configuration directive, or the [Redis `MODULE LOAD` command](https://redis.io/commands/module-load) with the path to module's library and the Gears Python plugin `gears_python.so`.
 
 For example, to load the module into a local Redis server after you've [built](#building) it, run:
 ```
-redis-server --loadmodule ./redisgears.so
+redis-server --loadmodule ./redisgears.so Plugin ./gears_python/gears_python.so
 ```
 
 If you've compiled the module on a different server than the one loading it (or downloaded the module), copy the directory `bin/linux-x64-release/python3_<version>` (where `<version>` is the version compiled) to the target server. Use the [PythonInstallationDir](configuration.md#pythoninstallationdir) configuration parameter to specify the path of the copied directory on the target to RedisGears. **Important:** the directory's name, that is `python3_<version>`, should not be changed.


### PR DESCRIPTION
gears-plugin.so is required to do anything meaningful with Gears, including going through introductory docs and running RG.PYEXECUTE. This pull request adds gears-plugin.so to the ##Loading section of the quickstart.

I've actually attempted to follow docs pre-PR and RG.PYEXECUTE was not available. It took me reading through the source code of Dockerfile to figure out what's going on.