### PR TITLE
Valgrind fixes

### DIFF
--- a/leakcheck.supp
+++ b/leakcheck.supp
@@ -92,6 +92,13 @@
    ...
 }
 {
+   <ignore_Cluster_SendMsg_false_leak>
+   Memcheck:Leak
+   ...
+   fun:Cluster_SendMsg
+   ...
+}
+{
    <ignore_connection_leak_for_now>
    Memcheck:Leak
    ...

--- a/src/module.c
+++ b/src/module.c
@@ -1270,7 +1270,6 @@ static bool isInitiated = false;
 void RedisGears_OnShutDown(RedisModuleCtx *ctx, RedisModuleEvent e, uint64_t sub, void *data){
 #ifdef VALGRIND
     ExecutionPlan_Clean();
-    LockHandler_Release(ctx);
 #endif
 }
 


### PR DESCRIPTION
1. Fix wrong valgrind error when writing pointer address to pipe. Valgrind might think we lost the pointer if the processes exit before reading it from the pipe. Added this case to suppression file.

2. Use shutdown event to do cleanup instead of __attribute__((destructor)) This way we know that we run when the GIL help and there will be no race conditions on cleanups.