### PR TITLE
Fix #650, do not propagate multi exec on Redis 7.

### DIFF
--- a/plugins/python/redisgears_python.c
+++ b/plugins/python/redisgears_python.c
@@ -34,6 +34,8 @@ PythonConfig pythonConfig;
 
 static RedisModuleCtx *staticCtx = NULL;
 
+static RedisVersion *redisVersion = NULL;
+
 #define PY_OBJECT_TYPE_VERSION 1
 
 #define PY_SESSION_TYPE_VERSION 1
@@ -1813,7 +1815,15 @@ static PyObject* atomicEnter(PyObject *self, PyObject *args){
     ptctx->flags |= PythonThreadCtxFlag_InsideAtomic;
     PyAtomic* pyAtomic = (PyAtomic*)self;
     RedisGears_LockHanlderAcquire(pyAtomic->ctx);
-    RedisModule_Replicate(pyAtomic->ctx, "multi", "");
+    if (redisVersion->redisMajorVersion < 7) {
+        /* Before Redis 7 we need to manually wrap the atomic
+         * execution with multi exec to make sure the replica
+         * will also perform the commands atomically.
+         * On Redis 7 and above, thanks to this PR:
+         * https://github.com/redis/redis/pull/9890
+         * It is not needed anymore. */
+        RedisModule_Replicate(pyAtomic->ctx, "multi", "");
+    }
     Py_INCREF(self);
     return self;
 }
@@ -1826,7 +1836,10 @@ static PyObject* atomicExit(PyObject *self, PyObject *args){
     }
     ptctx->flags &= ~PythonThreadCtxFlag_InsideAtomic;
     PyAtomic* pyAtomic = (PyAtomic*)self;
-    RedisModule_Replicate(pyAtomic->ctx, "exec", "");
+    if (redisVersion->redisMajorVersion < 7) {
+        /* see comment on atomicEnter */
+        RedisModule_Replicate(pyAtomic->ctx, "exec", "");
+    }
     RedisGears_LockHanlderRelease(pyAtomic->ctx);
     Py_INCREF(Py_None);
     return Py_None;
@@ -6824,6 +6837,8 @@ int RedisGears_OnLoad(RedisModuleCtx *ctx){
         RedisModule_Log(ctx, "warning", "Failed initialize RedisGears API");
         return REDISMODULE_ERR;
     }
+
+    redisVersion = RedisGears_GetRedisVersion();
 
     RedisGears_PluginSetInfoCallback(p, Python_Info);
 

--- a/src/common.c
+++ b/src/common.c
@@ -55,7 +55,7 @@ int GearsCompareVersions(RedisVersion v1, RedisVersion v2) {
     return 0;
 }
 
-int GearsCheckSupportedVestion(){
+int GearsCheckSupportedVersion(){
     if (GearsCompareVersions(currVesion, supportedVersion) < 0) {
         return REDISMODULE_ERR;
     }

--- a/src/common.h
+++ b/src/common.h
@@ -10,6 +10,7 @@
 #include "version.h"
 #include "utils/dict.h"
 #include "redismodule.h"
+#include "redisgears.h"
 #include "cluster.h"
 
 #include "utils/arr_rm_alloc.h"
@@ -27,12 +28,6 @@
 #define MAX(a,b) (((a)>(b))?(a):(b))
 
 extern Gears_dictType* dictTypeHeapIdsPtr;
-
-typedef struct RedisVersion{
-    int redisMajorVersion;
-    int redisMinorVersion;
-    int redisPatchVersion;
-}RedisVersion;
 
 extern RedisVersion currVesion;
 extern RedisVersion supportedVersion;
@@ -56,7 +51,7 @@ extern RedisModuleCtx *staticCtx;
 	} while(0)
 
 int GearsCompareVersions();
-int GearsCheckSupportedVestion();
+int GearsCheckSupportedVersion();
 void GearsGetRedisVersion();
 void SetId(char* finalId, char* idBuf, char* idStrBuf, long long* lastID);
 int rg_vasprintf(char **__restrict __ptr, const char *__restrict __fmt, va_list __arg);

--- a/src/module.c
+++ b/src/module.c
@@ -824,6 +824,10 @@ static void RG_RegisterLoadingEvent(RedisModuleEventCallback pluginLoadingCallba
 
 }
 
+static RedisVersion* RG_GetRedisVersion() {
+    return &currVesion;
+}
+
 static void RedisGears_OnLoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data){
     if(pluginLoadingCallbacks){
         for(size_t i = 0 ; i < array_len(pluginLoadingCallbacks) ; ++i){
@@ -1149,6 +1153,8 @@ static int RedisGears_RegisterApi(RedisModuleCtx* ctx){
     REGISTER_API(KeysReaderTriggerArgsSetReadRecordCallback, ctx);
     REGISTER_API(KeysReaderRegisterReadRecordCallback, ctx);
 
+    REGISTER_API(GetRedisVersion, ctx);
+
     return REDISMODULE_OK;
 }
 
@@ -1294,7 +1300,7 @@ int RedisGears_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                         gearsRlecMajorVersion, gearsRlecMinorVersion, gearsRlecPatchVersion, gearsRlecBuild);
     }
 
-    if(GearsCheckSupportedVestion() != REDISMODULE_OK){
+    if(GearsCheckSupportedVersion() != REDISMODULE_OK){
         RedisModule_Log(staticCtx, "warning", "Redis version is to old, please upgrade to redis %d.%d.%d and above.", supportedVersion.redisMajorVersion,
                                                                                                                 supportedVersion.redisMinorVersion,
                                                                                                                 supportedVersion.redisPatchVersion);

--- a/src/redisgears.h
+++ b/src/redisgears.h
@@ -29,6 +29,12 @@
 #pragma clang diagnostic ignored "-Wunused-function"
 #endif
 
+typedef struct RedisVersion{
+    int redisMajorVersion;
+    int redisMinorVersion;
+    int redisPatchVersion;
+}RedisVersion;
+
 #define ID_LEN REDISMODULE_NODE_ID_LEN + sizeof(long long) + 1 // the +1 is for the \0
 #define STR_ID_LEN  REDISMODULE_NODE_ID_LEN + 13
 
@@ -555,6 +561,8 @@ typedef void (*AfterConfigSet)(const char* key, const char* val);
 typedef int (*GetConfig)(const char* key, RedisModuleCtx* ctx);
 GEARS_API void MODULE_API_FUNC(RedisGears_AddConfigHooks)(BeforeConfigSet before, AfterConfigSet after, GetConfig getConfig);
 
+GEARS_API RedisVersion* MODULE_API_FUNC(RedisGears_GetRedisVersion)();
+
 #define REDISGEARS_MODULE_INIT_FUNCTION(ctx, name) \
         RedisGears_ ## name = RedisModule_GetSharedAPI(ctx, "RedisGears_" #name);\
         if(!RedisGears_ ## name){\
@@ -1011,6 +1019,8 @@ static Plugin* RedisGears_Initialize(RedisModuleCtx* ctx, const char* name, int 
     REDISGEARS_MODULE_INIT_FUNCTION(ctx, AddLockStateHandler);
     REDISGEARS_MODULE_INIT_FUNCTION(ctx, AddConfigHooks);
     REDISGEARS_MODULE_INIT_FUNCTION(ctx, RegisterLoadingEvent);
+
+    REDISGEARS_MODULE_INIT_FUNCTION(ctx, GetRedisVersion);
 
     if(RedisGears_GetLLApiVersion() < REDISGEARS_LLAPI_VERSION){
         return NULL;


### PR DESCRIPTION
This PR is for future compatability to Redis 7. Till Redis 7, if commands would have executed from background thread, then Redis would not have wrap them with multi exec and the commands would not have executed atomically on replica. Gears solved
it by propagating multi exec by itself.

Thanks to this PR: https://github.com/redis/redis/pull/9890 It is no longer needed to replicate multi exec, Redis takes care of this for us.