### PR TITLE
Fix globals dictionary not set correctly after deserialization.

### DIFF
--- a/plugins/python/cloudpickle.py
+++ b/plugins/python/cloudpickle.py
@@ -1054,7 +1054,10 @@ def _fill_function(*args):
     #   content of state['globals'] to populate the shared isolated
     #   namespace with all the global variables that are specifically
     #   referenced for this function.
-    func.__globals__.update(state['globals'])
+    #   update only keys that does not exists in the current global dictionary
+    for k,v in state['globals'].items():
+        if k not in func.__globals__.keys():
+            func.__globals__[k] = v
 
     func.__defaults__ = state['defaults']
     func.__dict__ = state['dict']
@@ -1086,7 +1089,7 @@ def _make_empty_cell():
 
     return (lambda: cell).__closure__[0]
 
-
+requested_base_globals = None
 def _make_skel_func(code, cell_count, base_globals=None):
     """ Creates a skeleton function object that contains just the provided
         code and the correct number of cells in func_closure.  All other
@@ -1098,7 +1101,10 @@ def _make_skel_func(code, cell_count, base_globals=None):
     if base_globals is None or isinstance(base_globals, str):
         base_globals = {}
 
-    base_globals['__builtins__'] = __builtins__
+    if requested_base_globals is not None:
+        base_globals = requested_base_globals
+    else:
+        base_globals['__builtins__'] = __builtins__
 
     closure = (
         tuple(_make_empty_cell() for _ in range(cell_count))

--- a/plugins/python/redisgears_python.c
+++ b/plugins/python/redisgears_python.c
@@ -5551,6 +5551,15 @@ static void* RedisGearsPy_PyCallbackDeserialize(FlatExecutionPlan* fep, Gears_Bu
         return NULL;
     }
     RedisGearsPy_LOCK
+
+    if(fep){
+        /* set requested_base_globals, cloud pickle was modified to look at this
+         * variable and if set, use is as the global dictionary for the deserialized
+         * functions. */
+        PythonSessionCtx* sctx = RedisGears_GetFlatExecutionPrivateDataFromFep(fep);
+        PyDict_SetItemString(pyGlobals, "requested_base_globals", sctx->globalsDict);
+    }
+
     size_t len;
     char* data = RedisGears_BRReadBuffer(br, &len);
     PyObject *dataStr = PyBytes_FromStringAndSize(data, len);
@@ -5573,15 +5582,9 @@ static void* RedisGearsPy_PyCallbackDeserialize(FlatExecutionPlan* fep, Gears_Bu
     }
     GearsPyDecRef(args);
 
-    if(fep){
-        // replace the global dictionary with the session global dictionary
-        PythonSessionCtx* sctx = RedisGears_GetFlatExecutionPrivateDataFromFep(fep);
-        PyFunctionObject* callback_func = (PyFunctionObject*)callback;
-        PyDict_Merge(sctx->globalsDict, callback_func->func_globals, 0);
-        GearsPyDecRef(callback_func->func_globals);
-        callback_func->func_globals = sctx->globalsDict;
-        Py_INCREF(callback_func->func_globals);
-    }
+    /* restore requested_base_globals */
+    Py_INCREF(Py_None);
+    PyDict_SetItemString(pyGlobals, "requested_base_globals", Py_None);
 
     RedisGearsPy_UNLOCK
     return callback;

--- a/pytest/test_basics.py
+++ b/pytest/test_basics.py
@@ -788,7 +788,7 @@ def testConfigGetSet(env):
     env.expect('RG.CONFIGSET', 'test', 'test').contains('OK - value was saved in extra config dictionary')
     env.expect('RG.CONFIGGET', 'test').equal(['test'])
 
-@gearsTest(skipOnCluster=True)
+@gearsTest(skipOnCluster=True, envArgs={'moduleArgs': 'CreateVenv 1'})
 def testInfo(env):
     env.expect('RG.PYEXECUTE', "GB('CommandReader').foreach(lambda x: __import__('time').sleep(2)).register(trigger='test')", 'REQUIREMENTS', 'redis').equal('OK')
     env.expect('RG.PYEXECUTE', "GB().foreach(lambda x: __import__('time').sleep(2)).register(eventTypes=['set','hset'], keyTypes=['string', 'hash'], commands=['set', 'hset'])").equal('OK')


### PR DESCRIPTION
The problem
---

After deserialization, the deserialized function are created with its own globals dictionary. We want all the functions on the same execution (and even different execution that was generated by the same `RG.PYEXECUTE` command) to share the same globals dictionary. The current solution is to change the function global dictionary to be the global dictionary of the `PY.EXECUTE` session that created the execution.

This solution only changes the top most function, but it does not change function that is used by it, so the following example will break:

```
g = 1
def f1():
    global g
    g = g + 1
    print(id(globals()))
    return g

def f(x):
    global g
    g = g + 1
    print(id(globals()))
    return f1()

GB('CommandReader').map(f).register(trigger='test', convertToStr=False)
GB('CommandReader').map(f).register(trigger='test1', convertToStr=False)
```

Running `RG.TRIGGER test` and `RG.TRIGGER test1` will give the following:

```
> RG.TRIGGER test
3
> RG.TRIGGER test1
5
```

But after RDB load we will get the following result (that proves that `f1` was created with a different global dictionary):

```
> RG.TRIGGER test
3
> RG.TRIGGER test1
4
```

The solution
---

Modify `cloudpickle` to look for a global variable, `requested_base_globals`. If set, use this dictionary as the global dictionary of all the created functions. RedisGears will make sure to set `requested_base_globals` to the correct value before deserializing a function. In addition, changed `cloudpickle` to update the global dictionary only with the missing fields and not override existing fields. After this change, the above example works as expected.

Test was added to verify the fix.