### PR TITLE
Adding JVM OS as a variable to pull down openjdk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,7 +401,8 @@ workflows:
       - valgrind:
           <<: *on-integ-and-version-tags
       - build-macos:
-          <<: *on-integ-and-version-tags
+        #<<: *on-integ-and-version-tags
+          <<: *on-any-branch
       - deploy-snapshots:
           context: common
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,13 +406,13 @@ workflows:
           context: common
           requires:
             - build-platforms
-            - build-macos
+              #- build-macos
           <<: *on-integ-branch
       - deploy-releases:
           context: common
           requires:
             - build-platforms
-            - build-macos
+              #- build-macos
           <<: *on-version-tags
       - release-automation:
           <<: *on-version-tags

--- a/plugins/jvmplugin/Makefile
+++ b/plugins/jvmplugin/Makefile
@@ -1,6 +1,20 @@
 OS?=$(shell uname -s)
 ARCH?=$(shell uname -m)
 OSNICK?=$(shell ../../deps/readies/bin/platform --osnick)
+OS?=$(shell ../../deps/readies/bin/platform --os)
+ifeq ($(OS),macos)
+JVM_OS=mac
+endif
+ifeq ($(OS),Linux)
+JVM_OS=linux
+endif
+ifeq ($(OS),linux)
+JVM_OS=linux
+endif
+ifndef JVM_OS
+$(error No supported jdk. Exiting)
+endif
+
 GIT_BRANCH=$(shell ../../getbranch)
 VERSION=$(shell ../../getver)
 
@@ -26,7 +40,7 @@ gears_jvm: InstallOpenJDK
 	make -C ./src/
 
 /tmp/openjdk-hotspot.zip:
-	test -f /tmp/opendjk-hotspot.zip || wget -q "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.9.1%2B1/OpenJDK11U-jdk_x64_linux_hotspot_11.0.9.1_1.tar.gz" -O /tmp/openjdk-hotspot.zip
+	test -f /tmp/opendjk-hotspot.zip || wget -q "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.9.1%2B1/OpenJDK11U-jdk_x64_${JVM_OS}_hotspot_11.0.9.1_1.tar.gz" -O /tmp/openjdk-hotspot.zip
 
 InstallOpenJDK: bin/OpenJDK
 


### PR DESCRIPTION
- snapshots do not depend on osx now
- jvmos for osx and linux, validating
