### PR TITLE
Fix #545, check REDISMODULE_CTX_FLAGS_DENY_BLOCKING flag before blocking the client.

### DIFF
--- a/plugins/python/redisgears_python.c
+++ b/plugins/python/redisgears_python.c
@@ -4604,8 +4604,8 @@ static void RedisGearsPy_BackgroundExecute(PythonSessionCtx* session,
 int RedisGearsPy_Execute(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
     int ctxFlags = RedisModule_GetContextFlags(ctx);
 
-    if(ctxFlags & (REDISMODULE_CTX_FLAGS_LUA|REDISMODULE_CTX_FLAGS_MULTI)){
-        RedisModule_ReplyWithError(ctx, "Can not run gear inside multi exec or lua");
+    if(ctxFlags & (REDISMODULE_CTX_FLAGS_LUA|REDISMODULE_CTX_FLAGS_MULTI|REDISMODULE_CTX_FLAGS_DENY_BLOCKING)){
+        RedisModule_ReplyWithError(ctx, "Can not run gear inside multi exec, lua, or if blocking is not allowed");
         return REDISMODULE_OK;
     }
 

--- a/plugins/python/redisgears_python.c
+++ b/plugins/python/redisgears_python.c
@@ -4605,7 +4605,7 @@ int RedisGearsPy_Execute(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     int ctxFlags = RedisModule_GetContextFlags(ctx);
 
     if(ctxFlags & (REDISMODULE_CTX_FLAGS_LUA|REDISMODULE_CTX_FLAGS_MULTI|REDISMODULE_CTX_FLAGS_DENY_BLOCKING)){
-        RedisModule_ReplyWithError(ctx, "Can not run gear inside multi exec, lua, or if blocking is not allowed");
+        RedisModule_ReplyWithError(ctx, "Can not run gears inside a multi exec, lua, or when blocking is not allowed");
         return REDISMODULE_OK;
     }
 

--- a/pytest/common.py
+++ b/pytest/common.py
@@ -162,6 +162,7 @@ def gearsTest(skipTest=False,
               skipCleanups=False,
               skipOnSingleShard=False,
               skipCallback=None,
+              skipOnRedis6=False,
               envArgs={}):
     def test_func_generator(test_function):
         def test_func():
@@ -184,7 +185,10 @@ def gearsTest(skipTest=False,
                 # able to execute commands on shards, on slow envs, run with valgrind,
                 # or mac, it is needed.
                 env.broadcast('CONFIG', 'set', 'cluster-node-timeout', '60000')
-            getConnectionByEnv(env)
+            conn = getConnectionByEnv(env)
+            version = conn.execute_command('info', 'server')['redis_version']
+            if skipOnRedis6 and '6.0' in version:
+                env.skip()
             test_function(env)
             if not skipCleanups:
                 dropRegistrationsAndExecutions(env)

--- a/pytest/test_async.py
+++ b/pytest/test_async.py
@@ -1141,7 +1141,7 @@ GB('CommandReader').map(c).register(trigger='test')
     env.expect('MULTI').equal('OK')
     env.expect('RG.TRIGGER', 'test').equal('QUEUED')
     res = env.cmd('EXEC')
-    env.assertIn('can not run a none sync execution inside MULTI/LUA', str(res[0]))
+    env.assertIn('can not run a non-sync execution inside a MULTI/LUA', str(res[0]))
     
 @gearsTest()
 def testAsyncWithoutWait(env):

--- a/pytest/test_basics.py
+++ b/pytest/test_basics.py
@@ -845,3 +845,21 @@ def test1676(env):
 
     time.sleep(0.1) # make sure shard did not crash
     env.expect('ping').equal(True)
+
+@gearsTest(skipOnCluster=True)
+def testRecursiveGearsBuilder(env):
+    env.cmd('set', 'x', '1')
+    res = env.cmd('RG.PYEXECUTE', "GearsBuilder().map(lambda x: execute('RG.PYEXECUTE', 'GearsBuilder().run()')).run()")
+    env.assertContains('blocking is not allowed', res[1][0])
+
+@gearsTest(skipOnCluster=True)
+def testOverrideSetWithAsyncExecution(env):
+    env.expect('RG.PYEXECUTE', "GearsBuilder('CommandReader').register(hook='set')").equal('OK')
+    res = env.cmd('RG.PYEXECUTE', "GearsBuilder('ShardsIDReader').map(lambda x: execute('set', 'x', '1')).run()")
+    env.assertContains('blocking is not allowed', res[1][0])
+
+@gearsTest(skipOnCluster=True)
+def testKeysReaderCommandsOptionWithAsyncExecution(env):
+    env.expect('RG.PYEXECUTE', "GearsBuilder().foreach(lambda x: override_reply('-no allowed')).register(commands=['set'])").equal('OK')
+    env.expect('set', 'x', '1').error().equal('no allowed')
+    env.expect('RG.PYEXECUTE', "GearsBuilder('ShardsIDReader').map(lambda x: execute('ping')).run()").equal([['PONG'], []])

--- a/pytest/test_basics.py
+++ b/pytest/test_basics.py
@@ -846,19 +846,19 @@ def test1676(env):
     time.sleep(0.1) # make sure shard did not crash
     env.expect('ping').equal(True)
 
-@gearsTest(skipOnCluster=True)
+@gearsTest(skipOnCluster=True, skipOnRedis6=True)
 def testRecursiveGearsBuilder(env):
     env.cmd('set', 'x', '1')
     res = env.cmd('RG.PYEXECUTE', "GearsBuilder().map(lambda x: execute('RG.PYEXECUTE', 'GearsBuilder().run()')).run()")
     env.assertContains('blocking is not allowed', res[1][0])
 
-@gearsTest(skipOnCluster=True)
+@gearsTest(skipOnCluster=True, skipOnRedis6=True)
 def testOverrideSetWithAsyncExecution(env):
     env.expect('RG.PYEXECUTE', "GearsBuilder('CommandReader').register(hook='set')").equal('OK')
     res = env.cmd('RG.PYEXECUTE', "GearsBuilder('ShardsIDReader').map(lambda x: execute('set', 'x', '1')).run()")
     env.assertContains('blocking is not allowed', res[1][0])
 
-@gearsTest(skipOnCluster=True)
+@gearsTest(skipOnCluster=True, skipOnRedis6=True)
 def testKeysReaderCommandsOptionWithAsyncExecution(env):
     env.expect('RG.PYEXECUTE', "GearsBuilder().foreach(lambda x: override_reply('-no allowed')).register(commands=['set'])").equal('OK')
     env.expect('set', 'x', '1').error().equal('no allowed')

--- a/src/readers/command_reader.c
+++ b/src/readers/command_reader.c
@@ -1011,7 +1011,7 @@ static int CommandReader_Trigger(RedisModuleCtx *ctx, RedisModuleString **argv, 
        (ctxFlags & REDISMODULE_CTX_FLAGS_LUA) ||
        (ctxFlags & REDISMODULE_CTX_FLAGS_DENY_BLOCKING)){
         if(crtCtx->mode != ExecutionModeSync){
-            RedisModule_ReplyWithError(ctx, "ERR can not run a none sync execution inside MULTI/LUA (blocking is not allowed) or on loading.");
+            RedisModule_ReplyWithError(ctx, "ERR can not run a non-sync execution inside a MULTI/LUA (blocking is not allowed) or on loading.");
             return REDISMODULE_OK;
         }
         runFlags |= RFNoAsync;

--- a/src/readers/keys_reader.c
+++ b/src/readers/keys_reader.c
@@ -971,7 +971,8 @@ static int KeysReader_OnKeyTouched(RedisModuleCtx *ctx, int type, const char *ev
                     // check if we are allow to block
                     int ctxFlags = RedisModule_GetContextFlags(currCmdCtx->clientCtx);
                     if((ctxFlags & REDISMODULE_CTX_FLAGS_MULTI) ||
-                            (ctxFlags & REDISMODULE_CTX_FLAGS_LUA)){
+                       (ctxFlags & REDISMODULE_CTX_FLAGS_LUA) ||
+                       (ctxFlags & REDISMODULE_CTX_FLAGS_DENY_BLOCKING)){
                         // we are not allow to block, we will free the cmdCtx
                         KeyReader_CommandCtxFree(cmdCtx);
                         arg->cmdCtx = NULL;


### PR DESCRIPTION
Fix #545, check REDISMODULE_CTX_FLAGS_DENY_BLOCKING flag before blocking the client.

We check it on 3 places and act as if we run in MULTI/EXEC or Lua script:
1. RG.PYEXECUTE
2. Command override
3. Keys Reader commands option