### PR TITLE
Fix hashtag() function on enterprise.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -783,6 +783,10 @@ const char* Cluster_GetMyHashTag(){
     if(RedisModule_ShardingGetSlotRange){
         int first, last;
         RedisModule_ShardingGetSlotRange(&first, &last);
+        if (first < 0) {
+            /* first < 0 means we are on a single shard database, set first=0 */
+            first = 0;
+        }
         return slot_table[first];
     }
 


### PR DESCRIPTION
On a single shard enterprise database, RedisModule_ShardingGetSlotRange will return first and last slot as -1. In this case, set it to 0 (return string that matches the first slot).