### PR TITLE
Removing active OS check

### DIFF
--- a/plugins/python/redisgears_python.c
+++ b/plugins/python/redisgears_python.c
@@ -498,10 +498,6 @@ static PythonRequirementCtx* PythonRequirementCtx_Deserialize(Gears_BufferReader
             *err = RG_STRDUP("Bad serialization format on reading requirement os");
             goto done;
         }
-        if(strcmp(os, RedisGears_GetCompiledOs()) != 0){
-            RedisGears_ASprintf(err, "Requirement was compiled on different os (compiled_os = %s, current_os = %s)", os, RedisGears_GetCompiledOs());
-            goto done;
-        }
     }
 
     long nWheels = RedisGears_BRReadLong(br);


### PR DESCRIPTION
Given that we compile for each target OS, on the OS itself, this check should not be present. It limits (for example) the ability to use Oracle8 for Centos8