### PR TITLE
Locale change, as a result of the build error

### DIFF
--- a/pack.sh
+++ b/pack.sh
@@ -11,6 +11,7 @@ export READIES=$ROOT/deps/readies
 cd $ROOT
 
 export PYTHONWARNINGS=ignore
+export LC_CTYPE=en_US.UTF-8
 
 #----------------------------------------------------------------------------------------------
 


### PR DESCRIPTION

The build used to error as below. This locale change should solve that.

```
This system supports the C.UTF-8 locale which is recommended. You might be able to resolve your issue by exporting the following environment variables:

    export LC_ALL=C.UTF-8
    export LANG=C.UTF-8
```
