### PR TITLE
Pause/Unpause registrations

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -28,6 +28,8 @@ The following sections describe the supported commands.
 | [`RG.TRIGGERONKEY`](#rgtriggeronkey) | Triggers execution of registration on a given key |
 | [`RG.UNREGISTER`](#rgunregister) | Removes registration |
 | [`RG.CLEARREGISTRATIONSSTATS`](#rgclearregistrationsstats) | Clears stats from all registrations |
+| [`RG.PAUSEREGISTRATIONS`](#rgpauseregistrations) | Pause a registrations by ids |
+| [`RG.UNPAUSEREGISTRATIONS`](#rgunpauseregistrations) | Unpause a registrations by ids |
 
 **Syntax Conventions**
 
@@ -841,4 +843,36 @@ RG.CREARREGISTRATIONSSTATS
 _Return_
 
 A simple 'OK' string.
+
+## RG.PAUSEREGISTRATIONS
+The **RG.PAUSEREGISTRATIONS** command pause a given registrations from triggering any more events. **Currently its only possible to pause a stream registrations**. pause a registration that already pause is consider as no op and will keep the state exactly as it is (without any errors). pause is considered an atomic operation, all the registrations that was given will be pause together and if one failed, the entire operation is aborted (atomicity is promised on the shard level and not on the cluster level).
+
+It is also possible to pause the registration from within the registration code itself by returning a special error message that starts with `PAUSE` string (message must be raised with [flatError](runtime.md#flat-error) api so the error trace will not be added to the error message), example:
+
+```python
+GB('StreamReader').foreach(lambda x: flatError('PAUSE registration is paused')).register()
+```
+
+**Redis API**
+
+```
+RG.PAUSEREGISTRATIONS id1 [id2 ...]
+```
+
+_Return_
+
+A simple 'OK' string. Or error if operation failed.
+
+## RG.UNPAUSEREGISTRATIONS
+The **RG.UNPAUSEREGISTRATIONS** command unpause a given registrations and cause it to restart triggering events. **Currently its only possible to unpause a stream registrations**. Unpause a registration that already running is consider as no op and will keep the state exactly as it is (without any errors). Unpause is considered an atomic operation, all the registrations that was given will be unpause together and if one failed, the entire operation is aborted (atomicity is promised on the shard level and not on the cluster level). Unpausing a registration will restart processing data from the stream, if the stream is not set to trim messages (using trimStream option) then all the element will potentially be processed again.
+
+**Redis API**
+
+```
+RG.UNPAUSEREGISTRATIONS id1 [id2 ...]
+```
+
+_Return_
+
+A simple 'OK' string. Or error if operation failed.
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -261,3 +261,18 @@ def override_reply(reply)
 _Arguments_
 
 * reply: the new reply to send to the client. If the reply starts with `-` it will be returned as error reply. If the reply starts with `+` it will be returned as a status reply.
+
+## flat_error
+The `flat_error` function is imported to the runtime's environment by default.
+This function raise a special exception type that instructs gears not to extract the error stack trace.
+
+**Python API**
+
+```python
+def flat_error(msg)
+```
+
+_Arguments_
+
+* msg: The error msg to add as is in the execution error list.
+

--- a/plugins/jvmplugin/pytest/test_stream_reader.py
+++ b/plugins/jvmplugin/pytest/test_stream_reader.py
@@ -17,4 +17,4 @@ def testStreamReaderFromId(env, conn, results, **kargs):
 @jvmTestDecorator()
 def testStreamRegisterArgs(env, **kargs):
 	res = env.cmd('RG.DUMPREGISTRATIONS')
-	env.assertEqual(res[0][7][23], ['batchSize', 100, 'durationMS', 1000, 'stream', 's'])
+	env.assertEqual(res[0][7][23], ['batchSize', 100, 'durationMS', 1000, 'stream', 's', 'trimStream', 0, 'onFailedPolicy', 'retry', 'retryInterval', 5000])

--- a/plugins/python/GearsBuilder.py
+++ b/plugins/python/GearsBuilder.py
@@ -171,16 +171,16 @@ class GearsBuilder():
             arg = createKeysOnlyReader(arg, **kargs)
         return self.gearsCtx.run(arg, **kargs)
 
-    def register(self, prefix='*', convertToStr=True, collect=True, **kargs):
+    def register(self, prefix='*', convertToStr=True, collect=True, **kwargs):
         if(convertToStr):
             self.gearsCtx.map(lambda x: str(x))
         if(collect):
             self.gearsCtx.collect()
-        kargs['prefix'] = prefix # this is for backword comptability
-        if 'regex' in kargs:
+        kwargs['prefix'] = prefix # this is for backword comptability
+        if 'regex' in kwargs:
             log('Using regex argument with register is deprecated and missleading, use prefix instead.', level='warning')
-            kargs['prefix'] = kargs['regex']
-        return self.gearsCtx.register(**kargs)
+            kwargs['prefix'] = kwargs['regex']
+        return self.gearsCtx.register(**kwargs)
 
 def createDecorator(f):
     def deco(self, *args):

--- a/plugins/python/GearsBuilder.py
+++ b/plugins/python/GearsBuilder.py
@@ -21,7 +21,7 @@ from redisgears import isInAtomicBlock
 from redisgears import config_get as configGet
 from redisgears import PyFlatExecution
 from redisgears import isAsyncAllow as isAsyncAllow
-from redisgears import flatError as flatError
+from redisgears import flatError as flat_error
 import asyncio
 from asyncio.futures import Future
 from threading import Thread

--- a/plugins/python/GearsBuilder.py
+++ b/plugins/python/GearsBuilder.py
@@ -21,6 +21,7 @@ from redisgears import isInAtomicBlock
 from redisgears import config_get as configGet
 from redisgears import PyFlatExecution
 from redisgears import isAsyncAllow as isAsyncAllow
+from redisgears import flatError as flatError
 import asyncio
 from asyncio.futures import Future
 from threading import Thread

--- a/plugins/python/GearsBuilder.py
+++ b/plugins/python/GearsBuilder.py
@@ -179,7 +179,7 @@ class GearsBuilder():
         if 'regex' in kargs:
             log('Using regex argument with register is deprecated and missleading, use prefix instead.', level='warning')
             kargs['prefix'] = kargs['regex']
-        self.gearsCtx.register(**kargs)
+        return self.gearsCtx.register(**kargs)
 
 def createDecorator(f):
     def deco(self, *args):

--- a/pytest/test_basics.py
+++ b/pytest/test_basics.py
@@ -841,7 +841,7 @@ def test1676(env):
     env.expect('RG.PYEXECUTE', "GB('StreamReader').map(lambda x: test()).register(onFailedPolicy='abort')").equal('OK')
     env.cmd('xadd', 's1', '*', 'foo', 'bar')
     env.cmd('XTRIM', 's1', 'MAXLEN', '0')
-    env.expect('RG.PYEXECUTE', "GB('StreamReader').map(lambda x: test()).register(onFailedPolicy='abort')").equal('OK')
+    # env.expect('RG.PYEXECUTE', "GB('StreamReader').map(lambda x: test()).register(onFailedPolicy='abort')").equal('OK')
 
     time.sleep(0.1) # make sure shard did not crash
     env.expect('ping').equal(True)

--- a/pytest/test_basics.py
+++ b/pytest/test_basics.py
@@ -841,7 +841,7 @@ def test1676(env):
     env.expect('RG.PYEXECUTE', "GB('StreamReader').map(lambda x: test()).register(onFailedPolicy='abort')").equal('OK')
     env.cmd('xadd', 's1', '*', 'foo', 'bar')
     env.cmd('XTRIM', 's1', 'MAXLEN', '0')
-    # env.expect('RG.PYEXECUTE', "GB('StreamReader').map(lambda x: test()).register(onFailedPolicy='abort')").equal('OK')
+    env.expect('RG.PYEXECUTE', "GB('StreamReader').map(lambda x: test()).register(onFailedPolicy='abort')").equal('OK')
 
     time.sleep(0.1) # make sure shard did not crash
     env.expect('ping').equal(True)

--- a/pytest/test_errors.py
+++ b/pytest/test_errors.py
@@ -181,7 +181,7 @@ def testCommandReaderRegisterWithExcpetionCommand(env):
     env.expect('rg.pyexecute', 'GB("CommandReader").foreach(lambda x: noexists).register(trigger="command")').ok()
     env.expect('rg.trigger', 'command').error().contains("'noexists' is not defined")
 
-@gearsTest()
+@gearsTest(envArgs={'moduleArgs': 'CreateVenv 1'})
 def testNoSerializableRegistrationWithAllReaders(env):
     script = '''
 import redis

--- a/pytest/test_rdb_compatibility.py
+++ b/pytest/test_rdb_compatibility.py
@@ -18,7 +18,7 @@ class RdbMetaData:
 
 RDBS = [
     RdbMetaData(fileName='redisgears_1.0.0.rdb', nRegistrations=1, nExecutions=0),
-    RdbMetaData(fileName='redisgears_1.0.0_2.rdb', nRegistrations=3, nExecutions=2)
+    RdbMetaData(fileName='redisgears_1.0.0_2.rdb', nRegistrations=3, nExecutions=1)
 ]
 
 def downloadFiles():

--- a/pytest/test_register.py
+++ b/pytest/test_register.py
@@ -273,7 +273,7 @@ GB('StreamReader').map(InfinitLoop).register('s', mode='async_local', onFailedPo
             done = False
             while not done:
                 registrationInfo = env.cmd('RG.DUMPREGISTRATIONS')
-                if registrationInfo[0][7][3] == 3 and registrationInfo[0][7][5] == 3:
+                if registrationInfo[0][7][3] == 2 and registrationInfo[0][7][5] == 2:
                     done = True
                 time.sleep(0.1)
     except Exception as e:
@@ -292,7 +292,7 @@ GB('StreamReader').map(InfinitLoop).register('s', mode='async_local', onFailedPo
             done = False
             while not done:
                 registrationInfo = env.cmd('RG.DUMPREGISTRATIONS')
-                if registrationInfo[0][7][3] == 7 and registrationInfo[0][7][5] == 5:
+                if registrationInfo[0][7][3] == 5 and registrationInfo[0][7][5] == 4:
                     done = True
                 time.sleep(0.1)
     except Exception as e:
@@ -302,9 +302,9 @@ GB('StreamReader').map(InfinitLoop).register('s', mode='async_local', onFailedPo
     eid = env.cmd('rg.pyexecute', 'GB("KeysOnlyReader").run()', 'UNBLOCKING')
 
     executionsInfo = env.cmd('RG.DUMPEXECUTIONS')
-    env.assertEqual(len([a[3] for a in executionsInfo if a[3] == 'done']), 5)
+    env.assertEqual(len([a[3] for a in executionsInfo if a[3] == 'done']), 4)
     env.assertEqual(len([a[3] for a in executionsInfo if a[3] == 'running']), 1)
-    env.assertEqual(len([a[3] for a in executionsInfo if a[3] == 'created']), 2)
+    env.assertEqual(len([a[3] for a in executionsInfo if a[3] == 'created']), 1)
 
     env.expect('RG.UNREGISTER', registrationId, 'abortpending').ok()
 

--- a/pytest/test_register.py
+++ b/pytest/test_register.py
@@ -1819,7 +1819,7 @@ def testPauseFromWithinTheRegistrationCode(env):
 def foreachFunc(x):
     isPaused = execute('get', 'paused{%s}' % (x['key']))
     if isPaused == 'yes':
-        flatError('PAUSE')
+        flat_error('PAUSE')
     execute('incr', 'counter{%s}' % (x['key']))
 
 regId = GB('StreamReader').foreach(foreachFunc).register(mode='sync')

--- a/src/commands.c
+++ b/src/commands.c
@@ -13,6 +13,7 @@ static ExecutionThreadPool* mgmtPool;
 static WorkerData* mgmtWorker;
 
 #define STRING_TYPE_VERSION 1
+#define PAUSE_REGISTRATIONS_TYPE_VERSION 1
 
 void Command_ReturnResult(RedisModuleCtx* rctx, Record* record){
     RG_RecordSendReply(record, rctx);
@@ -602,6 +603,189 @@ int Command_Register(SessionRegistrationCtx* srctx, SessionRegistrationCtx_OnDon
     return REDISMODULE_OK;
 }
 
+typedef enum PauseRegistrations{
+    PauseRegistrations_Pause = 0, PauseRegistrations_Unpause
+} PauseRegistrationsOp;
+
+typedef struct PauseRegistrationsArg {
+    int abortPendings;
+    char **registrations;
+    PauseRegistrationsOp op;
+} PauseRegistrationsArg;
+
+static void Command_pauseRegistrationsArgFree(FlatExecutionPlan* fep, void* arg){
+    PauseRegistrationsArg *pauseRegistrationsArg = arg;
+    for (size_t i = 0 ; i < array_len(pauseRegistrationsArg->registrations) ; ++i) {
+        RG_FREE(pauseRegistrationsArg->registrations[i]);
+    }
+    array_free(pauseRegistrationsArg->registrations);
+    RG_FREE(pauseRegistrationsArg);
+}
+
+static void* Command_pauseRegistrationsArgDup(FlatExecutionPlan* fep, void* arg){
+    PauseRegistrationsArg *pauseRegistrationsArg = arg;
+    PauseRegistrationsArg *ret = RG_ALLOC(sizeof(*ret));
+    ret->abortPendings = pauseRegistrationsArg->abortPendings;
+    ret->op = pauseRegistrationsArg->op;
+    ret->registrations = array_new(char*, 5);
+    for (size_t i = 0 ; i < array_len(pauseRegistrationsArg->registrations) ; ++i) {
+        ret->registrations = array_append(ret->registrations, RG_STRDUP(pauseRegistrationsArg->registrations[i]));
+    }
+    return ret;
+}
+
+static int Command_pauseRegistrationsArgSerialize(FlatExecutionPlan* fep, void* arg, Gears_BufferWriter* bw, char** err){
+    PauseRegistrationsArg *pauseRegistrationsArg = arg;
+    RedisGears_BWWriteLong(bw, pauseRegistrationsArg->abortPendings);
+    RedisGears_BWWriteLong(bw, pauseRegistrationsArg->op);
+    RedisGears_BWWriteLong(bw, array_len(pauseRegistrationsArg->registrations));
+    for (size_t i = 0 ; i < array_len(pauseRegistrationsArg->registrations) ; ++i) {
+        RedisGears_BWWriteString(bw, pauseRegistrationsArg->registrations[i]);
+    }
+    return REDISMODULE_OK;
+}
+
+static void* Command_pauseRegistrationsArgDeserialize(FlatExecutionPlan* fep, Gears_BufferReader* br, int version, char** err){
+    if(version > PAUSE_REGISTRATIONS_TYPE_VERSION){
+        return NULL;
+    }
+    PauseRegistrationsArg *ret = RG_ALLOC(sizeof(*ret));
+    ret->abortPendings = RedisGears_BRReadLong(br);
+    ret->op = RedisGears_BRReadLong(br);
+    size_t numRegistrations = RedisGears_BRReadLong(br);
+    ret->registrations = array_new(char*, numRegistrations);
+    for (size_t i = 0 ; i < numRegistrations ; ++i) {
+        const char *registrationId = RedisGears_BRReadString(br);
+        ret->registrations = array_append(ret->registrations, RG_STRDUP(registrationId));
+    }
+    return ret;
+}
+
+static char* Command_pauseRegistrationsArgToString(FlatExecutionPlan* fep, void* arg){
+    return RG_STRDUP("PauseRegistrationsArg");
+}
+
+static Record* Command_PauseRegistrationsMap(ExecutionCtx* rctx, Record *data, void* arg){
+    PauseRegistrationsArg *pauseRegistrationsArg = arg;
+    Record *ret = NULL;
+    char *err = NULL;
+    RedisGears_FreeRecord(data);
+
+    FlatExecutionPlan **feps = array_new(FlatExecutionPlan*, array_len(pauseRegistrationsArg->registrations));
+    LockHandler_Acquire(staticCtx);
+    for (size_t i = 0 ; i < array_len(pauseRegistrationsArg->registrations) ; ++i) {
+        FlatExecutionPlan *fep = RedisGears_GetFepById(pauseRegistrationsArg->registrations[i]);
+        if (!fep) {
+            RedisGears_ASprintf(&err, "Execution %s does not exists on shard %s", pauseRegistrationsArg->registrations[i], Cluster_GetMyId());
+            goto done;
+        }
+
+        RedisGears_ReaderCallbacks* callbacks = ReadersMgmt_Get(fep->reader->reader);
+
+        if(pauseRegistrationsArg->op == PauseRegistrations_Pause && !callbacks->pauseTrigger){
+            RedisGears_ASprintf(&err, "Reader %s does not support pause", fep->reader->reader);
+            goto done;
+        }
+
+        if(pauseRegistrationsArg->op == PauseRegistrations_Unpause && !callbacks->unpauseTrigger){
+            RedisGears_ASprintf(&err, "Reader %s does not support unpause", fep->reader->reader);
+            goto done;
+        }
+
+        feps = array_append(feps, fep);
+    }
+
+    for (size_t i = 0 ; i < array_len(feps) ; ++i) {
+        FlatExecutionPlan *fep = feps[i];
+        RedisGears_ReaderCallbacks* callbacks = ReadersMgmt_Get(fep->reader->reader);
+        if(pauseRegistrationsArg->op == PauseRegistrations_Pause) {
+            callbacks->pauseTrigger(fep, pauseRegistrationsArg->abortPendings);
+        } else if(pauseRegistrationsArg->op == PauseRegistrations_Unpause) {
+            callbacks->unpauseTrigger(fep);
+        }
+    }
+
+done:
+    if (err) {
+        RedisGears_SetError(rctx, err);
+    } else {
+        ret = RedisGears_StringRecordCreate(RG_STRDUP("OK"), strlen("OK"));
+    }
+    array_free(feps);
+    LockHandler_Release(staticCtx);
+    return ret;
+}
+
+int Command_PauseOrUnpausedRegistrations(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
+    if(argc != 2){
+        return RedisModule_WrongArity(ctx);
+    }
+
+    VERIFY_CLUSTER_INITIALIZE(ctx);
+
+    PauseRegistrationsArg *pauseArg = RG_ALLOC(sizeof(*pauseArg));
+    pauseArg->abortPendings = 0;
+    pauseArg->registrations = array_new(char*, 5);
+
+    const char* op = RedisModule_StringPtrLen(argv[0], NULL);
+    if(strcasecmp(op, "rg.pauseregistrations") == 0) {
+        pauseArg->op = PauseRegistrations_Pause;
+    } else if(strcasecmp(op, "rg.unpauseregistrations") == 0){
+        pauseArg->op = PauseRegistrations_Unpause;
+    } else {
+        RedisModule_Assert(false);
+    }
+
+    size_t currArg = 1;
+    if (pauseArg->op == PauseRegistrations_Pause) {
+        // currently only RG.PAUSEREGISTRATIONS has extra arguments
+        for(; currArg < argc ; ++currArg) {
+            const char* option = RedisModule_StringPtrLen(argv[currArg], NULL);
+            if(strcasecmp(option, "ABORTPENDING") == 0){
+                pauseArg->abortPendings = 1;
+                continue;
+            }
+            break;
+        }
+    }
+
+    for(; currArg < argc ; ++currArg) {
+        const char *regId = RedisModule_StringPtrLen(argv[currArg], NULL);
+        pauseArg->registrations = array_append(pauseArg->registrations, RG_STRDUP(regId));
+    }
+
+    if (array_len(pauseArg->registrations) == 0) {
+        RedisModule_ReplyWithError(ctx, "ERR no registration to pause");
+        Command_pauseRegistrationsArgFree(NULL, pauseArg);
+        return REDISMODULE_OK;
+    }
+
+    char* err = NULL;
+    FlatExecutionPlan* fep = RGM_CreateCtx(ShardIDReader, &err);
+    if(!fep){
+        if(!err){
+            err = RG_STRDUP("ERR Failed creating abort Flat Execution Plan");
+        }
+        RedisModule_ReplyWithError(ctx, err);
+        RG_FREE(err);
+        return REDISMODULE_OK;
+    }
+    RGM_Map(fep, Command_PauseRegistrationsMap, pauseArg);
+    RGM_Collect(fep);
+    ExecutionPlan* ep = RedisGears_Run(fep, ExecutionModeAsync, NULL, NULL, NULL, mgmtWorker, &err);
+    if(!ep){
+        RedisModule_ReplyWithError(ctx, err);
+        RG_FREE(err);
+    } else {
+        RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
+        RedisGears_AddOnDoneCallback(ep, Command_Done, bc);
+    }
+
+    RedisGears_FreeFlatExecution(fep);
+
+    return REDISMODULE_OK;
+}
+
 int Command_Init(){
     mgmtPool = ExecutionPlan_CreateThreadPool("MgmtPool", 1);
     mgmtWorker = ExecutionPlan_CreateWorker(mgmtPool);
@@ -613,10 +797,19 @@ int Command_Init(){
                                                 Command_StringDeserialize,
                                                 Command_StringToString,
                                                 NULL);
+    ArgType* pauseRegistrationArgType = RedisGears_CreateType("PauseRegistrations",
+                                                           PAUSE_REGISTRATIONS_TYPE_VERSION,
+                                                           Command_pauseRegistrationsArgFree,
+                                                           Command_pauseRegistrationsArgDup,
+                                                           Command_pauseRegistrationsArgSerialize,
+                                                           Command_pauseRegistrationsArgDeserialize,
+                                                           Command_pauseRegistrationsArgToString,
+                                                           NULL);
     RGM_RegisterMap(Command_AbortExecutionMap, stringType);
     RGM_RegisterMap(Command_FlushRegistrationsStatsMap, NULL);
     RGM_RegisterMap(Command_SingleShardGetter, stringType);
     RGM_RegisterMap(Command_MirrorMapper, NULL);
+    RGM_RegisterMap(Command_PauseRegistrationsMap, pauseRegistrationArgType);
 
     ArgType* registrationSessionType = RedisGears_CreateType("RegistrationSessionDT",
                                                     STRING_TYPE_VERSION,

--- a/src/commands.h
+++ b/src/commands.h
@@ -22,6 +22,7 @@ int Command_GetResults(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int Command_GetResultsBlocking(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int Command_ExecutionGet(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int Command_Register(SessionRegistrationCtx* srctx, SessionRegistrationCtx_OnDone onDone, void *pd, char **err);
+int Command_PauseOrUnpausedRegistrations(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 int Command_Init();
 

--- a/src/execution_plan.c
+++ b/src/execution_plan.c
@@ -2349,7 +2349,7 @@ static void ExecutionPlan_LocalUnregisterExecutionInternal(FlatExecutionPlan* fe
 
     // call unregister callback
     if(fep->onUnregisteredStep.stepName){
-        RedisGears_FlatExecutionOnRegisteredCallback onUnregistered = FlatExecutionOnUnregisteredsMgmt_Get(fep->onUnregisteredStep.stepName);
+        RedisGears_FlatExecutionOnUnregisteredCallback onUnregistered = FlatExecutionOnUnregisteredsMgmt_Get(fep->onUnregisteredStep.stepName);
         RedisModule_Assert(onUnregistered);
         onUnregistered(fep, fep->onUnregisteredStep.arg.stepArg);
     }

--- a/src/module.c
+++ b/src/module.c
@@ -1558,6 +1558,16 @@ int RedisGears_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return REDISMODULE_ERR;
     }
 
+    if (RedisModule_CreateCommand(ctx, "rg.pauseregistrations", Command_PauseOrUnpausedRegistrations, "readonly", 0, 0, 0) != REDISMODULE_OK) {
+        RedisModule_Log(staticCtx, "warning", "could not register command rg.pauseregistrations");
+        return REDISMODULE_ERR;
+    }
+
+    if (RedisModule_CreateCommand(ctx, "rg.unpauseregistrations", Command_PauseOrUnpausedRegistrations, "readonly", 0, 0, 0) != REDISMODULE_OK) {
+        RedisModule_Log(staticCtx, "warning", "could not register command rg.unpauseregistrations");
+        return REDISMODULE_ERR;
+    }
+
     if (RedisModule_CreateCommand(ctx, "rg.clearregistrationsstats", Command_FlushRegistrationsStats, "readonly", 0, 0, 0) != REDISMODULE_OK) {
         RedisModule_Log(staticCtx, "warning", "could not register command rg.clearregistrationsstats");
         return REDISMODULE_ERR;

--- a/src/redisgears.h
+++ b/src/redisgears.h
@@ -178,6 +178,8 @@ typedef Reader* (*RedisGears_CreateReaderCallback)(void* arg);
 typedef int (*RedisGears_ReaderVerifyRegisterCallback)(SessionRegistrationCtx *srctx, FlatExecutionPlan* fep, ExecutionMode mode, void* arg, char** err);
 typedef int (*RedisGears_ReaderRegisterCallback)(FlatExecutionPlan* fep, ExecutionMode mode, void* arg, char** err);
 typedef void (*RedisGears_ReaderUnregisterCallback)(FlatExecutionPlan* fep, bool abortPending);
+typedef void (*RedisGears_ReaderPauseCallback)(FlatExecutionPlan* fep, bool abortPending);
+typedef void (*RedisGears_ReaderUnpauseCallback)(FlatExecutionPlan* fep);
 typedef void (*RedisGears_ReaderSerializeRegisterArgsCallback)(void* arg, Gears_BufferWriter* bw);
 typedef void* (*RedisGears_ReaderDeserializeRegisterArgsCallback)(Gears_BufferReader* br, int encver);
 typedef void (*RedisGears_ReaderFreeArgsCallback)(void* args);
@@ -198,6 +200,8 @@ typedef struct RedisGears_ReaderCallbacks{
     RedisGears_ReaderVerifyRegisterCallback verifyRegister;
     RedisGears_ReaderRegisterCallback registerTrigger;
     RedisGears_ReaderUnregisterCallback unregisterTrigger;
+    RedisGears_ReaderPauseCallback pauseTrigger;
+    RedisGears_ReaderUnpauseCallback unpauseTrigger;
     RedisGears_ReaderSerializeRegisterArgsCallback serializeTriggerArgs;
     RedisGears_ReaderDeserializeRegisterArgsCallback deserializeTriggerArgs;
     RedisGears_ReaderFreeArgsCallback freeTriggerArgs;


### PR DESCRIPTION
Fix #724, add support for registrations pause and unpause.
The PR introduce 2 new commands:

* `RG.PAUSEREGISTRATIONS [ABORTPENDINGS] <ID1> [<ID2> ...]`
* `RG.UNPAUSEREGISTRATIONS <ID1> [<ID2> ...]`

The new commands allows to pause/unpause registration from triggering new executions. Currently, only stream registrations support pausing/unpausing. An attempt to pause/unpause a registration that do not use the stream reader
will raise an error.

It is also possible to unpause a registration from within the registration code by raising a special error containing the `PAUSE` string, example:

```python
GB('StreamReader').foreach(lambda x: flatError('PAUSE registration is paused')).register()
```

pause/unpause a registration that already pause/unpause is consider as no op and will keep the state exactly as it is (without any errors).

pause/unpause is considered an atomic operation, all the registrations that was given will be pause/unpause together and if one failed, the entire operation is aborted (atomicity is promised on the shard level and not on the cluster level).

Unpausing a registration will restart processing data from the stream, **if the stream is not set to trim messages (using `trimStream` option) then all the element will potentially be processed again**.

This PR also fix #722, added `trimStream`, `onFailedPolicy` and `retryInterval` to `RG.DUMPREGISTRATIONS`.

todo:
- [x] Update docs
- [x] Allow pause execution by returning a special error type
- [x] Testing