### PR TITLE
Fix #764, allow disabling costume python allocator using module argument.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,7 +120,7 @@ _Runtime Configurability_
 Supported
 
 ## OverridePythonAllocators
-The **OverridePythonAllocators** configuration option controls whether RedisGears will override the default python memory allocators. By disabling this option the python interpreter can achieve better performance (in some cases we saw improvement of up to 50%), the disadvantage is that the report of [RG.PYSTATS](commands.md#rgpystats) command is no longer valid and Redis will not be able to track and report the memory usage used by the python interpreter.
+The **OverridePythonAllocators** configuration option controls whether RedisGears will override the default python memory allocators. Disabling this option, causes the python interpreter to increase performance (in some cases we saw improvement of up to 50%), the disadvantage is that the output of [RG.PYSTATS](commands.md#rgpystats) becomes invalid, and Redis will be unable to track and report memory usage by the python interpreter.
 
 !!! important "Notice"
     Available sense v1.2.4

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,6 +119,24 @@ _Runtime Configurability_
 
 Supported
 
+## OverridePythonAllocators
+The **OverridePythonAllocators** configuration option controls whether RedisGears will override the default python memory allocators. By disabling this option the python interpreter can achieve better performance (in some cases we saw improvement of up to 50%), the disadvantage is that the report of [RG.PYSTATS](commands.md#rgpystats) command is no longer valid and Redis will not be able to track and report the memory usage used by the python interpreter.
+
+!!! important "Notice"
+    Available sense v1.2.4
+
+_Expected Value_
+
+0 (disabled) or 1 (enabled)
+
+_Default Value_
+
+"1"
+
+_Runtime Configurability_
+
+Not Supported
+
 ## DownloadDeps
 The **DownloadDeps** configuration option determines whether RedisGears will attempt to download missing Python dependencies.
 


### PR DESCRIPTION
Fix #764, allow disabling custom python allocator using module argument.

Introduce a new module argument to disable Redis custom python allocator. The new module argument called `OverridePythonAllocators` and can be set to either `1` or `0`. Disabling custom python allocator allows to achieve better performance (in some cases we saw improvement of up to 50%), the disadvantage is that the report of `RG.PYSTATS` command becomes invalid and Redis will not be able to track and report the memory usage used by the python interpreter.