### PR TITLE
Fix flaky tests by adding MaxIdle time to register session.

### DIFF
--- a/plugins/python/redisgears_python.c
+++ b/plugins/python/redisgears_python.c
@@ -866,6 +866,7 @@ static PythonSessionCtx* PythonSessionCtx_Create(const char *id, const char *des
 
     PythonSessionCtx* session = PythonSessionCtx_CreateWithId(id, desc, requirementsList, requirementsListLen, forceReqReinstallation);
     session->srctx = RedisGears_SessionRegisterCtxCreate(pluginCtx);
+    RedisGears_SessionRegisterSetMaxIdle(session->srctx, pythonConfig.installReqMaxIdleTime);
     return session;
 }
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -580,6 +580,7 @@ int Command_Register(SessionRegistrationCtx* srctx, SessionRegistrationCtx_OnDon
     // a distributed calculation
 
     FlatExecutionPlan* fep = RedisGears_CreateCtx("ShardIDReader", err);
+    RedisGears_SetMaxIdleTime(fep, srctx->maxIdle);
     if (!fep) {
         RedisGears_SessionRegisterCtxFree(srctx);
         return REDISMODULE_ERR;

--- a/src/execution_plan.c
+++ b/src/execution_plan.c
@@ -3993,6 +3993,7 @@ SessionRegistrationCtx* SessionRegistrationCtx_Create(Plugin *p) {
     ret->usedSession = NULL;
     ret->buff = Gears_BufferCreate();
     ret->requireDeserialization = 0;
+    ret->maxIdle = GearsConfig_ExecutionMaxIdleTime();
     Gears_BufferWriterInit(&ret->bw, ret->buff);
     Gears_BufferWriterWriteString(&ret->bw, p->name);
     return ret;

--- a/src/execution_plan.h
+++ b/src/execution_plan.h
@@ -295,6 +295,7 @@ typedef struct SessionRegistrationCtx {
     RegistrationData *registrationsData;
     Gears_Buffer* buff;
     Gears_BufferWriter bw;
+    long long maxIdle;
 } SessionRegistrationCtx;
 
 #define EXECUTION_POOL_SIZE 1

--- a/src/module.c
+++ b/src/module.c
@@ -243,6 +243,10 @@ static void RG_SessionRegisterCtxFree(SessionRegistrationCtx* s) {
     return SessionRegistrationCtx_Free(s);
 }
 
+static void RG_SessionRegisterSetMaxIdle(SessionRegistrationCtx* s, long long maxIdle) {
+    s->maxIdle = maxIdle;
+}
+
 static void RG_AddRegistrationToUnregister(SessionRegistrationCtx* srctx, const char* registrationId) {
     FlatExecutionPlan_AddRegistrationToUnregister(srctx, registrationId);
 }
@@ -1099,6 +1103,7 @@ static int RedisGears_RegisterApi(RedisModuleCtx* ctx){
     REGISTER_API(AddSessionToUnlink, ctx);
     REGISTER_API(SessionRegisterCtxCreate, ctx);
     REGISTER_API(SessionRegisterCtxFree, ctx);
+    REGISTER_API(SessionRegisterSetMaxIdle, ctx);
     REGISTER_API(FreeFlatExecution, ctx);
     REGISTER_API(GetReader, ctx);
     REGISTER_API(StreamReaderCtxCreate, ctx);

--- a/src/redisgears.h
+++ b/src/redisgears.h
@@ -475,6 +475,7 @@ GEARS_API int MODULE_API_FUNC(RedisGears_PrepareForRegister)(SessionRegistration
 GEARS_API int MODULE_API_FUNC(RedisGears_RegisterFep)(Plugin *p, FlatExecutionPlan* fep, ExecutionMode mode, void* key, char** err, char** registrationId);
 GEARS_API SessionRegistrationCtx* MODULE_API_FUNC(RedisGears_SessionRegisterCtxCreate)(Plugin *p);
 GEARS_API void MODULE_API_FUNC(RedisGears_SessionRegisterCtxFree)(SessionRegistrationCtx* srctx);
+GEARS_API void MODULE_API_FUNC(RedisGears_SessionRegisterSetMaxIdle)(SessionRegistrationCtx* s, long long maxIdle);
 GEARS_API int MODULE_API_FUNC(RedisGears_Register)(SessionRegistrationCtx* srctx, SessionRegistrationCtx_OnDone onDone, void *pd, char **err);
 #define RGM_Register(ctx, mode, arg, err) RedisGears_Register(ctx, mode, arg, err, NULL);
 
@@ -908,6 +909,7 @@ static Plugin* RedisGears_Initialize(RedisModuleCtx* ctx, const char* name, int 
     REDISGEARS_MODULE_INIT_FUNCTION(ctx, AddSessionToUnlink);
     REDISGEARS_MODULE_INIT_FUNCTION(ctx, SessionRegisterCtxCreate);
     REDISGEARS_MODULE_INIT_FUNCTION(ctx, SessionRegisterCtxFree);
+    REDISGEARS_MODULE_INIT_FUNCTION(ctx, SessionRegisterSetMaxIdle);
     REDISGEARS_MODULE_INIT_FUNCTION(ctx, ForEach);
     REDISGEARS_MODULE_INIT_FUNCTION(ctx, GroupBy);
     REDISGEARS_MODULE_INIT_FUNCTION(ctx, Collect);


### PR DESCRIPTION
Requirement installation was moved to be part of the session update processes, we need to allow the upgrade processes to continue long enough without a timeout. This PR changes the code to use `PythonInstallReqMaxIdleTime` config value to set the session update MaxIdle time.