### PR TITLE
Fix #791, stop trigger execution on Pause even on failure.

### DIFF
--- a/pytest/test_register.py
+++ b/pytest/test_register.py
@@ -2030,3 +2030,27 @@ GB('CommandReader').map(lambda x: regId).register(mode='sync', trigger='get_reg_
                 time.sleep(0.1)
     except Exception as e:
         pass
+
+@gearsTest(skipOnCluster=True)
+def testStreamReaderPauseFailedRegistration(env):
+    script = '''
+import time
+regId = GB('StreamReader').foreach(lambda x: execute('incr', 'x')).foreach(lambda x: foo()).register(onFailedPolicy='retry')
+GB('CommandReader').map(lambda x: regId).register(mode='sync', trigger='get_reg_id')
+    '''
+    env.expect('rg.pyexecute', script).ok()
+    verifyRegistrationIntegrity(env)
+
+    regId = env.execute_command('RG.TRIGGER', 'get_reg_id')[0]
+
+    env.cmd('xadd', 's', '*', 'foo', 'bar')
+
+    env.expect('RG.PAUSEREGISTRATIONS', regId).ok()
+
+    with TimeLimit(5, env, 'Failed waiting for registration to pause'):
+        while True:
+            registrations = env.cmd('RG.DUMPREGISTRATIONS')
+            stream_registration = [r for r in registrations if r[3] == 'StreamReader'][0]
+            if stream_registration[7][25] == 'PAUSED':
+                break
+            time.sleep(0.1)

--- a/src/readers/streams_reader.c
+++ b/src/readers/streams_reader.c
@@ -674,7 +674,7 @@ static void StreamReader_ExecutionDone(ExecutionPlan* ctx, void* privateData){
         srctx->lastError = RG_STRDUP(RedisGears_StringRecordGet(r, NULL));
 
         if (ssrctx->createdEpoc == srctx->epoc) {
-            if (strncmp(srctx->lastError, "PAUSE", 5) == 0) {
+            if (strncmp(srctx->lastError, "PAUSE", 5) == 0 || srctx->status == StreamRegistrationStatus_PAUSED) {
                 StreamReaderTriggerCtx_CleanSingleStreamsData(srctx);
                 srctx->status = StreamRegistrationStatus_PAUSED;
             } else if(srctx->args->onFailedPolicy != OnFailedPolicyContinue){
@@ -919,7 +919,8 @@ static void StreamReader_PauseTrigger(FlatExecutionPlan* fep, bool abortPending)
     StreamReaderTriggerCtx* srctx = StreamReader_GetStreamTriggerCtxByFep(fep, 0);
     RedisModule_Assert(srctx);
 
-    if (srctx->status == StreamRegistrationStatus_OK) {
+    if (srctx->status == StreamRegistrationStatus_OK ||
+        srctx->status == StreamRegistrationStatus_WAITING_FOR_RETRY_ON_FAILURE) {
         StreamReaderTriggerCtx_CleanSingleStreamsData(srctx);
         srctx->status = StreamRegistrationStatus_PAUSED;
     }


### PR DESCRIPTION
Fix #791, stop trigger execution on Pause even on failure.

If registration was repeatedly fails, pause would have return OK but would not actually stop triggering executions.

The PR fixes it by checking on 2 locations:
1. On the Pause callback itself. Allow pausing even if registration is in error state.
2. When execution finishes and failed, if the registration is pause avoid triggering another execution.