### PR TITLE
Fix #792, trigger execution infinitely when trimming is disabled.

### DIFF
--- a/pytest/test_register.py
+++ b/pytest/test_register.py
@@ -2082,12 +2082,12 @@ GB('StreamReader').foreach(lambda x: execute('incr', 'x')).register(batch=2, onF
             while True:
                 registrations = env.cmd('RG.DUMPREGISTRATIONS')
                 if registrations[0][7][3] > 2:
-                    self.env.assertTrue(False, message='More than 2 executions was triggered')
+                    self.env.assertTrue(False, message='More than 2 executions were triggered')
                     break
                 time.sleep(0.1)
     except Exception as e:
         if 'timeout' not in str(e):
-            print(str(e))
+            sys.stderr.write('%s\n' % str(e))
         env.assertContains('timeout', str(e))
 
     env.cmd('xadd', 's', '*', 'foo', 'bar')
@@ -2098,10 +2098,10 @@ GB('StreamReader').foreach(lambda x: execute('incr', 'x')).register(batch=2, onF
             while True:
                 registrations = env.cmd('RG.DUMPREGISTRATIONS')
                 if registrations[0][7][3] != 3:
-                    self.env.assertTrue(False, message='More than 2 executions was triggered')
+                    self.env.assertTrue(False, message='More than 3 executions were triggered')
                     break
                 time.sleep(0.1)
     except Exception as e:
         if 'timeout' not in str(e):
-            print(str(e))
+            sys.stderr.write('%s\n' % str(e))
         env.assertContains('timeout', str(e))

--- a/pytest/test_register.py
+++ b/pytest/test_register.py
@@ -2061,7 +2061,7 @@ def testStreamReaderInfinitLoopOnTrimmingDisabled(env):
 import time
 GB('StreamReader').foreach(lambda x: execute('incr', 'x')).register(batch=2, onFailedPolicy='retry', trimStream=False)
     '''
-    env.expect('rg.pyexecute', script, 'ID', 'test').ok()
+    env.expect('RG.PYEXECUTE', script, 'ID', 'test').ok()
     verifyRegistrationIntegrity(env)
 
     env.cmd('xadd', 's', '*', 'foo', 'bar')
@@ -2074,7 +2074,7 @@ GB('StreamReader').foreach(lambda x: execute('incr', 'x')).register(batch=2, onF
                 break
             time.sleep(0.1)
 
-    env.expect('rg.pyexecute', script, 'ID', 'test', 'UPGRADE').ok()
+    env.expect('RG.PYEXECUTE', script, 'ID', 'test', 'UPGRADE').ok()
     verifyRegistrationIntegrity(env)
     
     try:

--- a/src/readers/streams_reader.c
+++ b/src/readers/streams_reader.c
@@ -585,6 +585,9 @@ static void StreamReader_TriggerAnotherExecutionIfNeeded(StreamReaderTriggerCtx*
     if (!hasData && !readPending && ssrctx->nextBatch == 0) {
         // Did not processed any data on this batch, and we do not have any new data added.
         // There is not need to trigger another execution.
+        ssrctx->isRunning = false;
+        // it is safe to set pending message to 0 here, we know we are at the end of the stream.
+        ssrctx->pendingMessages = 0;
         return;
     }
     if(srctx->args->batchSize <= ssrctx->pendingMessages){

--- a/src/readers/streams_reader.c
+++ b/src/readers/streams_reader.c
@@ -539,6 +539,10 @@ typedef struct ExecutionDoneCtx{
     SingleStreamReaderCtx ssrctx;
 }ExecutionDoneCtx;
 
+static int StreamReader_HasData(StreamReaderCtx* readerCtx){
+    return array_len(readerCtx->batchIds) > 0;
+}
+
 static void StreamReader_AckAndTrimm(StreamReaderCtx* readerCtx, SingleStreamReaderCtx* ssrctx, bool alsoTrimm){
     if(array_len(readerCtx->batchIds) == 0){
         // nothing to ack on
@@ -572,10 +576,15 @@ static void StreamReader_AckAndTrimm(StreamReaderCtx* readerCtx, SingleStreamRea
     }
 }
 
-static void StreamReader_TriggerAnotherExecutionIfNeeded(StreamReaderTriggerCtx* srctx, SingleStreamReaderCtx* ssrctx){
+static void StreamReader_TriggerAnotherExecutionIfNeeded(StreamReaderTriggerCtx* srctx, SingleStreamReaderCtx* ssrctx, int hasData, int readPending){
     if (!ssrctx->pendingMessages) {
         /* Nothing to run on */
         ssrctx->isRunning = false;
+        return;
+    }
+    if (!hasData && !readPending && ssrctx->nextBatch == 0) {
+        // Did not processed any data on this batch, and we do not have any new data added.
+        // There is not need to trigger another execution.
         return;
     }
     if(srctx->args->batchSize <= ssrctx->pendingMessages){
@@ -738,7 +747,7 @@ static void StreamReader_ExecutionDone(ExecutionPlan* ctx, void* privateData){
             /* only if we are master we should continue trigger events */
             StreamReader_AckAndTrimm(reader->ctx, ssrctx, srctx->args->trimStream);
             if (!ssrctx->isFreeWhenDone) {
-                StreamReader_TriggerAnotherExecutionIfNeeded(srctx, ssrctx);
+                StreamReader_TriggerAnotherExecutionIfNeeded(srctx, ssrctx, StreamReader_HasData(srCtx), srCtx->readPenging);
             } else {
                 ssrctx->isRunning = false;
             }


### PR DESCRIPTION
Fix #792, trigger execution infinitely when trimming is disabled.

When trimming is disabled, if the registration was registered on a stream such that gears consumer group are not point to the beginning of the stream, RedisGears would enter a state where it triggers execution infinitely. Such situation can happened when upgrade a registrations (that has trimming disable) or when loading from RDB (again when trimming disabled).

This happened because RedisGears decides to trigger executions base on the amount of pending data which is calculated by checking the stream length. This check is wrong when trimming is disabled because the stream length is not a good indication to the amount of pending data.

To solve this issue, RedisGears will use a different way to decide if there is more data to processes. If, in the current batch, there was no data to processes and no new data was added to the stream during the batch execution, we know there is
no more data to processes and we avoid trigger another execution.