### PR TITLE
Fix MOD82576, fix invalid memory access when checking if a trigger is already register

### DIFF
--- a/pytest/test_sessions.py
+++ b/pytest/test_sessions.py
@@ -200,7 +200,7 @@ GB('CommandReader').count().map(lambda x: 'test2 reports %s shards' % str(x)).re
 
 @gearsTest(skipOnCluster=True)
 def testMod4054(env):
-    script = '''
+    script = """
 dm_g1 = GearsBuilder()
 dm_g1.register('prefix*', eventTypes=['set', 'change'], readValue=False, mode='sync')
 
@@ -219,7 +219,7 @@ GearsBuilder().register("key", eventTypes=['expired'], noScan=True, readValue=Fa
 
 GB('CommandReader').register(trigger='foo1')
 GB('CommandReader').register(trigger='foo1')
-    '''
+    """
     env.expect('RG.PYEXECUTE', script, 'ID', 'test', 'DESCRIPTION', 'desc').error().contains('trigger already registered')
 
 @gearsTest(skipOnCluster=True)

--- a/pytest/test_sessions.py
+++ b/pytest/test_sessions.py
@@ -199,6 +199,30 @@ GB('CommandReader').count().map(lambda x: 'test2 reports %s shards' % str(x)).re
     env.expect('RG.PYEXECUTE', script, 'ID', 'test', 'DESCRIPTION', 'desc').error().contains('trigger already registered in this session')
 
 @gearsTest(skipOnCluster=True)
+def testMod4054(env):
+    script = '''
+dm_g1 = GearsBuilder()
+dm_g1.register('prefix*', eventTypes=['set', 'change'], readValue=False, mode='sync')
+
+m1_g2 = GearsBuilder('StreamReader')
+m1_g2.register(prefix='foo:*', mode='async_local', trimStream=False) 
+
+m2_g2 = GearsBuilder('StreamReader')
+m2_g2.register(prefix='foo:*', mode='async_local', trimStream=False) 
+
+m3_g2 = GearsBuilder('StreamReader')
+m3_g2.register(prefix='foo:*', mode='async_local', trimStream=False) 
+
+GB('CommandReader').register(trigger='bar')
+
+GearsBuilder().register("key", eventTypes=['expired'], noScan=True, readValue=False, mode='sync')
+
+GB('CommandReader').register(trigger='foo1')
+GB('CommandReader').register(trigger='foo1')
+    '''
+    env.expect('RG.PYEXECUTE', script, 'ID', 'test', 'DESCRIPTION', 'desc').error().contains('trigger already registered')
+
+@gearsTest(skipOnCluster=True)
 def testCommandReaderOverrideCommandWithNoneSyncRegistration(env):
     script = '''
 GB('CommandReader').count().map(lambda x: 'test1 reports %s shards' % str(x)).register(hook='set')

--- a/src/readers/command_reader.c
+++ b/src/readers/command_reader.c
@@ -384,7 +384,7 @@ static int CommandReader_VerifyRegister(SessionRegistrationCtx *srctx, FlatExecu
         if (srctx) {
             for (size_t i = 0 ; i < array_len(srctx->registrationsData) ; ++i) {
                 RegistrationData *rd = srctx->registrationsData + i;
-                RedisGears_ReaderCallbacks* callbacks = ReadersMgmt_Get(fep->reader->reader);
+                RedisGears_ReaderCallbacks* callbacks = ReadersMgmt_Get(rd->fep->reader->reader);
                 if (callbacks->verifyRegister == CommandReader_VerifyRegister) {
                     // another command reader found, check its arguments.
                     CommandReaderTriggerArgs* crtArgs2 = rd->args;
@@ -442,7 +442,7 @@ static int CommandReader_VerifyRegister(SessionRegistrationCtx *srctx, FlatExecu
         if (srctx) {
             for (size_t i = 0 ; i < array_len(srctx->registrationsData) ; ++i) {
                 RegistrationData *rd = srctx->registrationsData + i;
-                RedisGears_ReaderCallbacks* callbacks = ReadersMgmt_Get(fep->reader->reader);
+                RedisGears_ReaderCallbacks* callbacks = ReadersMgmt_Get(rd->fep->reader->reader);
                 if (callbacks->verifyRegister == CommandReader_VerifyRegister) {
                     // another command reader found, check its arguments.
                     CommandReaderTriggerArgs* crtArgs2 = rd->args;


### PR DESCRIPTION
The invalid memory access happened because each registration was examine even if its not a command reader. This causes wrong casting of structs and in rare cases invalid memory access and crash.