### PR TITLE
Return global ExecutionMaxIdleTime as other tests need it.

### DIFF
--- a/pytest/run_tests.sh
+++ b/pytest/run_tests.sh
@@ -52,7 +52,7 @@ run_tests() {
 		local shards_arg="--shards-count $shards"
 		local env="${ENV_PREFIX}-cluster"
 	fi
-	$OP python3 -m RLTest --clear-logs --module $MOD --module-args "Plugin $GEARSPY_PATH" --env $env $shards_arg $MORE_ARGS $TEST_ARGS "$@"
+	$OP python3 -m RLTest --clear-logs --module $MOD --module-args "ExecutionMaxIdleTime 20000 Plugin $GEARSPY_PATH" --env $env $shards_arg $MORE_ARGS $TEST_ARGS "$@"
 }
 
 cd $HERE

--- a/pytest/test_requirements.py
+++ b/pytest/test_requirements.py
@@ -87,7 +87,7 @@ def testDependenciesReplicatedToSlave(env):
 
     slaveConn = env.getSlaveConnection()
     try:
-        with TimeLimit(15):
+        with TimeLimit(20):
             res = []
             while len(res) < 1:
                 res = slaveConn.execute_command('RG.PYDUMPREQS')


### PR DESCRIPTION
Return global ExecutionMaxIdleTime as other tests need it. Increase timeout for unstable replication test.