### PR TITLE
Redis 7 fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -397,7 +397,7 @@ workflows:
           <<: *on-any-branch
           matrix:
             parameters:
-              redis_version: ["6.0.9", "6.2.6"]
+              redis_version: ["6.0.9", "6.2.6", "7.0.4"]
       - build-platforms:
           <<: *on-integ-and-version-tags
           context: common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -397,7 +397,7 @@ workflows:
           <<: *on-any-branch
           matrix:
             parameters:
-              redis_version: ["6.0.9", "6.2.6", "7.0.4"]
+              redis_version: ["6.0.9", "6.2.7", "7.0.4"]
       - build-platforms:
           <<: *on-integ-and-version-tags
           context: common

--- a/plugins/jvmplugin/pytest/test_register.py
+++ b/plugins/jvmplugin/pytest/test_register.py
@@ -87,6 +87,7 @@ def testRegistersReplicatedToSlave(env, conn, **kargs):
     #                         "foreach(lambda x: execute('incrby', 'NumOfKeys', ('1' if 'value' in x.keys() else '-1')))."
     #                         "register()")
 
+    env.expect('wait', '1', '10000').equal(1)
     slaveConn = env.getSlaveConnection()
     try:
         with TimeLimit(5):

--- a/pytest/common.py
+++ b/pytest/common.py
@@ -101,6 +101,7 @@ def verifyRegistrationIntegrity(env):
 def extractInfoOnfailure(env, suffixFileName):
     for i in range(1, env.shardsCount + 1):
         conn = env.getConnection(shardId=i)
+        conn.set_response_callback('info', lambda r: r)
         shardInfo = {}
         shardInfo['RG.DUMPREGISTRATIONS'] = conn.execute_command('RG.DUMPREGISTRATIONS')
         shardInfo['RG.DUMPEXECUTIONS'] = conn.execute_command('RG.DUMPEXECUTIONS')

--- a/pytest/test_register.py
+++ b/pytest/test_register.py
@@ -752,6 +752,8 @@ GB('StreamReader').foreach(FailedOnMaster).register(regex='stream', batch=3, onF
 '''
     if env.envRunner.debugger is not None:
         env.skip() # valgrind is not working correctly with replication
+
+    env.expect('wait', '1', '10000').equal(1)
     slaveConn = env.getSlaveConnection()
     masterConn = env.getConnection()
     env.cmd('rg.pyexecute', script)
@@ -1160,6 +1162,8 @@ def doHset(x):
 
 GB("CommandReader").map(doHset).register(hook="hset", convertToStr=False)
     '''
+    env.expect('wait', '1', '10000').equal(1)
+
     env.expect('rg.pyexecute', script).ok()
 
     env.expect('hset', 'h', 'foo', 'bar').equal(1)

--- a/pytest/test_register.py
+++ b/pytest/test_register.py
@@ -524,7 +524,7 @@ def testRegistersReplicatedToSlave(env):
                             "foreach(lambda x: execute('incrby', 'NumOfKeys', ('1' if 'value' in x.keys() else '-1')))."
                             "register()")
 
-    time.sleep(0.5) # wait for registration to reach all the shards
+    env.expect('wait', '1', '10000').equal(1)
 
     slaveConn = env.getSlaveConnection()
     try:

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -716,7 +716,7 @@ static void Cluster_Refresh(RedisModuleCtx* ctx){
 
         RedisModuleCallReply *nodeDetailsRelpy = RedisModule_CallReplyArrayElement(slotRangeRelpy, 2);
         RedisModule_Assert(RedisModule_CallReplyType(nodeDetailsRelpy) == REDISMODULE_REPLY_ARRAY);
-        RedisModule_Assert(RedisModule_CallReplyLength(nodeDetailsRelpy) == 3);
+        RedisModule_Assert(RedisModule_CallReplyLength(nodeDetailsRelpy) >= 3);
         RedisModuleCallReply *nodeipReply = RedisModule_CallReplyArrayElement(nodeDetailsRelpy, 0);
         RedisModuleCallReply *nodeportReply = RedisModule_CallReplyArrayElement(nodeDetailsRelpy, 1);
         RedisModuleCallReply *nodeidReply = RedisModule_CallReplyArrayElement(nodeDetailsRelpy, 2);


### PR DESCRIPTION
Fix #817. Change refresh cluster to be compatible with Redis 7.
Additional changes:
* Fix tests to be compatible with Redis 7.
* Run with enableDebugCommand on Redis 7.
* Do not crash on info collection on test failure.