### PR TITLE
Bump the MSRV to 1.57.

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  rust_msrv: 1.56.0
+  rust_msrv: 1.57.0
 
 jobs:
   build:

--- a/docs/build_instructions.md
+++ b/docs/build_instructions.md
@@ -75,7 +75,7 @@ export PATH=/home/meir/.cargo/bin:$PATH
 ```
 
 #### MSRV (Minimally Supported Rust Version)
-Currently the edition 2021 of Rust language is used and the MSRV is `1.56`.
+Currently the edition 2021 of Rust language is used and the MSRV is `1.57`.
 
 ## Build_Release
 


### PR DESCRIPTION
The bump is required by the dependency on bindgen.