### PR TITLE
Update the pkg-config paths for macOS.

### DIFF
--- a/.github/workflows/macos_latest.yml
+++ b/.github/workflows/macos_latest.yml
@@ -29,7 +29,7 @@ jobs:
       run: cargo fmt -- --check
     - name: Build
       run: |
-        export PKG_CONFIG_PATH=/usr/local/opt/openssl@1.1/lib/pkgconfig/
+        export PKG_CONFIG_PATH=/opt/homebrew/opt/openssl@1.1/lib/pkgconfig/
         cargo build --verbose
     - name: Tests
       run: cd pytests; python3 -m RLTest


### PR DESCRIPTION
Due the the recent change of the macOS GitHub actions runner the previously used pkg-config paths changed.
This commit changes the paths to the correct (new) ones, and so allows the CI runner to successfully continue the macOS job.