### PR TITLE
Specify OPENSSL_PREFIX for macOS builds.

### DIFF
--- a/.github/workflows/macos_latest.yml
+++ b/.github/workflows/macos_latest.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Build
       run: |
         export PKG_CONFIG_PATH=/opt/homebrew/opt/openssl@1.1/lib/pkgconfig/
+        export OPENSSL_PREFIX=/opt/homebrew/opt/openssl@1.1/
         cargo build --verbose
     - name: Tests
       run: cd pytests; python3 -m RLTest


### PR DESCRIPTION
This should make the CI job have green badge again.