### PR TITLE
Ignore the dump.rdb file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ Cargo.lock
 .vscode
 
 wordlist.dic
+
+dump.rdb


### PR DESCRIPTION
Helpful for the developers as this file may be created by Redis instance when running with the repository folder as current working directory.