### PR TITLE
Create a run script.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,14 +1,62 @@
-# Run under release
-#redis-server --loadmodule ./target/release/libredisgears.so ./target/release/libredisgears_v8_plugin.so
+#!/usr/bin/env bash
 
-# Run under debug
-redis-server --loadmodule ./target/debug/libredisgears.so ./target/debug/libredisgears_v8_plugin.so --enable-debug-command yes
+# A script to run Redis with RedisGears module.
+# Supports running under release and debug modes, using locally-built
+# Redis server instance path and may run under gdb.
 
-# Run some locally-built redis server with the debug library.
-#../redis/src/redis-server --loadmodule ./target/debug/libredisgears.so ./target/debug/libredisgears_v8_plugin.so --enable-debug-command yes
+GEARS_RELEASE_PATH=$PWD/target/release/libredisgears.so
+GEARS_V8_RELEASE_PATH=$PWD/target/release/libredisgears_v8_plugin.so
+GEARS_DEBUG_PATH=$PWD/target/debug/libredisgears.so
+GEARS_V8_DEBUG_PATH=$PWD/target/debug/libredisgears_v8_plugin.so
+REDIS_ARGUMENTS="--enable-debug-command yes"
+REDIS_GLOBAL_PATH=redis-server
+DEBUGGER_SCRIPT="gdb --args"
 
-# Run the redis-server built locally with the module under GDB for immediate debugging.
-#gdb --args ../redis/src/redis-server --loadmodule ./target/debug/libredisgears.so ./target/debug/libredisgears_v8_plugin.so --enable-debug-command yes
+function launch() {
+    local redis_path=$1
+    local gears_module_path=$2
+    local gears_v8_plugin_path=$3
+    local redis_arguments="$4 $5"
 
-# Run valgrind with the debug module and redis-server in $PATH.
-#valgrind --leak-check=full redis-server --loadmodule ./target/debug/libredisgears.so ./target/debug/libredisgears_v8_plugin.so
+    $redis_path --loadmodule $gears_module_path $gears_v8_plugin_path $redis_arguments
+}
+
+function parse_args_and_launch() {
+    local redis_path=$REDIS_GLOBAL_PATH
+    local gears_module_path=$GEARS_RELEASE_PATH
+    local gears_v8_plugin_path=$GEARS_V8_RELEASE_PATH
+    local redis_arguments=$REDIS_ARGUMENTS
+    local prefix=""
+
+    while getopts 'dDs:h' opt; do
+    case "$opt" in
+        d)
+        echo "Setting up to run against the debug binaries."
+        gears_module_path=$GEARS_DEBUG_PATH
+        gears_v8_plugin_path=$GEARS_V8_DEBUG_PATH
+        ;;
+
+        D)
+        echo "Setting up to run through a debugger."
+        gears_module_path=$GEARS_DEBUG_PATH
+        gears_v8_plugin_path=$GEARS_V8_DEBUG_PATH
+        prefix="${DEBUGGER_SCRIPT}"
+        ;;
+
+        s)
+        arg="$OPTARG"
+        echo "Setting up to run a custom redis server: '${OPTARG}'"
+        redis_path=${OPTARG}
+        ;;
+
+        ?|h)
+        printf "Usage: $(basename $0) [-d] [-D] [-s custom-redis-path]\nArguments:\n\t-d\tUse debug binaries\n\t-D\tRun in debugger\n\t-s\tSpecify custom redis server\n\nExample: $(basename $0) -d -s ../redis/src/redis-server\n"
+        exit 1
+        ;;
+    esac
+    done
+
+    launch "${prefix} ${redis_path}" $gears_module_path $gears_v8_plugin_path $redis_arguments
+}
+
+parse_args_and_launch $@


### PR DESCRIPTION
Changes the existing earlier run.sh script so that it accepts arguments and has pre-defined settings to allow a user to run with either release or debug-mode build binaries, custom redis-server path, and to run through a debugger.

```
❯ ./run.sh -h
Usage: run.sh [-d] [-D] [-s custom-redis-path]
Arguments:
	-d	Use debug binaries
	-D	Run in debugger
	-s	Specify custom redis server

Example: run.sh -d -s ../redis/src/redis-server
```