### PR TITLE
Extracto information on failure

### DIFF
--- a/pytests/test_cluster.py
+++ b/pytests/test_cluster.py
@@ -172,4 +172,4 @@ redis.register_function("test", async (async_client) => {
 });
     """
     cluster_conn.execute_command('set', 'z', '1')
-    env.expect('RG.FCALL', 'foo', 'test', '1', 'z').error().contains('Timeout')
+    env.expect('RG.FCALL', 'foo', 'test', '1', 'z').error().contains('Timeout1')

--- a/pytests/test_cluster.py
+++ b/pytests/test_cluster.py
@@ -172,4 +172,4 @@ redis.register_function("test", async (async_client) => {
 });
     """
     cluster_conn.execute_command('set', 'z', '1')
-    env.expect('RG.FCALL', 'foo', 'test', '1', 'z').error().contains('Timeout1')
+    env.expect('RG.FCALL', 'foo', 'test', '1', 'z').error().contains('Timeout')


### PR DESCRIPTION
Extract relevant information on test failure.

The information extracted are:
1. `info everything` from each shard.
2. Shards logs.

This information will be printed as forced debug print so we will see it on CI.