### PR TITLE
Fix #866, change artefacts names according to the general modules convetion

### DIFF
--- a/.github/workflows/CENTOS_7_REUSABLE.yml
+++ b/.github/workflows/CENTOS_7_REUSABLE.yml
@@ -103,4 +103,4 @@ jobs:
     - name: Upload artifacts
       if: ${{ inputs.upload_artifacts }}
       run: |
-        s3cmd put -P target/release/redisgears2-release.linux-rhel.7-x86_64.master.zip s3://redismodules/redisgears/snapshots/
+        s3cmd put -P target/release/redisgears2.Linux-rhel7-x86_64.master.zip s3://redismodules/redisgears/snapshots/

--- a/.github/workflows/CENTOS_8_REUSABLE.yml
+++ b/.github/workflows/CENTOS_8_REUSABLE.yml
@@ -83,4 +83,4 @@ jobs:
     - name: Upload artifacts
       if: ${{ inputs.upload_artifacts }}
       run: |
-        s3cmd put -P target/release/redisgears2-release.linux-rhel.8-x86_64.master.zip s3://redismodules/redisgears/snapshots/
+        s3cmd put -P target/release/redisgears2.Linux-rhel8-x86_64.master.zip s3://redismodules/redisgears/snapshots/

--- a/.github/workflows/UBUNTU_BIONIC_REUSABLE.yml
+++ b/.github/workflows/UBUNTU_BIONIC_REUSABLE.yml
@@ -86,4 +86,4 @@ jobs:
     - name: Upload artifacts
       if: ${{ inputs.upload_artifacts }}
       run: |
-        s3cmd put -P target/release/redisgears2-release.linux-ubuntu.18.04-x86_64.master.zip s3://redismodules/redisgears/snapshots/
+        s3cmd put -P target/release/redisgears2.Linux-bionic-x86_64.master.zip s3://redismodules/redisgears/snapshots/

--- a/.github/workflows/UBUNTU_FOCAL_REUSABLE.yml
+++ b/.github/workflows/UBUNTU_FOCAL_REUSABLE.yml
@@ -62,4 +62,4 @@ jobs:
     - name: Upload artifacts
       if: ${{ inputs.upload_artifacts }}
       run: |
-        s3cmd put -P target/release/redisgears2-release.linux-ubuntu.20.04-x86_64.master.zip s3://redismodules/redisgears/snapshots/
+        s3cmd put -P target/release/redisgears2.Linux-focal-x86_64.master.zip s3://redismodules/redisgears/snapshots/

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -102,9 +102,7 @@ pub const VERSION_NUM: Option<&str> = std::option_env!("VERSION_NUM");
 /// The operating system used for building the crate.
 pub const BUILD_OS: Option<&str> = std::option_env!("BUILD_OS");
 /// The type of the operating system used for building the crate.
-pub const BUILD_OS_TYPE: Option<&str> = std::option_env!("BUILD_OS_TYPE");
-/// The version of the operating system used for building the crate.
-pub const BUILD_OS_VERSION: Option<&str> = std::option_env!("BUILD_OS_VERSION");
+pub const BUILD_OS_NICK: Option<&str> = std::option_env!("BUILD_OS_NICK");
 /// The CPU architeture of the operating system used for building the crate.
 pub const BUILD_OS_ARCH: Option<&str> = std::option_env!("BUILD_OS_ARCH");
 /// The build type of the crate.
@@ -486,14 +484,13 @@ fn js_init(ctx: &Context, _args: &[RedisString]) -> Status {
     }
 
     ctx.log_notice(&format!(
-        "RedisGears v{}, sha='{}', branch='{}', build_type='{}', built_for='{}-{}.{}-{}'.",
+        "RedisGears v{}, sha='{}', branch='{}', build_type='{}', built_for='{}-{}.{}'.",
         VERSION_STR.unwrap_or_default(),
         GIT_SHA.unwrap_or_default(),
         GIT_BRANCH.unwrap_or_default(),
         BUILD_TYPE.unwrap_or_default(),
         BUILD_OS.unwrap_or_default(),
-        BUILD_OS_TYPE.unwrap_or_default(),
-        BUILD_OS_VERSION.unwrap_or_default(),
+        BUILD_OS_NICK.unwrap_or_default(),
         BUILD_OS_ARCH.unwrap_or_default()
     ));
     if let Err(e) = check_redis_version_compatible(ctx) {

--- a/redisgears_core/src/packer.rs
+++ b/redisgears_core/src/packer.rs
@@ -11,10 +11,8 @@ pub const GIT_BRANCH: Option<&str> = std::option_env!("GIT_BRANCH");
 pub const VERSION_STR: Option<&str> = std::option_env!("VERSION_STR");
 pub const VERSION_NUM: Option<&str> = std::option_env!("VERSION_NUM");
 pub const BUILD_OS: Option<&str> = std::option_env!("BUILD_OS");
-pub const BUILD_OS_TYPE: Option<&str> = std::option_env!("BUILD_OS_TYPE");
-pub const BUILD_OS_VERSION: Option<&str> = std::option_env!("BUILD_OS_VERSION");
+pub const BUILD_OS_NICK: Option<&str> = std::option_env!("BUILD_OS_NICK");
 pub const BUILD_OS_ARCH: Option<&str> = std::option_env!("BUILD_OS_ARCH");
-pub const BUILD_TYPE: Option<&str> = std::option_env!("BUILD_TYPE");
 
 fn main() {
     let mut curr_path = std::env::current_exe().expect("Could not get binary location");
@@ -34,20 +32,16 @@ fn main() {
     println!("{:?}", redisgears_v8_plugin_so_path);
 
     let gears_snapeshot_file_name = format!(
-        "redisgears2-{}.{}-{}.{}-{}.{}.zip",
-        BUILD_TYPE.unwrap(),
+        "redisgears2.{}-{}-{}.{}.zip",
         BUILD_OS.unwrap(),
-        BUILD_OS_TYPE.unwrap(),
-        BUILD_OS_VERSION.unwrap(),
+        BUILD_OS_NICK.unwrap(),
         BUILD_OS_ARCH.unwrap(),
         GIT_BRANCH.unwrap()
     );
     let gears_release_file_name = format!(
-        "redisgears2-{}.{}-{}.{}-{}.{}.zip",
-        BUILD_TYPE.unwrap(),
+        "redisgears2.{}-{}-{}.{}.zip",
         BUILD_OS.unwrap(),
-        BUILD_OS_TYPE.unwrap(),
-        BUILD_OS_VERSION.unwrap(),
+        BUILD_OS_NICK.unwrap(),
         BUILD_OS_ARCH.unwrap(),
         VERSION_NUM.unwrap()
     );


### PR DESCRIPTION
Fix #866, change artefacts names according to the general modules convetion.

Convention:
`redisgears2.Linux-{OS}-{arch}.{branch/version}.zip`