### PR TITLE
Resp3 support

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -55,3 +55,4 @@ RLTest
 pytests
 oss
 MSRV
+utf

--- a/.github/workflows/CENTOS_7_REUSABLE.yml
+++ b/.github/workflows/CENTOS_7_REUSABLE.yml
@@ -60,7 +60,9 @@ jobs:
     - name: Add RedisGears directory to git safe directory
       run: git config --global --add safe.directory /__w/RedisGears/RedisGears
     - name: install rltest
-      run: /opt/rh/rh-python38/root/usr/bin/python -m pip install RLTest
+      run: |
+        /opt/rh/rh-python38/root/usr/bin/python -m pip install RLTest
+        /opt/rh/rh-python38/root/usr/bin/python -m pip install -U redis==5.0.0b1
     - name: Install redis
       run: |
         set -x

--- a/.github/workflows/CENTOS_8_REUSABLE.yml
+++ b/.github/workflows/CENTOS_8_REUSABLE.yml
@@ -48,7 +48,9 @@ jobs:
         dnf -y install autoconf automake libtool
     - uses: actions/checkout@v3
     - name: install rltest
-      run: python3 -m pip install RLTest
+      run: |
+        python3 -m pip install RLTest
+        python3 -m pip install -U redis==5.0.0b1
     - name: Install redis
       run: |
         . /opt/rh/gcc-toolset-11/enable

--- a/.github/workflows/MACOS_REUSABLE.yml
+++ b/.github/workflows/MACOS_REUSABLE.yml
@@ -33,7 +33,9 @@ jobs:
       with:
         python-version: '3.10'
     - name: install rltest
-      run: python3 -m pip install RLTest\
+      run: |
+        python3 -m pip install RLTest
+        python3 -m pip install -U redis==5.0.0b1
     - name: install automake
       run: brew install automake
     - name: install openssl

--- a/.github/workflows/UBUNTU_BIONIC_REUSABLE.yml
+++ b/.github/workflows/UBUNTU_BIONIC_REUSABLE.yml
@@ -61,7 +61,9 @@ jobs:
     - name: update pip3
       run: pip3 install -U pip
     - name: install rltest
-      run: pip3 install RLTest
+      run: |
+        pip3 install RLTest
+        pip3 install -U redis==5.0.0b1
     - name: install redis
       run: git clone https://github.com/redis/redis; cd redis; git checkout ${{ inputs.redis_version }}; make install
     - name: install rust

--- a/.github/workflows/UBUNTU_FOCAL_REUSABLE.yml
+++ b/.github/workflows/UBUNTU_FOCAL_REUSABLE.yml
@@ -39,7 +39,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: install rltest
-      run: pip install RLTest
+      run: |
+        pip install RLTest
+        pip install -U redis==5.0.0b1
     - name: install redis
       run: git clone https://github.com/redis/redis; cd redis; git checkout ${{ inputs.redis_version }}; make install
     - name: format

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -39,7 +39,9 @@ jobs:
     - name: update pip3
       run: python3 -m pip install -U pip
     - name: install rltest
-      run: python3 -m pip install RLTest
+      run: |
+        python3 -m pip install RLTest
+        python3 -m pip install -U redis==5.0.0b1
     - name: install redis
       run: git clone https://github.com/redis/redis; cd redis; git checkout 7.2-rc1; make install
     - name: Build debug

--- a/docs/function_advance_topics.md
+++ b/docs/function_advance_topics.md
@@ -168,25 +168,60 @@ And we can see that the last update field name is `last_update`:
 
 Notice, RedisGears only gives the library the json configuration, **its the library responsibility to verify the correctness of the given configuration**.
 
-## Resp <-> JS Conversion
+## Resp -> JS Conversion
 
 When running Redis commands from within a RedisGears function using `client.call` API, the reply is parsed as resp3 reply and converted to JS object using the following rules:
 
-| resp 3            | JS object type                                                                                                                              |
-|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| `status`          | `StringObject` with a field called `__reply_type` and value `status`                                                                        |
-| `bulk string`     | `StringObject` with a field called `__reply_type` and value `bulk_string`                                                                   |
-| `Error`           | Raise JS exception                                                                                                                          |
-| `long`            | JS big integer                                                                                                                              |
-| `double`          | JS number                                                                                                                                   |
-| `array`           | JS array                                                                                                                                    |
-| `map`             | JS object                                                                                                                                   |
-| `set`             | JS set                                                                                                                                      |
-| `bool`            | JS boolean                                                                                                                                  |
-| `big number`      | `StringObject` with a field called `__reply_type` and value `big_number`                                                                    |
-| `verbatim string` | `StringObject` with 2 additional fields: 1. `__reply_type` and value `verbatim` 2. `__ext` with the value of the ext in the verbatim string |
-| `null`            | JS null                                                                                                                                     |
-|                   |                                                                                                                                             |
+| resp 3            | JS object type                                                                                                                                 |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| `status`          | `StringObject` with a field called `__reply_type` and value `status` (or error if failed to convert to utf8)                                   |
+| `bulk string`     | JS `String` (or error if failed to convert to utf8)                                                                                            |
+| `Error`           | Raise JS exception                                                                                                                             |
+| `long`            | JS big integer                                                                                                                                 |
+| `double`          | JS number                                                                                                                                      |
+| `array`           | JS array                                                                                                                                       |
+| `map`             | JS object                                                                                                                                      |
+| `set`             | JS set                                                                                                                                         |
+| `bool`            | JS boolean                                                                                                                                     |
+| `big number`      | `StringObject` with a field called `__reply_type` and value `big_number`                                                                       |
+| `verbatim string` | `StringObject` with 2 additional fields: 1. `__reply_type` and value `verbatim` 2. `__format` with the value of the ext in the verbatim string (or error if failed to convert to utf8) |
+| `null`            | JS null                                                                                                                                        |
+|                   |                                                                                                                                                |
+
+When running Redis commands from within a RedisGears function using `client.call_raw` API, the reply is parsed as resp3 reply and converted to JS object using the following rules:
+
+| resp 3            | JS object type                                                                                                                                 |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| `status`          | JS `ArrayBufffer` with a field called `__reply_type` and value `status`                                                                        |
+| `bulk string`     | JS `ArrayBufffer`                                                                                                                              |
+| `Error`           | Raise JS exception                                                                                                                             |
+| `long`            | JS big integer                                                                                                                                 |
+| `double`          | JS number                                                                                                                                      |
+| `array`           | JS array                                                                                                                                       |
+| `map`             | JS object                                                                                                                                      |
+| `set`             | JS set                                                                                                                                         |
+| `bool`            | JS boolean                                                                                                                                     |
+| `big number`      | `StringObject` with a field called `__reply_type` and value `big_number`                                                                       |
+| `verbatim string` | JS `ArrayBufffer` with 2 additional fields: 1. `__reply_type` and value `verbatim` 2. `__format` with the value of the ext in the verbatim string |
+| `null`            | JS null                                                                                                                                        |
+|                   |                                                                                                                                                |
+
+## JS -> RESP Conversion
+
+| JS type                                                          | RESP2         | RESP3                                  |
+|------------------------------------------------------------------|---------------|----------------------------------------|
+| `string`                                                         | `bulk string` | `bulk string`                          |
+| `string` object with field `__reply_type=status`                 | `status`      | `status`                               |
+| Exception                                                        | `error`       | `error`                                |
+| `big integer`                                                    | `long`        | `long`                                 |
+| `number`                                                         | `bulk string` | `double`                               |
+| `array`                                                          | `array`       | `array`                                |
+| `map`                                                            | `array`       | `map`                                  |
+| `set`                                                            | `array`       | `set`                                  |
+| `bool`                                                           | `long`        | `bool`                                 |
+| `string` object with field`__reply_type=status` and `format=txt` | `bulk string` | `verbatim string` with format as `txt` |
+| `null`                                                           | resp2 `null`  | resp3 `null`                           |
+
 ## Working with Binary Data
 
 By default, RedisGears will decode all data as string and will raise error on failures. Though usefull for most users sometimes there is a need to work with binary data. In order to do so, the library developer has to considerations the following:

--- a/docs/function_advance_topics.md
+++ b/docs/function_advance_topics.md
@@ -219,7 +219,7 @@ When running Redis commands from within a RedisGears function using `client.call
 | `map`                                                            | `array`       | `map`                                  |
 | `set`                                                            | `array`       | `set`                                  |
 | `bool`                                                           | `long`        | `bool`                                 |
-| `string` object with field`__reply_type=status` and `format=txt` | `bulk string` | `verbatim string` with format as `txt` |
+| `string` object with field`__reply_type=varbatim` and `__format=txt` | `bulk string` | `verbatim string` with format as `txt` |
 | `null`                                                           | resp2 `null`  | resp3 `null`                           |
 
 ## Working with Binary Data

--- a/pytests/test_basics.py
+++ b/pytests/test_basics.py
@@ -506,7 +506,7 @@ redis.register_function("debug_protocol", function(client, arg){
     env.assertEqual(conn.execute_command('RG.FCALL', 'lib', 'debug_protocol', '0', 'array'), [0, 1, 2])
     env.assertEqual(conn.execute_command('RG.FCALL', 'lib', 'debug_protocol', '0', 'set'), set([0, 1, 2]))
     env.assertEqual(conn.execute_command('RG.FCALL', 'lib', 'debug_protocol', '0', 'map'), {1: True, 2: False, 0: False})
-    env.assertEqual(conn.execute_command('RG.FCALL', 'lib', 'debug_protocol', '0', 'verbatim'), 'txt:undefinedThis is a verbatim\nstring')
+    env.assertEqual(conn.execute_command('RG.FCALL', 'lib', 'debug_protocol', '0', 'verbatim'), 'txt:This is a verbatim\nstring')
     env.assertEqual(conn.execute_command('RG.FCALL', 'lib', 'debug_protocol', '0', 'true'), True)
     env.assertEqual(conn.execute_command('RG.FCALL', 'lib', 'debug_protocol', '0', 'false'), False)
 
@@ -521,7 +521,7 @@ redis.register_function("debug_protocol", function(client, arg){
     env.assertEqual(conn.execute_command('RG.FCALL', 'lib', 'debug_protocol', '0', 'array'), [0, 1, 2])
     env.assertEqual(sorted(conn.execute_command('RG.FCALL', 'lib', 'debug_protocol', '0', 'set')), sorted([0, 1, 2]))
     env.assertEqual(sorted(conn.execute_command('RG.FCALL', 'lib', 'debug_protocol', '0', 'map')), sorted([1, 1, 0, 0, 2, 0]))
-    env.assertEqual(conn.execute_command('RG.FCALL', 'lib', 'debug_protocol', '0', 'verbatim'), 'undefinedThis is a verbatim\nstring')
+    env.assertEqual(conn.execute_command('RG.FCALL', 'lib', 'debug_protocol', '0', 'verbatim'), 'This is a verbatim\nstring')
     env.assertEqual(conn.execute_command('RG.FCALL', 'lib', 'debug_protocol', '0', 'true'), True)
     env.assertEqual(conn.execute_command('RG.FCALL', 'lib', 'debug_protocol', '0', 'false'), False)
 

--- a/pytests/test_basics.py
+++ b/pytests/test_basics.py
@@ -525,6 +525,33 @@ redis.register_function("debug_protocol", function(client, arg){
     env.assertEqual(conn.execute_command('RG.FCALL', 'lib', 'debug_protocol', '0', 'true'), True)
     env.assertEqual(conn.execute_command('RG.FCALL', 'lib', 'debug_protocol', '0', 'false'), False)
 
+@gearsTest(enableGearsDebugCommands=True)
+def testFunctionListResp3(env):
+    """#!js api_version=1.0 name=lib
+redis.register_function("test", function(){
+    return "test";
+});
+    """
+    port = int(env.cmd('config', 'get', 'port')[1])
+
+    # test resp3
+    conn = Redis('localhost', port, protocol=3, decode_responses=True)
+    
+    env.assertEqual(conn.execute_command('RG.FUNCTION', 'LIST'), [\
+        {\
+         'configuration': None,\
+         'remote_functions': [],\
+         'engine': 'js',\
+         'name': 'lib',\
+         'pending_jobs': 0,\
+         'functions': ['test'],\
+         'user': 'default',\
+         'notifications_consumers': [],\
+         'api_version': '1.0',\
+         'stream_consumers': []\
+        }\
+    ])
+
 @gearsTest()
 def testNoAsyncFunctionOnMultiExec(env):
     """#!js api_version=1.0 name=lib

--- a/redisgears_core/src/function_list_command.rs
+++ b/redisgears_core/src/function_list_command.rs
@@ -4,11 +4,12 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
+use redis_module::redisvalue::RedisValueKey;
 use redis_module::{Context, NextArg, RedisError, RedisResult, RedisValue};
 use redisgears_plugin_api::redisgears_plugin_api::load_library_ctx::FunctionFlags;
 
-use std::iter::Skip;
 use std::vec::IntoIter;
+use std::{collections::HashMap, iter::Skip};
 
 use crate::{get_libraries, get_msg_verbose, json_to_redis_value};
 
@@ -69,226 +70,323 @@ pub(crate) fn function_list_command(
                 None => true,
             })
             .map(|l| {
-                let mut res = vec![
-                    RedisValue::BulkString("engine".to_string()),
-                    RedisValue::BulkString(l.gears_lib_ctx.meta_data.engine.to_string()),
-                    RedisValue::BulkString("api_version".to_string()),
-                    RedisValue::BulkString(l.gears_lib_ctx.meta_data.api_version.to_string()),
-                    RedisValue::BulkString("name".to_string()),
-                    RedisValue::BulkString(l.gears_lib_ctx.meta_data.name.to_string()),
-                    RedisValue::BulkString("user".to_string()),
-                    RedisValue::BulkString(l.gears_lib_ctx.meta_data.user.to_string()),
-                    RedisValue::BulkString("configuration".to_string()),
-                    {
-                        match l.gears_lib_ctx.meta_data.config.as_ref() {
-                            Some(c) => RedisValue::BulkString(c.to_string()),
-                            None => RedisValue::Null,
-                        }
-                    },
-                    RedisValue::BulkString("pending_jobs".to_string()),
-                    RedisValue::Integer(l.compile_lib_internals.pending_jobs() as i64),
-                    RedisValue::BulkString("functions".to_string()),
-                    RedisValue::Array(if verbosity > 0 {
-                        l.gears_lib_ctx
-                            .functions
-                            .iter()
-                            .map(|(k, v)| {
-                                RedisValue::Array(vec![
-                                    RedisValue::BulkString("name".to_string()),
-                                    RedisValue::BulkString(k.to_string()),
-                                    RedisValue::BulkString("flags".to_string()),
-                                    function_list_command_flags(v.flags),
-                                ])
-                            })
-                            .collect::<Vec<RedisValue>>()
-                    } else {
-                        l.gears_lib_ctx
-                            .functions
-                            .keys()
-                            .map(|k| RedisValue::BulkString(k.to_string()))
-                            .collect::<Vec<RedisValue>>()
-                    }),
-                    RedisValue::BulkString("remote_functions".to_string()),
-                    RedisValue::Array(
-                        l.gears_lib_ctx
-                            .remote_functions
-                            .keys()
-                            .map(|k| RedisValue::BulkString(k.to_string()))
-                            .collect::<Vec<RedisValue>>(),
-                    ),
-                    RedisValue::BulkString("stream_consumers".to_string()),
-                    RedisValue::Array(
-                        l.gears_lib_ctx
-                            .stream_consumers
-                            .iter()
-                            .map(|(k, v)| {
-                                let v = v.ref_cell.borrow();
-                                if verbosity > 0 {
-                                    let mut res = vec![
-                                        RedisValue::BulkString("name".to_string()),
-                                        RedisValue::BulkString(k.to_string()),
-                                        RedisValue::BulkString("prefix".to_string()),
-                                        RedisValue::BulkRedisString(
-                                            ctx.create_string(v.prefix.as_slice()),
-                                        ),
-                                        RedisValue::BulkString("window".to_string()),
-                                        RedisValue::Integer(v.window as i64),
-                                        RedisValue::BulkString("trim".to_string()),
-                                        RedisValue::BulkString(
-                                            (if v.trim { "enabled" } else { "disabled" })
-                                                .to_string(),
-                                        ),
-                                        RedisValue::BulkString("num_streams".to_string()),
-                                        RedisValue::Integer(v.consumed_streams.len() as i64),
-                                    ];
-                                    if verbosity > 1 {
-                                        res.push(RedisValue::BulkString("streams".to_string()));
-                                        res.push(RedisValue::Array(
-                                            v.consumed_streams
-                                                .iter()
-                                                .map(|(s, v)| {
-                                                    let v = v.ref_cell.borrow();
-                                                    let mut res = vec![
-                                                        RedisValue::BulkString("name".to_string()),
-                                                        RedisValue::BulkRedisString(
-                                                            ctx.create_string(s.as_slice()),
-                                                        ),
-                                                        RedisValue::BulkString(
-                                                            "last_processed_time".to_string(),
-                                                        ),
-                                                        RedisValue::Integer(
-                                                            v.last_processed_time as i64,
-                                                        ),
-                                                        RedisValue::BulkString(
-                                                            "avg_processed_time".to_string(),
-                                                        ),
-                                                        RedisValue::Float(
-                                                            v.total_processed_time as f64
-                                                                / v.records_processed as f64,
-                                                        ),
-                                                        RedisValue::BulkString(
-                                                            "last_lag".to_string(),
-                                                        ),
-                                                        RedisValue::Integer(v.last_lag as i64),
-                                                        RedisValue::BulkString(
-                                                            "avg_lag".to_string(),
-                                                        ),
-                                                        RedisValue::Float(
-                                                            v.total_lag as f64
-                                                                / v.records_processed as f64,
-                                                        ),
-                                                        RedisValue::BulkString(
-                                                            "total_record_processed".to_string(),
-                                                        ),
-                                                        RedisValue::Integer(
-                                                            v.records_processed as i64,
-                                                        ),
-                                                        RedisValue::BulkString(
-                                                            "id_to_read_from".to_string(),
-                                                        ),
-                                                        match v.last_read_id {
-                                                            Some(id) => RedisValue::BulkString(
-                                                                format!("{}-{}", id.ms, id.seq),
-                                                            ),
-                                                            None => RedisValue::BulkString(
-                                                                "None".to_string(),
-                                                            ),
-                                                        },
-                                                        RedisValue::BulkString(
-                                                            "last_error".to_string(),
-                                                        ),
-                                                        match &v.last_error {
-                                                            Some(err) => RedisValue::BulkString(
-                                                                get_msg_verbose(err).to_string(),
-                                                            ),
-                                                            None => RedisValue::BulkString(
-                                                                "None".to_string(),
-                                                            ),
-                                                        },
-                                                    ];
-                                                    if verbosity > 2 {
-                                                        res.push(RedisValue::BulkString(
-                                                            "pending_ids".to_string(),
-                                                        ));
-                                                        let pending_ids = v
-                                                            .pending_ids
+                let mut res =
+                    HashMap::from([
+                        (
+                            RedisValueKey::String("engine".to_string()),
+                            RedisValue::BulkString(l.gears_lib_ctx.meta_data.engine.to_string()),
+                        ),
+                        (
+                            RedisValueKey::String("api_version".to_string()),
+                            RedisValue::BulkString(l.gears_lib_ctx.meta_data.api_version.to_string()),
+                        ),
+                        (
+                            RedisValueKey::String("name".to_string()),
+                            RedisValue::BulkString(l.gears_lib_ctx.meta_data.name.to_string()),
+                        ),
+                        (
+                            RedisValueKey::String("user".to_string()),
+                            RedisValue::BulkString(l.gears_lib_ctx.meta_data.user.to_string()),
+                        ),
+                        (RedisValueKey::String("configuration".to_string()), {
+                            l.gears_lib_ctx
+                                .meta_data
+                                .config
+                                .as_ref()
+                                .map(|v| RedisValue::BulkString(v.to_string()))
+                                .unwrap_or(RedisValue::Null)
+                        }),
+                        (
+                            RedisValueKey::String("pending_jobs".to_string()),
+                            RedisValue::Integer(l.compile_lib_internals.pending_jobs() as i64),
+                        ),
+                        (
+                            RedisValueKey::String("functions".to_string()),
+                            RedisValue::Array(if verbosity > 0 {
+                                l.gears_lib_ctx
+                                    .functions
+                                    .iter()
+                                    .map(|(k, v)| {
+                                        RedisValue::Map(HashMap::from([
+                                            (
+                                                RedisValueKey::String("name".to_string()),
+                                                RedisValue::BulkString(k.to_string()),
+                                            ),
+                                            (
+                                                RedisValueKey::String("flags".to_string()),
+                                                function_list_command_flags(v.flags),
+                                            ),
+                                        ]))
+                                    })
+                                    .collect::<Vec<RedisValue>>()
+                            } else {
+                                l.gears_lib_ctx
+                                    .functions
+                                    .keys()
+                                    .map(|k| RedisValue::BulkString(k.to_string()))
+                                    .collect::<Vec<RedisValue>>()
+                            }),
+                        ),
+                        (
+                            RedisValueKey::String("remote_functions".to_string()),
+                            RedisValue::Array(
+                                l.gears_lib_ctx
+                                    .remote_functions
+                                    .keys()
+                                    .map(|k| RedisValue::BulkString(k.to_string()))
+                                    .collect::<Vec<RedisValue>>(),
+                            ),
+                        ),
+                        (
+                            RedisValueKey::String("stream_consumers".to_string()),
+                            RedisValue::Array(
+                                l.gears_lib_ctx
+                                    .stream_consumers
+                                    .iter()
+                                    .map(|(k, v)| {
+                                        let v = v.ref_cell.borrow();
+                                        if verbosity > 0 {
+                                            let mut res = HashMap::from([
+                                                (
+                                                    RedisValueKey::String("name".to_string()),
+                                                    RedisValue::BulkString(k.to_string()),
+                                                ),
+                                                (
+                                                    RedisValueKey::String("prefix".to_string()),
+                                                    RedisValue::BulkRedisString(
+                                                        ctx.create_string(v.prefix.as_slice()),
+                                                    ),
+                                                ),
+                                                (
+                                                    RedisValueKey::String("window".to_string()),
+                                                    RedisValue::Integer(v.window as i64),
+                                                ),
+                                                (
+                                                    RedisValueKey::String("trim".to_string()),
+                                                    RedisValue::BulkString(
+                                                        (if v.trim {
+                                                            "enabled"
+                                                        } else {
+                                                            "disabled"
+                                                        })
+                                                        .to_string(),
+                                                    ),
+                                                ),
+                                                (
+                                                    RedisValueKey::String(
+                                                        "num_streams".to_string(),
+                                                    ),
+                                                    RedisValue::Integer(
+                                                        v.consumed_streams.len() as i64
+                                                    ),
+                                                ),
+                                            ]);
+                                            if verbosity > 1 {
+                                                res.insert(
+                                                    RedisValueKey::String("streams".to_string()),
+                                                    RedisValue::Array(
+                                                        v.consumed_streams
                                                             .iter()
-                                                            .map(|e| {
-                                                                RedisValue::BulkString(format!(
-                                                                    "{}-{}",
-                                                                    e.ms, e.seq
-                                                                ))
+                                                            .map(|(s, v)| {
+                                                                let v = v.ref_cell.borrow();
+                                                                let mut res = HashMap::from([
+                                                                    (
+                                                                        RedisValueKey::String(
+                                                                            "name".to_string(),
+                                                                        ),
+                                                                        RedisValue::BulkRedisString(
+                                                                            ctx.create_string(
+                                                                                s.as_slice(),
+                                                                            ),
+                                                                        ),
+                                                                    ),
+                                                                    (
+                                                                        RedisValueKey::String(
+                                                                            "last_processed_time"
+                                                                                .to_string(),
+                                                                        ),
+                                                                        RedisValue::Integer(
+                                                                            v.last_processed_time
+                                                                                as i64,
+                                                                        ),
+                                                                    ),
+                                                                    (RedisValueKey::String(
+                                                                        "avg_processed_time"
+                                                                            .to_string(),
+                                                                    ),
+                                                                    RedisValue::Float(
+                                                                        v.total_processed_time
+                                                                            as f64
+                                                                            / v.records_processed
+                                                                                as f64,
+                                                                    )),
+                                                                    (RedisValueKey::String(
+                                                                        "last_lag".to_string(),
+                                                                    ),
+                                                                    RedisValue::Integer(
+                                                                        v.last_lag as i64,
+                                                                    )),
+                                                                    (RedisValueKey::String(
+                                                                        "avg_lag".to_string(),
+                                                                    ),
+                                                                    RedisValue::Float(
+                                                                        v.total_lag as f64
+                                                                            / v.records_processed
+                                                                                as f64,
+                                                                    )),
+                                                                    (RedisValueKey::String(
+                                                                        "total_record_processed"
+                                                                            .to_string(),
+                                                                    ),
+                                                                    RedisValue::Integer(
+                                                                        v.records_processed as i64,
+                                                                    )),
+                                                                    (RedisValueKey::String(
+                                                                        "id_to_read_from"
+                                                                            .to_string(),
+                                                                    ),
+                                                                    RedisValue::BulkString(v.last_read_id
+                                                                        .map(|id| format!("{}-{}",id.ms, id.seq)).
+                                                                        unwrap_or_else(|| "None".to_string()))),
+                                                                    (RedisValueKey::String(
+                                                                        "last_error".to_string(),
+                                                                    ),
+                                                                    RedisValue::BulkString(v.last_error.as_ref()
+                                                                        .map(|v| get_msg_verbose(v).to_string())
+                                                                        .unwrap_or_else(|| "None".to_string()))),
+                                                                ]);
+                                                                if verbosity > 2 {
+                                                                    let pending_ids = v
+                                                                        .pending_ids
+                                                                        .iter()
+                                                                        .map(|e| {
+                                                                            RedisValue::BulkString(
+                                                                                format!(
+                                                                                    "{}-{}",
+                                                                                    e.ms, e.seq
+                                                                                ),
+                                                                            )
+                                                                        })
+                                                                        .collect::<Vec<RedisValue>>(
+                                                                        );
+                                                                    res.insert(
+                                                                        RedisValueKey::String(
+                                                                            "pending_ids"
+                                                                                .to_string(),
+                                                                        ),
+                                                                        RedisValue::Array(
+                                                                            pending_ids,
+                                                                        ),
+                                                                    );
+                                                                }
+                                                                RedisValue::Map(res)
                                                             })
-                                                            .collect::<Vec<RedisValue>>();
-                                                        res.push(RedisValue::Array(pending_ids));
-                                                    }
-                                                    RedisValue::Array(res)
-                                                })
-                                                .collect::<Vec<RedisValue>>(),
-                                        ));
-                                    }
-                                    RedisValue::Array(res)
-                                } else {
-                                    RedisValue::BulkString(k.to_string())
-                                }
-                            })
-                            .collect::<Vec<RedisValue>>(),
-                    ),
-                    RedisValue::BulkString("notifications_consumers".to_string()),
-                    RedisValue::Array(
-                        l.gears_lib_ctx
-                            .notifications_consumers
-                            .iter()
-                            .map(|(name, c)| {
-                                if verbosity == 0 {
-                                    RedisValue::BulkString(name.to_string())
-                                } else {
-                                    let stats = c.borrow().get_stats();
-                                    RedisValue::Array(vec![
-                                        RedisValue::BulkString("name".to_string()),
-                                        RedisValue::BulkString(name.to_string()),
-                                        RedisValue::BulkString("num_triggered".to_string()),
-                                        RedisValue::Integer(stats.num_trigger as i64),
-                                        RedisValue::BulkString("num_finished".to_string()),
-                                        RedisValue::Integer(stats.num_finished as i64),
-                                        RedisValue::BulkString("num_success".to_string()),
-                                        RedisValue::Integer(stats.num_success as i64),
-                                        RedisValue::BulkString("num_failed".to_string()),
-                                        RedisValue::Integer(stats.num_failed as i64),
-                                        RedisValue::BulkString("last_error".to_string()),
-                                        RedisValue::BulkString(match stats.last_error {
-                                            Some(s) => get_msg_verbose(&s).to_string(),
-                                            None => "None".to_string(),
-                                        }),
-                                        RedisValue::BulkString("last_exection_time".to_string()),
-                                        RedisValue::Integer(stats.last_execution_time as i64),
-                                        RedisValue::BulkString("total_exection_time".to_string()),
-                                        RedisValue::Integer(stats.total_execution_time as i64),
-                                        RedisValue::BulkString("avg_exection_time".to_string()),
-                                        RedisValue::Float(
-                                            stats.total_execution_time as f64
-                                                / stats.num_finished as f64,
-                                        ),
-                                    ])
-                                }
-                            })
-                            .collect::<Vec<RedisValue>>(),
-                    ),
-                ];
+                                                            .collect::<Vec<RedisValue>>(),
+                                                    ),
+                                                );
+                                            }
+                                            RedisValue::Map(res)
+                                        } else {
+                                            RedisValue::BulkString(k.to_string())
+                                        }
+                                    })
+                                    .collect::<Vec<RedisValue>>(),
+                            ),
+                        ),
+                        (
+                            RedisValueKey::String("notifications_consumers".to_string()),
+                            RedisValue::Array(
+                                l.gears_lib_ctx
+                                    .notifications_consumers
+                                    .iter()
+                                    .map(|(name, c)| {
+                                        if verbosity == 0 {
+                                            RedisValue::BulkString(name.to_string())
+                                        } else {
+                                            let stats = c.borrow().get_stats();
+                                            RedisValue::Map(HashMap::from([
+                                                (
+                                                    RedisValueKey::String("name".to_string()),
+                                                    RedisValue::BulkString(name.to_string()),
+                                                ),
+                                                (
+                                                    RedisValueKey::String(
+                                                        "num_triggered".to_string(),
+                                                    ),
+                                                    RedisValue::Integer(stats.num_trigger as i64),
+                                                ),
+                                                (
+                                                    RedisValueKey::String(
+                                                        "num_finished".to_string(),
+                                                    ),
+                                                    RedisValue::Integer(stats.num_finished as i64),
+                                                ),
+                                                (
+                                                    RedisValueKey::String(
+                                                        "num_success".to_string(),
+                                                    ),
+                                                    RedisValue::Integer(stats.num_success as i64),
+                                                ),
+                                                (
+                                                    RedisValueKey::String("num_failed".to_string()),
+                                                    RedisValue::Integer(stats.num_failed as i64),
+                                                ),
+                                                (
+                                                    RedisValueKey::String("last_error".to_string()),
+                                                    RedisValue::BulkString(
+                                                        stats
+                                                            .last_error
+                                                            .as_ref()
+                                                            .map(|v| get_msg_verbose(v).to_string())
+                                                            .unwrap_or_else(|| "None".to_string()),
+                                                    ),
+                                                ),
+                                                (
+                                                    RedisValueKey::String(
+                                                        "last_exection_time".to_string(),
+                                                    ),
+                                                    RedisValue::Integer(
+                                                        stats.last_execution_time as i64,
+                                                    ),
+                                                ),
+                                                (
+                                                    RedisValueKey::String(
+                                                        "total_exection_time".to_string(),
+                                                    ),
+                                                    RedisValue::Integer(
+                                                        stats.total_execution_time as i64,
+                                                    ),
+                                                ),
+                                                (
+                                                    RedisValueKey::String(
+                                                        "avg_exection_time".to_string(),
+                                                    ),
+                                                    RedisValue::Float(
+                                                        stats.total_execution_time as f64
+                                                            / stats.num_finished as f64,
+                                                    ),
+                                                ),
+                                            ]))
+                                        }
+                                    })
+                                    .collect::<Vec<RedisValue>>(),
+                            ),
+                        ),
+                    ]);
                 if with_code {
-                    res.push(RedisValue::BulkString("code".to_string()));
-                    res.push(RedisValue::BulkString(
-                        l.gears_lib_ctx.meta_data.code.to_string(),
-                    ));
+                    res.insert(
+                        RedisValueKey::String("code".to_string()),
+                        RedisValue::BulkString(l.gears_lib_ctx.meta_data.code.to_string()),
+                    );
                 }
                 if verbosity > 0 {
-                    res.push(RedisValue::BulkString("gears_box_info".to_string()));
                     let gears_box_info_str = serde_json::to_string(&l.gears_box_lib).unwrap();
-                    res.push(json_to_redis_value(
-                        serde_json::from_str(&gears_box_info_str).unwrap(),
-                    ));
+                    res.insert(
+                        RedisValueKey::String("gears_box_info".to_string()),
+                        json_to_redis_value(serde_json::from_str(&gears_box_info_str).unwrap()),
+                    );
                 }
-                RedisValue::Array(res)
+                RedisValue::Map(res)
             })
             .collect::<Vec<RedisValue>>(),
     ))

--- a/redisgears_core/src/function_list_command.rs
+++ b/redisgears_core/src/function_list_command.rs
@@ -65,10 +65,7 @@ pub(crate) fn function_list_command(
     Ok(RedisValue::Array(
         libraries
             .values()
-            .filter(|l| match lib {
-                Some(lib_name) => l.gears_lib_ctx.meta_data.name == lib_name,
-                None => true,
-            })
+            .filter(|l| lib.map(|lib_name| l.gears_lib_ctx.meta_data.name == lib_name).unwrap_or(true))
             .map(|l| {
                 let mut res =
                     HashMap::from([

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -27,9 +27,9 @@ use redis_module::raw::RedisModule__Assert;
 use threadpool::ThreadPool;
 
 use redis_module::{
-    alloc::RedisAlloc, configuration::ConfigurationFlags, raw::KeyType::Stream, redis_command,
-    AclPermissions, CallOptions, Context, InfoContext, KeysCursor, NextArg, NotifyEvent,
-    RedisError, RedisResult, RedisString, RedisValue, Status, ThreadSafeContext,
+    alloc::RedisAlloc, configuration::ConfigurationFlags, raw::KeyType::Stream, AclPermissions,
+    CallOptions, Context, InfoContext, KeysCursor, NextArg, NotifyEvent, RedisError, RedisResult,
+    RedisString, RedisValue, Status, ThreadSafeContext,
 };
 
 use redis_module::server_events::{

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -10,6 +10,7 @@
 
 #![deny(missing_docs)]
 
+use redis_module::redisvalue::RedisValueKey;
 use redis_module::{CallResult, ContextFlags, DetachedContext, ErrorReply};
 use redisgears_plugin_api::redisgears_plugin_api::backend_ctx::BackendCtxInterfaceInitialised;
 use redisgears_plugin_api::redisgears_plugin_api::load_library_ctx::FunctionFlags;
@@ -787,12 +788,11 @@ pub(crate) fn json_to_redis_value(val: serde_json::Value) -> RedisValue {
             RedisValue::Array(res)
         }
         serde_json::Value::Object(o) => {
-            let mut res = Vec::new();
+            let mut res = HashMap::new();
             for (k, v) in o.into_iter() {
-                res.push(RedisValue::BulkString(k));
-                res.push(json_to_redis_value(v));
+                res.insert(RedisValueKey::String(k), json_to_redis_value(v));
             }
-            RedisValue::Array(res)
+            RedisValue::Map(res)
         }
     }
 }

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -784,13 +784,11 @@ pub(crate) fn json_to_redis_value(val: serde_json::Value) -> RedisValue {
             }
             RedisValue::Array(res)
         }
-        serde_json::Value::Object(o) => {
-            let mut res = HashMap::new();
-            for (k, v) in o.into_iter() {
-                res.insert(RedisValueKey::String(k), json_to_redis_value(v));
-            }
-            RedisValue::Map(res)
-        }
+        serde_json::Value::Object(o) => RedisValue::Map(
+            o.into_iter()
+                .map(|(k, v)| (RedisValueKey::String(k), json_to_redis_value(v)))
+                .collect(),
+        ),
     }
 }
 

--- a/redisgears_v8_plugin/Cargo.toml
+++ b/redisgears_v8_plugin/Cargo.toml
@@ -8,8 +8,8 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 
 [dependencies]
 redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master" }
-v8_rs = { git = "https://github.com/RedisGears/v8-rs", branch = "master"}
-v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs", branch = "master"}
+v8_rs = { git = "https://github.com/RedisGears/v8-rs", branch = "extend_set_api"}
+v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs", branch = "extend_set_api"}
 redisgears_plugin_api = { path="../redisgears_plugin_api/" }
 serde_json = "1"
 serde = "1"

--- a/redisgears_v8_plugin/Cargo.toml
+++ b/redisgears_v8_plugin/Cargo.toml
@@ -8,8 +8,8 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 
 [dependencies]
 redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master" }
-v8_rs = { git = "https://github.com/RedisGears/v8-rs", branch = "extend_set_api"}
-v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs", branch = "extend_set_api"}
+v8_rs = { git = "https://github.com/RedisGears/v8-rs", branch = "master"}
+v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs", branch = "master"}
 redisgears_plugin_api = { path="../redisgears_plugin_api/" }
 serde_json = "1"
 serde = "1"

--- a/redisgears_v8_plugin/src/v8_function_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_function_ctx.rs
@@ -100,11 +100,7 @@ fn v8_value_to_call_result(
                         .get_str_field(ctx_scope, "__format")
                         .map_or(None, |v| v.to_utf8());
                     return Ok(RedisValue::VerbatimString((
-                        format
-                            .as_ref()
-                            .map(|v| v.as_str())
-                            .unwrap_or("txt")
-                            .to_owned(),
+                        format.as_ref().map(|v| v.as_str()).unwrap_or("txt").into(),
                         val.to_utf8().unwrap().as_str().as_bytes().to_vec(),
                     )));
                 }

--- a/redisgears_v8_plugin/src/v8_function_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_function_ctx.rs
@@ -100,7 +100,11 @@ fn v8_value_to_call_result(
                         .get_str_field(ctx_scope, "__format")
                         .map_or(None, |v| v.to_utf8());
                     return Ok(RedisValue::VerbatimString((
-                        format.as_ref().map(|v| v.as_str()).unwrap_or("txt").into(),
+                        format
+                            .as_ref()
+                            .map(|v| v.as_str())
+                            .unwrap_or("txt")
+                            .try_into()?,
                         val.to_utf8().unwrap().as_str().as_bytes().to_vec(),
                     )));
                 }


### PR DESCRIPTION
Fix #894 

The PR adds support for RESP3 on 2 commands:

1. RG.FUNCTION LIST will now return the data in RESP3 (if requested by the client). This means that all the information will be presented as map instead of array and will be easier for the user to understand.
2. RG.FCALL will return the data in RESP3 (if requested by the client). Sense RG.FCALL runs user code, we define the following rules to translate the return value from  the user code into RESP types:

| JS type                                                          | RESP2         | RESP3                                  |
|------------------------------------------------------------------|---------------|----------------------------------------|
| `string`                                                         | `bulk string` | `bulk string`                          |
| `string` object with field `__reply_type=status`                 | `status`      | `status`                               |
| Exception                                                        | `error`       | `error`                                |
| `big integer`                                                    | `long`        | `long`                                 |
| `number`                                                         | `bulk string` | `double`                               |
| `array`                                                          | `array`       | `array`                                |
| `map`                                                            | `array`       | `map`                                  |
| `set`                                                            | `array`       | `set`                                  |
| `bool`                                                           | `long`        | `bool`                                 |
| `string` object with field`__reply_type=verbatim` and `__format=txt` | `bulk string` | `verbatim string` with format as `txt` |
| `null`                                                           | resp2 `null`  | resp3 `null`                           |

Notice that currently the following RESP3 types are not supported:
* Attribute
* Push notifications


Depends on: https://github.com/RedisLabsModules/redismodule-rs/pull/315

todo:

- [x] test function list
- [x] update this commit message
- [x] move to master v8-rs once merge: https://github.com/RedisGears/v8-rs/pull/19
- [x] Update docs about js type to resp3 transition.