### PR TITLE
Fix flaky tests.

### DIFF
--- a/pytests/common.py
+++ b/pytests/common.py
@@ -199,6 +199,8 @@ def gearsTest(skipTest=False,
                     # make sure all shards are in sync with their replica
                     for con in shardsConnections(env):
                         def synchronise_replicas():
+                            con.execute_command('set', 'x', '1')
+                            con.execute_command('del', 'x')
                             status = con.execute_command('wait', '1', '0')
                             return status
 

--- a/pytests/common.py
+++ b/pytests/common.py
@@ -199,8 +199,16 @@ def gearsTest(skipTest=False,
                     # make sure all shards are in sync with their replica
                     for con in shardsConnections(env):
                         def synchronise_replicas():
-                            con.execute_command('set', 'x', '1')
-                            con.execute_command('del', 'x')
+                            # Wait works on the connection level.
+                            # Because the client who register the function
+                            # and this current client are different, we need
+                            # to perform a simple command that will be replicated
+                            # to the replica so the `wait` command will be effective
+                            # and will return only after the library will reach
+                            # all the replicas.
+                            # A simple publish command will do the trick
+                            # and will also work properly on cluster.
+                            con.execute_command('publish', 'foo', 'bar')
                             status = con.execute_command('wait', '1', '0')
                             return status
 


### PR DESCRIPTION
Redis do not update the client `woff` (Last write global replication offset) value if the command went to the background and the replicate operation happened from the background. This cause the `wait` command to be ineffective.

By sending a simple command that replicated to the replica (like `publish`)(before the `wait` command), We make sure the client `woff` value will be updated correctly and the `wait` command will be executed as expected.

In addition this change make sure that connection that did not register the library will also wait for the library to reach the replica (`wait` command waits for all the write that was performed by the current connection).

This should fix failures such as: https://github.com/RedisGears/RedisGears/actions/runs/4870846502/jobs/8687088127

We should also consider whether or not this is a bug in Redis.