### PR TITLE
Introduce register_async_function API.

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -56,3 +56,4 @@ pytests
 oss
 MSRV
 utf
+FCALLASYNC

--- a/docs/cluster_support.md
+++ b/docs/cluster_support.md
@@ -24,7 +24,7 @@ We have couple of options to call a remote function, those options are expose th
 The following example register a function that will return the total amount of keys on the cluster. The function will use the remote function define above:
 
 ```js
-redis.register_function("my_dbsize", async(async_client) => {
+redis.register_async_function("my_dbsize", async(async_client) => {
     let res = await async_client.run_on_all_shards("dbsize");
     let results = res[0];
     let errors = res[1];
@@ -50,7 +50,7 @@ redis.register_remote_function("dbsize", async(client) => {
     });
 });
 
-redis.register_function("test", async(async_client) => {
+redis.register_async_function("test", async(async_client) => {
     let res = await async_client.run_on_all_shards("dbsize");
     let results = res[0];
     let errors = res[1];
@@ -78,7 +78,7 @@ redis.register_remote_function(remote_get, async(client, key) => {
     return res;
 });
 
-redis.register_function("test", async (async_client) => {
+redis.register_async_function("test", async (async_client) => {
     return await async_client.run_on_key("x", remote_get, "x");
 });
 ```

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,3 +118,29 @@ The return value from the function on error in case of failure.
 > RG.FCALL lib foo 0
 "bar"
 ```
+
+# RG.FCALLASYNC
+
+Invoke an async function (coroutine).
+
+```
+RG.FCALLASYNC <library name> <function name> <number of keys> [<key1> ... <keyn>] [<arg1> ... <argn>]
+```
+
+_Arguments_
+
+* _library name_ - The library name contains the function.
+* _function name_ - The function name to run.
+* _number of keys_ - The number of keys that will follow
+* _key1_ ... _keyn_ - keys that will be touched by the function.
+* _arg1_ ... _argn_ - Additional argument to pass to the function.
+
+_Return_
+
+The return value from the async function on error in case of failure.
+
+**Example**
+```bash
+> RG.FCALLASYNC lib foo 0
+"bar"
+```

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -121,7 +121,7 @@ The return value from the function on error in case of failure.
 
 # RG.FCALLASYNC
 
-Invoke an async function (coroutine).
+Invoke an async function (Coroutine).
 
 ```
 RG.FCALLASYNC <library name> <function name> <number of keys> [<key1> ... <keyn>] [<arg1> ... <argn>]

--- a/docs/sync_and_async_run.md
+++ b/docs/sync_and_async_run.md
@@ -175,7 +175,7 @@ redis.register_async_function('test', function(client, expected_name){
 
 `run_on_background` will return a `Promise` object, we return this Promise object as the function return value. When RedisGears sees that the function returned a Promise, it waits for the promise to be resolved and return its result to the client. The above implementation will be much faster in case of cache hit.
 
-**Notice** that even though we registered a sync function (not a coroutine) we still used `register_async_function`. This is because our function has the poterntial of blocking the client and take the execution to the background. If we would have used `register_function` RedisGears would not have allow us to blocke the client and would have ignore the returned promise object.
+**Notice** that even though we registered a sync function (not a Coroutine) we still used `register_async_function`. This is because our function has the potential of blocking the client and take the execution to the background. If we would have used `register_function` RedisGears would not have allow us to blocked the client and would have ignore the returned promise object.
 
 **Also notice** it is not always possible to wait for a promise to be resolved, if the command is called inside a `multi/exec` it is not possible to block it and wait for the promise. In such case the client will get an error. It is possible to check if blocking the client is allowed using `client.allow_block()` function that will return `true` if it is OK to wait for a promise to be resolved and `false` if its not possible.
 

--- a/docs/sync_and_async_run.md
+++ b/docs/sync_and_async_run.md
@@ -9,12 +9,12 @@ On major disadvantage of the atomicity property is that during the entire invoca
 
 RedisGears attempt to give a better flexibility to the Gears function writer and allow to invoke function on the background. When function is invoke on the background it can not touch the Redis key space, To touch the Redis key space from the background, the function must block Redis and enter an atomic section where the atomicity property is once again guaranteed.
 
-RedisGears function can go to the background by implement the function as a JS Coroutine. The Coroutine is invoked on a background thread and do not block the Redis processes. Example:
+RedisGears function can go to the background by implement the function as a JS Coroutine and use `register_async_function`. The Coroutine is invoked on a background thread and do not block the Redis processes. Example:
 
 ```js
 #!js api_version=1.0 name=lib
 
-redis.register_function('test', async function(){
+redis.register_async_function('test', async function(){
     return 'test';
 });
 ```
@@ -36,11 +36,13 @@ redis.register_function('test', async function(client){
 Running this function will return a `pong` reply:
 
 ```bash
-127.0.0.1:6379> RG.FCALL lib test 0
+127.0.0.1:6379> RG.FCALLASYNC lib test 0
 "PONG"
 ```
 
-Lets look at a more complex example, assuming we want to write a function that counts the number of hashes in Redis that has name property with some value. Lets first write a synchronous function that does it, we will use the [SCAN](https://redis.io/commands/scan/) command to scan the key space:
+Notice that this time, in order to invoke the function, we used [`RG.FCALLASYNC`](commands.md#rgfcallasync). **We can only invoke async functions using [`RG.FCALLASYNC`](commands.md#rgfcallasync)**.
+
+Now lets look at a more complex example, assuming we want to write a function that counts the number of hashes in Redis that has name property with some value. Lets first write a synchronous function that does it, we will use the [SCAN](https://redis.io/commands/scan/) command to scan the key space:
 
 ```js
 #!js api_version=1.0 name=lib
@@ -67,7 +69,7 @@ Though working fine, this function has a potential to block Redis for a long tim
 ```js
 #!js api_version=1.0 name=lib
 
-redis.register_function('test', async function(async_client, expected_name){
+redis.register_async_function('test', async function(async_client, expected_name){
     var count = 0;
     var cursor = '0';
     do{
@@ -95,7 +97,7 @@ The above example is costly, even though Redis is not blocked it is still takes 
 ```js
 #!js api_version=1.0 name=lib
 
-redis.register_function('test', async function(async_client, expected_name){
+redis.register_async_function('test', async function(async_client, expected_name){
     // check the cache first
     var cached_value = async_client.block((client)=>{
         return client.call('get', expected_name + '_count');
@@ -131,12 +133,12 @@ redis.register_function('test', async function(async_client, expected_name){
 });
 ```
 
-The above code works as expected, it first check the cache, if cache exists it returns it, otherwise it is perform the calculation and update the cache. But the above example is not optimal, the callback is a Coroutine which means that it will always be calculated on a background thread. Moving to a background thread by itself is costly, to best approach would have been to check the cache synchronously and only if its not there, move to the background. RedisGears allows to start synchronously and move asynchronously using `run_on_background` function. The new code:
+The above code works as expected, it first check the cache, if cache exists it returns it, otherwise it is perform the calculation and update the cache. But the above example is not optimal, the callback is a Coroutine which means that it will always be calculated on a background thread. Moving to a background thread by itself is costly, the best approach would have been to check the cache synchronously and only if its not there, move to the background. RedisGears allows to start synchronously and move asynchronously using `run_on_background` function. The new code:
 
 ```js
 #!js api_version=1.0 name=lib
 
-redis.register_function('test', function(client, expected_name){
+redis.register_async_function('test', function(client, expected_name){
     // check the cache first
     var cached_value = client.call('get', expected_name + '_count');
     if (cached_value != null) {
@@ -173,7 +175,9 @@ redis.register_function('test', function(client, expected_name){
 
 `run_on_background` will return a `Promise` object, we return this Promise object as the function return value. When RedisGears sees that the function returned a Promise, it waits for the promise to be resolved and return its result to the client. The above implementation will be much faster in case of cache hit.
 
-**Notice!!!** it is not always possible to wait for a promise to be resolved, if the command is called inside a `multi/exec` it is not possible to block it and wait for the promise. In such case the client will get an error. It is possible to check if blocking the client is allowed using `client.allow_block()` function that will return `true` if it is OK to wait for a promise to be resolved and `false` if its not possible.
+**Notice** that even though we registered a sync function (not a coroutine) we still used `register_async_function`. This is because our function has the poterntial of blocking the client and take the execution to the background. If we would have used `register_function` RedisGears would not have allow us to blocke the client and would have ignore the returned promise object.
+
+**Also notice** it is not always possible to wait for a promise to be resolved, if the command is called inside a `multi/exec` it is not possible to block it and wait for the promise. In such case the client will get an error. It is possible to check if blocking the client is allowed using `client.allow_block()` function that will return `true` if it is OK to wait for a promise to be resolved and `false` if its not possible.
 
 
 # Fail Blocking the Redis

--- a/pytests/test_basics.py
+++ b/pytests/test_basics.py
@@ -152,7 +152,7 @@ var continue_set = null;
 var set_done = null;
 var set_failed = null;
 
-redis.register_function("async_set_continue",
+redis.register_async_function("async_set_continue",
     async function(client) {
         if (continue_set == null) {
             throw "no async set was triggered"
@@ -186,7 +186,7 @@ redis.register_function("async_set_trigger", function(client, key, val){
     """
     env.expect('RG.FCALL', 'lib', 'async_set_trigger', '1', 'x', '1').equal('OK')
     env.expect('CONFIG', 'SET', 'maxmemory', '1')
-    env.expect('RG.FCALL', 'lib', 'async_set_continue', '0').error().contains('OOM Can not lock redis for write')
+    env.expect('RG.FCALLASYNC', 'lib', 'async_set_continue', '0').error().contains('OOM Can not lock redis for write')
 
 @gearsTest(withReplicas=True)
 def testRunOnReplica(env):
@@ -247,7 +247,7 @@ var continue_set = null;
 var set_done = null;
 var set_failed = null;
 
-redis.register_function("async_set_continue",
+redis.register_async_function("async_set_continue",
     async function(client) {
         if (continue_set == null) {
             throw "no async set was triggered"
@@ -281,7 +281,7 @@ redis.register_function("async_set_trigger", function(client, key, val){
     """
     env.expect('RG.FCALL', 'lib', 'async_set_trigger', '1', 'x', '1').equal('OK')
     env.expect('replicaof', '127.0.0.1', '33333')
-    env.expect('RG.FCALL', 'lib', 'async_set_continue', '0').error().contains('Can not lock redis for write on replica')
+    env.expect('RG.FCALLASYNC', 'lib', 'async_set_continue', '0').error().contains('Can not lock redis for write on replica')
     env.expect('replicaof', 'no', 'one')
 
 @gearsTest()
@@ -297,19 +297,19 @@ redis.register_function("test1", function(client){
 @gearsTest()
 def testAsyncScriptTimeout(env):
     """#!js api_version=1.0 name=lib
-redis.register_function("test1", async function(client){
+redis.register_async_function("test1", async function(client){
     client.block(function(){
         while (true);
     });
 });
     """
     env.expect('config', 'set', 'redisgears_2.lock-redis-timeout', '100').equal('OK')
-    env.expect('RG.FCALL', 'lib', 'test1', '0').error().contains('Execution was terminated due to OOM or timeout')
+    env.expect('RG.FCALLASYNC', 'lib', 'test1', '0').error().contains('Execution was terminated due to OOM or timeout')
 
 @gearsTest()
 def testTimeoutErrorNotCatchable(env):
     """#!js api_version=1.0 name=lib
-redis.register_function("test1", async function(client){
+redis.register_async_function("test1", async function(client){
     try {
         client.block(function(){
             while (true);
@@ -320,7 +320,7 @@ redis.register_function("test1", async function(client){
 });
     """
     env.expect('config', 'set', 'redisgears_2.lock-redis-timeout', '100').equal('OK')
-    env.expect('RG.FCALL', 'lib', 'test1', '0').error().contains('Execution was terminated due to OOM or timeout')
+    env.expect('RG.FCALLASYNC', 'lib', 'test1', '0').error().contains('Execution was terminated due to OOM or timeout')
 
 @gearsTest()
 def testScriptLoadTimeout(env):
@@ -555,11 +555,11 @@ redis.register_function("test", function(){
 @gearsTest()
 def testNoAsyncFunctionOnMultiExec(env):
     """#!js api_version=1.0 name=lib
-redis.register_function("test", async() => {return 'test'});
+redis.register_async_function("test", async() => {return 'test'});
     """
     conn = env.getConnection()
     p = conn.pipeline()
-    p.execute_command('RG.FCALL', 'lib', 'test', '0')
+    p.execute_command('RG.FCALLASYNC', 'lib', 'test', '0')
     try:
         p.execute()
         env.assertTrue(False, message='Except error on async function inside transaction')
@@ -585,12 +585,14 @@ def testAllowBlockAPI(env):
     """#!js api_version=1.0 name=lib
 redis.register_function("test", (c) => {return c.allow_block()});
     """
-    env.expect('RG.FCALL', 'lib', 'test', '0').equal(1)
+    env.expect('RG.FCALL', 'lib', 'test', '0').equal(0)
+    env.expect('RG.FCALLASYNC', 'lib', 'test', '0').equal(1)
     conn = env.getConnection()
     p = conn.pipeline()
     p.execute_command('RG.FCALL', 'lib', 'test', '0')
+    p.execute_command('RG.FCALLASYNC', 'lib', 'test', '0')
     res = p.execute()
-    env.assertEqual(res, [0])
+    env.assertEqual(res, [0, 0])
 
 @gearsTest(decodeResponses=False)
 def testRawArguments(env):
@@ -608,16 +610,16 @@ redis.register_function("my_set", (c, key, val) => {
 @gearsTest(decodeResponses=False)
 def testRawArgumentsAsync(env):
     """#!js api_version=1.0 name=lib
-redis.register_function("my_set", async (c, key, val) => {
+redis.register_async_function("my_set", async (c, key, val) => {
     return c.block((c)=>{
         return c.call("set", key, val);
     });
 },
 ["raw-arguments"]);
     """
-    env.expect('RG.FCALL', 'lib', 'my_set', '1', "x", "1").equal(b'OK')
+    env.expect('RG.FCALLASYNC', 'lib', 'my_set', '1', "x", "1").equal(b'OK')
     env.expect('get', 'x').equal(b'1')
-    env.expect('RG.FCALL', 'lib', 'my_set', '1', b'\xaa', b'\xaa').equal(b'OK')
+    env.expect('RG.FCALLASYNC', 'lib', 'my_set', '1', b'\xaa', b'\xaa').equal(b'OK')
     env.expect('get', b'\xaa').equal(b'\xaa')
 
 @gearsTest(decodeResponses=False)
@@ -697,13 +699,13 @@ redis.register_notifications_consumer("consumer", "", function(client, data) {})
 @gearsTest()
 def testReplyWithSimpleString(env):
     """#!js api_version=1.0 name=lib
-redis.register_function("test", async () => {
+redis.register_async_function("test", async () => {
     var res = new String('test');
     res.__reply_type = 'status';
     return res;
 });
     """
-    env.expect('RG.FCALL', 'lib', 'test', '0').equal("test")
+    env.expect('RG.FCALLASYNC', 'lib', 'test', '0').equal("test")
 
 @gearsTest()
 def testReplyWithDouble(env):
@@ -717,11 +719,11 @@ redis.register_function("test", () => {
 @gearsTest()
 def testReplyWithDoubleAsync(env):
     """#!js api_version=1.0 name=lib
-redis.register_function("test", async () => {
+redis.register_async_function("test", async () => {
     return 1.1;
 });
     """
-    env.expect('RG.FCALL', 'lib', 'test', '0').contains("1.1")
+    env.expect('RG.FCALLASYNC', 'lib', 'test', '0').contains("1.1")
 
 @gearsTest()
 def testRunOnBackgroundThatRaisesError(env):
@@ -732,7 +734,7 @@ redis.register_function("test", (c) => {
     });
 });
     """
-    env.expect('RG.FCALL', 'lib', 'test', '0').error().equal("Some Error")
+    env.expect('RG.FCALLASYNC', 'lib', 'test', '0').error().equal("Some Error")
 
 @gearsTest()
 def testRunOnBackgroundThatReturnInteger(env):
@@ -743,7 +745,7 @@ redis.register_function("test", (c) => {
     });
 });
     """
-    env.expect('RG.FCALL', 'lib', 'test', '0').equal(1)
+    env.expect('RG.FCALLASYNC', 'lib', 'test', '0').equal(1)
 
 @gearsTest()
 def testOver100Isolates(env):

--- a/pytests/test_errors.py
+++ b/pytests/test_errors.py
@@ -501,7 +501,7 @@ def testCallAsyncFunctionWithRGFCALL(env):
     '''#!js api_version=1.0 name=lib
 redis.register_async_function('test', async () => {return 1})
     '''
-    env.expect('RG.FCALL', 'lib', 'test', '0').error().contains('Function is declated async and was called while blocking is not allowed')
+    env.expect('RG.FCALL', 'lib', 'test', '0').error().contains('function is declared as async and was called while blocking was not allowed')
 
 @gearsTest()
 def testBlockOnRGFCall(env):

--- a/pytests/test_notifications_consumers.py
+++ b/pytests/test_notifications_consumers.py
@@ -34,18 +34,18 @@ redis.register_notifications_consumer("consumer", "", async function(client, dat
     n_notifications += 1;
 });
 
-redis.register_function("n_notifications", async function(){
+redis.register_async_function("n_notifications", async function(){
     return n_notifications
 })
     """
 
-    env.expect('RG.FCALL', 'lib', 'n_notifications', '0').equal(0)
+    env.expect('RG.FCALLASYNC', 'lib', 'n_notifications', '0').equal(0)
     env.expect('SET', 'X', '1').equal(True)
-    runUntil(env, 1, lambda: env.cmd('RG.FCALL', 'lib', 'n_notifications', '0'))
+    runUntil(env, 1, lambda: env.cmd('RG.FCALLASYNC', 'lib', 'n_notifications', '0'))
     env.expect('SET', 'X', '2').equal(True)
-    runUntil(env, 2, lambda: env.cmd('RG.FCALL', 'lib', 'n_notifications', '0'))
+    runUntil(env, 2, lambda: env.cmd('RG.FCALLASYNC', 'lib', 'n_notifications', '0'))
     env.expect('SET', 'X', '1').equal(True)
-    runUntil(env, 3, lambda: env.cmd('RG.FCALL', 'lib', 'n_notifications', '0'))
+    runUntil(env, 3, lambda: env.cmd('RG.FCALLASYNC', 'lib', 'n_notifications', '0'))
 
 @gearsTest()
 def testCallRedisOnNotification(env):
@@ -73,7 +73,7 @@ redis.register_notifications_consumer("consumer", "", function(client, data) {
     n_notifications += 1;
 });
 
-redis.register_function("n_notifications", async function(){
+redis.register_async_function("n_notifications", async function(){
     return n_notifications
 });
 
@@ -81,11 +81,11 @@ redis.register_function("simple_set", function(client){
     return client.call('set', 'x', '1');
 });
     """
-    env.expect('RG.FCALL', 'lib', 'n_notifications', '0').equal(0)
+    env.expect('RG.FCALLASYNC', 'lib', 'n_notifications', '0').equal(0)
     env.expect('SET', 'X', '1').equal(True)
-    env.expect('RG.FCALL', 'lib', 'n_notifications', '0').equal(1)
+    env.expect('RG.FCALLASYNC', 'lib', 'n_notifications', '0').equal(1)
     env.expect('RG.FCALL', 'lib', 'simple_set', '0').equal('OK')
-    env.expect('RG.FCALL', 'lib', 'n_notifications', '0').equal(1)
+    env.expect('RG.FCALLASYNC', 'lib', 'n_notifications', '0').equal(1)
 
 @gearsTest()
 def testNotificationsAreNotFiredFromWithinAsyncFunction(env):
@@ -95,21 +95,21 @@ redis.register_notifications_consumer("consumer", "", function(client, data) {
     n_notifications += 1;
 });
 
-redis.register_function("n_notifications", async function(){
+redis.register_async_function("n_notifications", async function(){
     return n_notifications
 });
 
-redis.register_function("simple_set", async function(client){
+redis.register_async_function("simple_set", async function(client){
     return client.block(function(client){
         return client.call('set', 'x', '1');
     });
 });
     """
-    env.expect('RG.FCALL', 'lib', 'n_notifications', '0').equal(0)
+    env.expect('RG.FCALLASYNC', 'lib', 'n_notifications', '0').equal(0)
     env.expect('SET', 'X', '1').equal(True)
-    env.expect('RG.FCALL', 'lib', 'n_notifications', '0').equal(1)
-    env.expect('RG.FCALL', 'lib', 'simple_set', '0').equal('OK')
-    env.expect('RG.FCALL', 'lib', 'n_notifications', '0').equal(1)
+    env.expect('RG.FCALLASYNC', 'lib', 'n_notifications', '0').equal(1)
+    env.expect('RG.FCALLASYNC', 'lib', 'simple_set', '0').equal('OK')
+    env.expect('RG.FCALLASYNC', 'lib', 'n_notifications', '0').equal(1)
 
 @gearsTest()
 def testNotificationsAreNotFiredFromWithinAnotherNotification(env):
@@ -120,13 +120,13 @@ redis.register_notifications_consumer("consumer", "", function(client, data) {
     n_notifications += 1;
 });
 
-redis.register_function("n_notifications", async function(){
+redis.register_async_function("n_notifications", async function(){
     return n_notifications
 });
     """
-    env.expect('RG.FCALL', 'lib', 'n_notifications', '0').equal(0)
+    env.expect('RG.FCALLASYNC', 'lib', 'n_notifications', '0').equal(0)
     env.expect('SET', 'X', '1').equal(True)
-    env.expect('RG.FCALL', 'lib', 'n_notifications', '0').equal(1)
+    env.expect('RG.FCALLASYNC', 'lib', 'n_notifications', '0').equal(1)
 
 @gearsTest()
 def testNotificationsAreNotFiredFromWithinStreamConsumer(env):
@@ -139,7 +139,7 @@ redis.register_notifications_consumer("consumer", "", function(client, data) {
     }
 });
 
-redis.register_function("n_notifications", async function(){
+redis.register_async_function("n_notifications", async function(){
     return n_notifications
 });
 
@@ -147,12 +147,12 @@ redis.register_stream_consumer("consumer", "stream", 1, true, function(client) {
     client.call('set', 'X' , '2');
 })
     """
-    env.expect('RG.FCALL', 'lib', 'n_notifications', '0').equal(0)
+    env.expect('RG.FCALLASYNC', 'lib', 'n_notifications', '0').equal(0)
     env.expect('SET', 'X', '1').equal(True)
-    env.expect('RG.FCALL', 'lib', 'n_notifications', '0').equal(1)
+    env.expect('RG.FCALLASYNC', 'lib', 'n_notifications', '0').equal(1)
     env.cmd('XADD', 'stream:1', '*', 'foo', 'bar')
     env.expect('GET', 'X').equal('2')
-    env.expect('RG.FCALL', 'lib', 'n_notifications', '0').equal(1)
+    env.expect('RG.FCALLASYNC', 'lib', 'n_notifications', '0').equal(1)
 
 @gearsTest(decodeResponses=False)
 def testNotificationsOnBinaryKey(env):
@@ -168,7 +168,7 @@ redis.register_notifications_consumer("consumer", new Uint8Array([255]).buffer, 
     }
 });
 
-redis.register_function("notifications_stats", async function(){
+redis.register_async_function("notifications_stats", async function(){
     return [
         n_notifications,
         last_key,
@@ -176,9 +176,9 @@ redis.register_function("notifications_stats", async function(){
     ];
 });
     """
-    env.expect('RG.FCALL', 'lib', 'notifications_stats', '0').equal([0, None, None])
+    env.expect('RG.FCALLASYNC', 'lib', 'notifications_stats', '0').equal([0, None, None])
     env.expect('SET', b'\xff\xff', b'\xaa').equal(True)
-    env.expect('RG.FCALL', 'lib', 'notifications_stats', '0').equal([1, None, b'\xff\xff'])
+    env.expect('RG.FCALLASYNC', 'lib', 'notifications_stats', '0').equal([1, None, b'\xff\xff'])
 
 @gearsTest()
 def testSyncNotificationsReturnPromise(env):

--- a/pytests/test_stream_reader.py
+++ b/pytests/test_stream_reader.py
@@ -444,7 +444,7 @@ def testBecomeReplicaWhileProcessingData(env):
 var promise = null;
 var done = null;
 
-redis.register_function("continue_process", async function(){
+redis.register_async_function("continue_process", async function(){
     if (promise == null) {
         return "no data to processes";
     }
@@ -468,15 +468,15 @@ redis.register_stream_consumer("consumer", "stream", 1, true, async function(cli
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 'OK', lambda: env.cmd('RG.FCALL', 'lib', 'continue_process', '0'))
+    runUntil(env, 'OK', lambda: env.cmd('RG.FCALLASYNC', 'lib', 'continue_process', '0'))
     runUntil(env, 1, lambda: toDictionary(toDictionary(env.execute_command('RG.FUNCTION', 'LIST', 'vvv'), 4)[0]['stream_consumers'][0]['streams'][0], 1)['total_record_processed'])
 
     # Turn into a slave
     env.cmd('slaveof', '127.0.0.1', '3300')
-    runUntil(env, 'OK', lambda: env.cmd('RG.FCALL', 'lib', 'continue_process', '0'))
+    runUntil(env, 'OK', lambda: env.cmd('RG.FCALLASYNC', 'lib', 'continue_process', '0'))
     runUntil(env, 2, lambda: toDictionary(toDictionary(env.execute_command('RG.FUNCTION', 'LIST', 'vvv'), 4)[0]['stream_consumers'][0]['streams'][0], 1)['total_record_processed'])
 
-    runFor('no data to processes', lambda: env.cmd('RG.FCALL', 'lib', 'continue_process', '0'))
+    runFor('no data to processes', lambda: env.cmd('RG.FCALLASYNC', 'lib', 'continue_process', '0'))
     res = toDictionary(toDictionary(env.execute_command('RG.FUNCTION', 'LIST', 'vvv'), 4)[0]['stream_consumers'][0]['streams'][0], 1)['total_record_processed']
     env.assertEqual(2, res)
 

--- a/pytests/test_verbose_error_reporting.py
+++ b/pytests/test_verbose_error_reporting.py
@@ -24,11 +24,11 @@ redis.register_function("test", function(client){
 @gearsTest(errorVerbosity=2)
 def testVerboseErrorOnAsyncFunctionRun(env):
     '''#!js api_version=1.0 name=foo
-redis.register_function("test", async function(client){
+redis.register_async_function("test", async function(client){
     return foo()
 })
     '''
-    env.expect('RG.FCALL', 'foo', 'test', 0).error().contains(':3:') # error on line 5
+    env.expect('RG.FCALLASYNC', 'foo', 'test', 0).error().contains(':3:') # error on line 5
 
 @gearsTest(errorVerbosity=2)
 def testVerboseErrorOnFunctionThatReturnsCoro(env):
@@ -39,7 +39,7 @@ redis.register_function("test", function(client){
     });
 })
     '''
-    env.expect('RG.FCALL', 'foo', 'test', 0).error().contains(':4:') # error on line 5
+    env.expect('RG.FCALLASYNC', 'foo', 'test', 0).error().contains(':4:') # error on line 5
 
 @gearsTest(errorVerbosity=2)
 def testVerboseErrorOnStreamProcessing(env):

--- a/ramp.yml
+++ b/ramp.yml
@@ -22,7 +22,8 @@ capabilities:
     - intershard_tls_pass
     - ipv6
 exclude_commands:
-    - _RG.FUNCTION
+    - _RG_INTERNALS.FUNCTION
+    - _RG_INTERNALS.UPDATE_STREAM_LAST_READ_ID
     - redisgears_2.REFRESHCLUSTER
     - redisgears_2.INFOCLUSTER
     - redisgears_2.NETWORKTEST
@@ -31,8 +32,12 @@ exclude_commands:
     - redisgears_2.CLUSTERSETFROMSHARD
     - rg.config_set
     - RG.CONFIG_SET
+    - rg.fcall
+    - RG.FCALL
+    - rg.fcallasync
+    - RG.FCALLASYNC
     - _rg_internals.update_stream_last_read_id
-    - _rg.function
+    - _rg_internals.function
 dependencies:
     gears_v8:
         local_path: "{os.getenv('REDISGEARS_V8_PLUGIN_PATH')}"

--- a/redisgears_core/src/function_del_command.rs
+++ b/redisgears_core/src/function_del_command.rs
@@ -61,7 +61,10 @@ impl RemoteTask for GearsFunctionDelRemoteTask {
         let mut libraries = get_libraries();
         let res = match libraries.remove(&r.lib_name) {
             Some(_) => {
-                ctx_guard.replicate("_rg.function", &["del".as_bytes(), r.lib_name.as_bytes()]);
+                ctx_guard.replicate(
+                    "_rg_internals.function",
+                    &["del".as_bytes(), r.lib_name.as_bytes()],
+                );
                 Ok(GearsFunctionDelOutputRecord)
             }
             None => Err("library does not exists".to_string()),

--- a/redisgears_core/src/function_list_command.rs
+++ b/redisgears_core/src/function_list_command.rs
@@ -113,6 +113,10 @@ pub(crate) fn function_list_command(
                                                 RedisValueKey::String("flags".to_string()),
                                                 function_list_command_flags(v.flags),
                                             ),
+                                            (
+                                                RedisValueKey::String("is_async".to_string()),
+                                                RedisValue::Bool(v.is_async),
+                                            ),
                                         ]))
                                     })
                                     .collect::<Vec<RedisValue>>()

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -292,7 +292,7 @@ impl RemoteTask for GearsFunctionLoadRemoteTask {
                 replicate_args.push("USER".as_bytes());
                 replicate_args.push(user.as_slice());
                 replicate_args.push(r.args.code.as_bytes());
-                ctx_guard.replicate("_rg.function", replicate_args.as_slice());
+                ctx_guard.replicate("_rg_internals.function", replicate_args.as_slice());
             }
             res
         };

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -35,7 +35,7 @@ use redis_module::server_events::{
     FlushSubevent, LoadingSubevent, ModuleChangeSubevent, ServerRole,
 };
 use redis_module_macros::{
-    flush_event_handler, loading_event_handler, module_changed_event_handler, redis_command,
+    command, flush_event_handler, loading_event_handler, module_changed_event_handler,
     role_changed_event_handler,
 };
 
@@ -741,7 +741,7 @@ fn function_call_command(
         if let FunctionCallResult::Hold = res {
             if !allow_block {
                 // If we reach here, it means that the plugin violates the API, it blocked the client even though it is not allow to.
-                DETACHED_CONTEXT.log_warning("Plugin API violation, plugin blocked the client even though blocking is forbiden.");
+                log::warn!("Plugin API violation, plugin blocked the client even though blocking is forbiden.");
                 return Err(RedisError::Str(
                     "Clien got blocked when blocking is not allow",
                 ));
@@ -947,16 +947,16 @@ pub(crate) fn get_msg_verbose(err: &GearsApiError) -> &str {
     err.get_msg_verbose()
 }
 
-#[redis_command(
+#[command(
     {
         name: "rg.fcall",
-        flags: "may-replicate deny-script no-mandatory-keys",
+        flags: [MayReplicate, DenyScript, NoMandatoryKeys],
         arity: -4,
         key_spec: [
             {
-                flags: ["RW", "ACCESS", "UPDATE"],
-                begin_search: Index(3),
-                find_keys: Keynum((0, 1, 1)),
+                flags: [ReadWrite, Access, Update],
+                begin_search: Index({ index : 3}),
+                find_keys: Keynum({ key_num_idx : 0, first_key : 1, key_step : 1 }),
             }
         ],
     }
@@ -966,16 +966,16 @@ fn function_call(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     function_call_command(ctx, args, false)
 }
 
-#[redis_command(
+#[command(
     {
         name: "rg.fcallasync",
-        flags: "may-replicate deny-script no-mandatory-keys",
+        flags: [MayReplicate, DenyScript, NoMandatoryKeys],
         arity: -4,
         key_spec: [
             {
-                flags: ["RW", "ACCESS", "UPDATE"],
-                begin_search: Index(3),
-                find_keys: Keynum((0, 1, 1)),
+                flags: [ReadWrite, Access, Update],
+                begin_search: Index({ index : 3}),
+                find_keys: Keynum({ key_num_idx : 0, first_key : 1, key_step : 1 }),
             }
         ],
     }
@@ -985,10 +985,10 @@ fn function_call_async(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     function_call_command(ctx, args, true)
 }
 
-#[redis_command(
+#[command(
     {
         name: "_rg_internals.function",
-        flags: "may-replicate deny-script no-mandatory-keys",
+        flags: [MayReplicate, DenyScript, NoMandatoryKeys],
         arity: -3,
         key_spec: [],
     }
@@ -1006,10 +1006,10 @@ fn function_command_on_replica(ctx: &Context, args: Vec<RedisString>) -> RedisRe
     }
 }
 
-#[redis_command(
+#[command(
     {
         name: "rg.function",
-        flags: "may-replicate deny-script no-mandatory-keys",
+        flags: [MayReplicate, DenyScript, NoMandatoryKeys],
         arity: -2,
         key_spec: [],
     }
@@ -1029,10 +1029,10 @@ fn function_command(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     }
 }
 
-#[redis_command(
+#[command(
     {
         name: "rg.box",
-        flags: "may-replicate deny-script no-mandatory-keys",
+        flags: [MayReplicate, DenyScript, NoMandatoryKeys],
         arity: -3,
         key_spec: [],
     }
@@ -1050,10 +1050,10 @@ fn gears_box_command(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     }
 }
 
-#[redis_command(
+#[command(
     {
         name: "_rg_internals.update_stream_last_read_id",
-        flags: "readonly deny-script no-mandatory-keys",
+        flags: [ReadOnly, DenyScript, NoMandatoryKeys],
         arity: 6,
         key_spec: [],
     }

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -954,7 +954,7 @@ pub(crate) fn get_msg_verbose(err: &GearsApiError) -> &str {
         arity: -4,
         key_spec: [
             {
-                flags: ["RO", "ACCESS"],
+                flags: ["RW", "ACCESS", "UPDATE"],
                 begin_search: Index(3),
                 find_keys: Keynum((0, 1, 1)),
             }
@@ -973,7 +973,7 @@ fn function_call(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
         arity: -4,
         key_spec: [
             {
-                flags: ["RO", "ACCESS"],
+                flags: ["RW", "ACCESS", "UPDATE"],
                 begin_search: Index(3),
                 find_keys: Keynum((0, 1, 1)),
             }

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -158,7 +158,7 @@ impl GearsFunctionCtx {
         is_async: bool,
     ) -> GearsFunctionCtx {
         GearsFunctionCtx {
-            func: func,
+            func,
             flags,
             is_async,
         }

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -35,7 +35,7 @@ use redis_module::server_events::{
     FlushSubevent, LoadingSubevent, ModuleChangeSubevent, ServerRole,
 };
 use redis_module_macros::{
-    flush_event_handler, loading_event_handler, module_changed_event_handler,
+    flush_event_handler, loading_event_handler, module_changed_event_handler, redis_command,
     role_changed_event_handler,
 };
 
@@ -48,7 +48,7 @@ use redisgears_plugin_api::redisgears_plugin_api::{
     stream_ctx::StreamCtxInterface, GearsApiError,
 };
 
-use redisgears_plugin_api::redisgears_plugin_api::RefCellWrapper;
+use redisgears_plugin_api::redisgears_plugin_api::{FunctionCallResult, RefCellWrapper};
 
 use crate::run_ctx::RunCtx;
 
@@ -148,11 +148,20 @@ pub struct GearsLibraryMetaData {
 struct GearsFunctionCtx {
     func: Box<dyn FunctionCtxInterface>,
     flags: FunctionFlags,
+    is_async: bool,
 }
 
 impl GearsFunctionCtx {
-    fn new(func: Box<dyn FunctionCtxInterface>, flags: FunctionFlags) -> GearsFunctionCtx {
-        GearsFunctionCtx { func, flags }
+    fn new(
+        func: Box<dyn FunctionCtxInterface>,
+        flags: FunctionFlags,
+        is_async: bool,
+    ) -> GearsFunctionCtx {
+        GearsFunctionCtx {
+            func: func,
+            flags,
+            is_async,
+        }
     }
 }
 
@@ -183,12 +192,11 @@ struct GearsLibrary {
     gears_box_lib: Option<GearsBoxLibraryInfo>,
 }
 
-impl<'ctx, 'lib_ctx> LoadLibraryCtxInterface for GearsLoadLibraryCtx<'ctx, 'lib_ctx> {
-    fn register_function(
+impl<'ctx, 'lib_ctx> GearsLoadLibraryCtx<'ctx, 'lib_ctx> {
+    fn register_function_internal(
         &mut self,
         name: &str,
-        function_ctx: Box<dyn FunctionCtxInterface>,
-        flags: FunctionFlags,
+        func_ctx: GearsFunctionCtx,
     ) -> Result<(), GearsApiError> {
         if self.gears_lib_ctx.functions.contains_key(name) {
             return Err(GearsApiError::new(format!(
@@ -196,11 +204,30 @@ impl<'ctx, 'lib_ctx> LoadLibraryCtxInterface for GearsLoadLibraryCtx<'ctx, 'lib_
                 name
             )));
         }
-        let func_ctx = GearsFunctionCtx::new(function_ctx, flags);
         self.gears_lib_ctx
             .functions
             .insert(name.to_string(), func_ctx);
         Ok(())
+    }
+}
+
+impl<'ctx, 'lib_ctx> LoadLibraryCtxInterface for GearsLoadLibraryCtx<'ctx, 'lib_ctx> {
+    fn register_function(
+        &mut self,
+        name: &str,
+        function_ctx: Box<dyn FunctionCtxInterface>,
+        flags: FunctionFlags,
+    ) -> Result<(), GearsApiError> {
+        self.register_function_internal(name, GearsFunctionCtx::new(function_ctx, flags, false))
+    }
+
+    fn register_async_function(
+        &mut self,
+        name: &str,
+        function_ctx: Box<dyn FunctionCtxInterface>,
+        flags: FunctionFlags,
+    ) -> Result<(), GearsApiError> {
+        self.register_function_internal(name, GearsFunctionCtx::new(function_ctx, flags, true))
     }
 
     fn register_remote_task(
@@ -659,6 +686,7 @@ pub(crate) fn verify_ok_on_replica(ctx: &Context, flags: FunctionFlags) -> bool 
 fn function_call_command(
     ctx: &Context,
     mut args: Skip<IntoIter<redis_module::RedisString>>,
+    allow_block: bool,
 ) -> RedisResult {
     let library_name = args.next_arg()?.try_as_str()?;
     let function_name = args.next_arg()?.try_as_str()?;
@@ -696,17 +724,31 @@ fn function_call_command(
         )));
     }
 
+    if function.is_async && !allow_block {
+        // Blocking is not allowed but the function declated as async which means it might block, we will not invoke it.
+        return Err(RedisError::Str("Function is declated async and was called while blocking is not allowed, notice that you can not invoke async functions from within lua or multi, and you must use RG.FCALLASYNC."));
+    }
+
     {
         let _notification_blocker = get_notification_blocker();
-        function.func.call(&RunCtx {
+        let res = function.func.call(&RunCtx {
             ctx,
             args,
             flags: function.flags,
             lib_meta_data: Arc::clone(&lib.gears_lib_ctx.meta_data),
+            allow_block: allow_block,
         });
+        if let FunctionCallResult::Hold = res {
+            if !allow_block {
+                // If we reach here, it means that the plugin violates the API, it blocked the client even though it is not allow to.
+                DETACHED_CONTEXT.log_warning("Plugin API violation, plugin blocked the client even though blocking is forbiden.");
+                return Err(RedisError::Str(
+                    "Clien got blocked when blocking is not allow",
+                ));
+            }
+        }
+        Ok(RedisValue::NoReply)
     }
-
-    Ok(RedisValue::NoReply)
 }
 
 fn function_debug_command(
@@ -801,52 +843,6 @@ fn function_search_lib_command(
     Ok(json_to_redis_value(search_result))
 }
 
-fn function_call(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
-    let args = args.into_iter().skip(1);
-    function_call_command(ctx, args)
-}
-
-fn function_command_on_replica(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
-    let mut args = args.into_iter().skip(1);
-    let sub_command = args.next_arg()?.try_as_str()?.to_lowercase();
-    match sub_command.as_ref() {
-        "load" => function_load_command::function_load_on_replica(ctx, args),
-        "del" => function_del_command::function_del_on_replica(ctx, args),
-        _ => Err(RedisError::String(format!(
-            "Unknown subcommand {}",
-            sub_command
-        ))),
-    }
-}
-
-fn function_command(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
-    let mut args = args.into_iter().skip(1);
-    let sub_command = args.next_arg()?.try_as_str()?.to_lowercase();
-    match sub_command.as_ref() {
-        "load" => function_load_command::function_load_command(ctx, args),
-        "list" => function_list_command::function_list_command(ctx, args),
-        "del" => function_del_command::function_del_command(ctx, args),
-        "debug" => function_debug_command(ctx, args),
-        _ => Err(RedisError::String(format!(
-            "Unknown subcommand {}",
-            sub_command
-        ))),
-    }
-}
-
-fn gears_box_command(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
-    let mut args = args.into_iter().skip(1);
-    let sub_command = args.next_arg()?.try_as_str()?.to_lowercase();
-    match sub_command.as_ref() {
-        "search" => function_search_lib_command(ctx, args),
-        "install" => function_load_command::function_install_lib_command(ctx, args),
-        _ => Err(RedisError::String(format!(
-            "Unknown subcommand {}",
-            sub_command
-        ))),
-    }
-}
-
 fn on_stream_touched(ctx: &Context, _event_type: NotifyEvent, event: &str, key: &[u8]) {
     if ctx.get_flags().contains(ContextFlags::MASTER) {
         let stream_ctx = &mut get_globals_mut().stream_ctx;
@@ -867,38 +863,6 @@ fn key_space_notification(ctx: &Context, _event_type: NotifyEvent, event: &str, 
         return;
     }
     globals.notifications_ctx.on_key_touched(ctx, event, key)
-}
-
-fn update_stream_last_read_id(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
-    let mut args = args.into_iter().skip(1);
-    let library_name = args.next_arg()?.try_as_str()?;
-    let stream_consumer = args.next_arg()?.try_as_str()?;
-    let stream_arg = args.next_arg()?;
-    let stream = stream_arg.as_slice();
-    let ms = args.next_arg()?.try_as_str()?.parse::<u64>()?;
-    let seq = args.next_arg()?.try_as_str()?.parse::<u64>()?;
-    let libraries = get_libraries();
-    let library = libraries.get(library_name);
-    if library.is_none() {
-        return Err(RedisError::String(format!(
-            "No such library '{}'",
-            library_name
-        )));
-    }
-    let library = library.unwrap();
-    let consumer = library.gears_lib_ctx.stream_consumers.get(stream_consumer);
-    if consumer.is_none() {
-        return Err(RedisError::String(format!(
-            "No such consumer '{}'",
-            stream_consumer
-        )));
-    }
-    let consumer = consumer.unwrap();
-    get_globals_mut()
-        .stream_ctx
-        .update_stream_for_consumer(stream, consumer, ms, seq);
-    ctx.replicate_verbatim();
-    Ok(RedisValue::SimpleStringStatic("OK"))
 }
 
 fn scan_key_space_for_streams() {
@@ -983,6 +947,149 @@ pub(crate) fn get_msg_verbose(err: &GearsApiError) -> &str {
     err.get_msg_verbose()
 }
 
+#[redis_command(
+    {
+        name: "rg.fcall",
+        flags: "may-replicate deny-script no-mandatory-keys",
+        arity: -4,
+        key_spec: [
+            {
+                flags: ["RO", "ACCESS"],
+                begin_search: Index(3),
+                find_keys: Keynum((0, 1, 1)),
+            }
+        ],
+    }
+)]
+fn function_call(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    let args = args.into_iter().skip(1);
+    function_call_command(ctx, args, false)
+}
+
+#[redis_command(
+    {
+        name: "rg.fcallasync",
+        flags: "may-replicate deny-script no-mandatory-keys",
+        arity: -4,
+        key_spec: [
+            {
+                flags: ["RO", "ACCESS"],
+                begin_search: Index(3),
+                find_keys: Keynum((0, 1, 1)),
+            }
+        ],
+    }
+)]
+fn function_call_async(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    let args = args.into_iter().skip(1);
+    function_call_command(ctx, args, true)
+}
+
+#[redis_command(
+    {
+        name: "_rg_internals.function",
+        flags: "may-replicate deny-script no-mandatory-keys",
+        arity: -3,
+        key_spec: [],
+    }
+)]
+fn function_command_on_replica(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    let mut args = args.into_iter().skip(1);
+    let sub_command = args.next_arg()?.try_as_str()?.to_lowercase();
+    match sub_command.as_ref() {
+        "load" => function_load_command::function_load_on_replica(ctx, args),
+        "del" => function_del_command::function_del_on_replica(ctx, args),
+        _ => Err(RedisError::String(format!(
+            "Unknown subcommand {}",
+            sub_command
+        ))),
+    }
+}
+
+#[redis_command(
+    {
+        name: "rg.function",
+        flags: "may-replicate deny-script no-mandatory-keys",
+        arity: -2,
+        key_spec: [],
+    }
+)]
+fn function_command(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    let mut args = args.into_iter().skip(1);
+    let sub_command = args.next_arg()?.try_as_str()?.to_lowercase();
+    match sub_command.as_ref() {
+        "load" => function_load_command::function_load_command(ctx, args),
+        "list" => function_list_command::function_list_command(ctx, args),
+        "del" => function_del_command::function_del_command(ctx, args),
+        "debug" => function_debug_command(ctx, args),
+        _ => Err(RedisError::String(format!(
+            "Unknown subcommand {}",
+            sub_command
+        ))),
+    }
+}
+
+#[redis_command(
+    {
+        name: "rg.box",
+        flags: "may-replicate deny-script no-mandatory-keys",
+        arity: -3,
+        key_spec: [],
+    }
+)]
+fn gears_box_command(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    let mut args = args.into_iter().skip(1);
+    let sub_command = args.next_arg()?.try_as_str()?.to_lowercase();
+    match sub_command.as_ref() {
+        "search" => function_search_lib_command(ctx, args),
+        "install" => function_load_command::function_install_lib_command(ctx, args),
+        _ => Err(RedisError::String(format!(
+            "Unknown subcommand {}",
+            sub_command
+        ))),
+    }
+}
+
+#[redis_command(
+    {
+        name: "_rg_internals.update_stream_last_read_id",
+        flags: "readonly deny-script no-mandatory-keys",
+        arity: 6,
+        key_spec: [],
+    }
+)]
+fn update_stream_last_read_id(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    let mut args = args.into_iter().skip(1);
+    let library_name = args.next_arg()?.try_as_str()?;
+    let stream_consumer = args.next_arg()?.try_as_str()?;
+    let stream_arg = args.next_arg()?;
+    let stream = stream_arg.as_slice();
+    let ms = args.next_arg()?.try_as_str()?.parse::<u64>()?;
+    let seq = args.next_arg()?.try_as_str()?.parse::<u64>()?;
+    let libraries = get_libraries();
+    let library = libraries.get(library_name);
+    if library.is_none() {
+        return Err(RedisError::String(format!(
+            "No such library '{}'",
+            library_name
+        )));
+    }
+    let library = library.unwrap();
+    let consumer = library.gears_lib_ctx.stream_consumers.get(stream_consumer);
+    if consumer.is_none() {
+        return Err(RedisError::String(format!(
+            "No such consumer '{}'",
+            stream_consumer
+        )));
+    }
+    let consumer = consumer.unwrap();
+    get_globals_mut()
+        .stream_ctx
+        .update_stream_for_consumer(stream, consumer, ms, seq);
+    ctx.replicate_verbatim();
+    Ok(RedisValue::SimpleStringStatic("OK"))
+}
+
 #[cfg(not(test))]
 macro_rules! get_allocator {
     () => {
@@ -1011,14 +1118,7 @@ mod gears_module {
         data_types: [REDIS_GEARS_TYPE],
         init: js_init,
         info: js_info,
-        commands: [
-            ["rg.function", function_command, "may-replicate deny-script", 0,0,0],
-            ["_rg.function", function_command_on_replica, "may-replicate deny-script", 0,0,0],
-            ["rg.fcall", function_call, "may-replicate deny-script", 4,4,1],
-            ["rg.fcall_no_keys", function_call, "may-replicate deny-script", 0,0,0],
-            ["rg.box", gears_box_command, "may-replicate deny-script", 0,0,0],
-            ["_rg_internals.update_stream_last_read_id", update_stream_last_read_id, "readonly", 0,0,0],
-        ],
+        commands: [],
         event_handlers: [
             [@STREAM: on_stream_touched],
             [@GENERIC: generic_notification],

--- a/redisgears_core/src/run_ctx.rs
+++ b/redisgears_core/src/run_ctx.rs
@@ -127,6 +127,7 @@ pub(crate) struct RunCtx<'a> {
     pub(crate) args: Vec<redis_module::RedisString>,
     pub(crate) flags: FunctionFlags,
     pub(crate) lib_meta_data: Arc<GearsLibraryMetaData>,
+    pub(crate) allow_block: bool,
 }
 
 impl<'a> ReplyCtxInterface for RunCtx<'a> {
@@ -173,7 +174,7 @@ impl<'a> RunFunctionCtxInterface for RunCtx<'a> {
     }
 
     fn allow_block(&self) -> bool {
-        !self.ctx.get_flags().contains(ContextFlags::DENY_BLOCKING)
+        self.allow_block && !self.ctx.get_flags().contains(ContextFlags::DENY_BLOCKING)
     }
 }
 

--- a/redisgears_plugin_api/src/redisgears_plugin_api/function_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/function_ctx.rs
@@ -5,7 +5,8 @@
  */
 
 use crate::redisgears_plugin_api::run_function_ctx::RunFunctionCtxInterface;
-use crate::redisgears_plugin_api::FunctionCallResult;
+
+use super::FunctionCallResult;
 
 pub trait FunctionCtxInterface {
     fn call(&self, run_ctx: &dyn RunFunctionCtxInterface) -> FunctionCallResult;

--- a/redisgears_plugin_api/src/redisgears_plugin_api/load_library_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/load_library_ctx.rs
@@ -52,6 +52,12 @@ pub trait LoadLibraryCtxInterface {
         function_ctx: Box<dyn FunctionCtxInterface>,
         flags: FunctionFlags,
     ) -> Result<(), GearsApiError>;
+    fn register_async_function(
+        &mut self,
+        name: &str,
+        function_ctx: Box<dyn FunctionCtxInterface>,
+        flags: FunctionFlags,
+    ) -> Result<(), GearsApiError>;
     fn register_remote_task(
         &mut self,
         name: &str,

--- a/redisgears_v8_plugin/src/v8_function_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_function_ctx.rs
@@ -448,7 +448,7 @@ impl FunctionCtxInterface for V8Function {
                 .run_on_background(Box::new(move || {
                     inner_function.call_async(args, bg_client, bg_redis_client, decode_arguments);
                 }));
-            FunctionCallResult::Done
+            FunctionCallResult::Hold
         } else {
             let redis_client = run_ctx.get_redis_client();
             {
@@ -456,10 +456,13 @@ impl FunctionCtxInterface for V8Function {
                 c.set_allow_block(run_ctx.allow_block());
                 c.set_client(redis_client.as_ref());
             }
-            self.inner_function
+            let res = self
+                .inner_function
                 .call_sync(run_ctx, self.decode_arguments);
+
             self.client.borrow_mut().make_invalid();
-            FunctionCallResult::Done
+
+            res
         }
     }
 }


### PR DESCRIPTION
Added `RG.FCALLASYNC` to run asynchronous functions.

Solved: https://github.com/RedisGears/RedisGears/pull/895

The PR adds a new command `RG.FCALLASYNC`. Run asynchronous functions can only be done using this new command. Trying to run asynchronous functions using `RG.FCALL` will fail with an error.

In addition, the PR introduce a new `JS` api, `redis.register_async_function` which is the same as `redis.register_function` but also accept async function (coroutine). Trying to register async function using `redis.register_function` will fail with an error.

Require: https://github.com/RedisLabsModules/redismodule-rs/pull/326