### PR TITLE
Add allow list to filter out globals.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
     "redisgears_core",
     "redisgears_plugin_api",
     "redisgears_v8_plugin",
-    "redisai_rs"
+    "redisai_rs",
+    "redisgears_macros_internals"
 ]

--- a/redisgears_macros_internals/Cargo.toml
+++ b/redisgears_macros_internals/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "redisgears-macros-internals"
+version = "0.1.0"
+authors = ["Meir Shpilraien <meir@redis.com>"]
+edition = "2021"
+description = "A macros crate for redisgears"
+license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+syn = { version="1", features = ["full", "extra-traits"]}
+quote = "1"
+lazy_static = "1"
+proc-macro2 = "1"
+serde = { version = "1", features = ["derive"] }
+serde_syn = "0.1.0"
+
+[lib]
+name = "redisgears_macros_internals"
+path = "src/lib.rs"
+proc-macro = true

--- a/redisgears_macros_internals/src/allow_deny_lists.rs
+++ b/redisgears_macros_internals/src/allow_deny_lists.rs
@@ -1,0 +1,48 @@
+use std::collections::HashSet;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use serde::Deserialize;
+use serde_syn::{config, from_stream};
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+};
+
+#[derive(Debug, Deserialize)]
+struct Args {
+    allow_list: HashSet<String>,
+    deny_list: HashSet<String>,
+}
+
+impl Parse for Args {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        from_stream(config::JSONY, &input)
+    }
+}
+
+pub(crate) fn get_allow_deny_lists(item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(item as Args);
+
+    // verify no overlaps
+    let res = args
+        .allow_list
+        .iter()
+        .find(|v| args.deny_list.contains(v.as_str()));
+
+    if let Some(res) = res {
+        return quote! {compile_error!(std::stringify!(#res value appears on both, the allow list and the deny list.))}
+            .into();
+    };
+
+    let allow_list: Vec<_> = args.allow_list.into_iter().collect();
+    let deny_list: Vec<_> = args.deny_list.into_iter().collect();
+
+    quote! {
+        (
+            [#(#allow_list, )*].into_iter().map(|v| v.to_owned()).collect::<std::collections::HashSet<String>>(),
+            [#(#deny_list, )*].into_iter().map(|v| v.to_owned()).collect::<std::collections::HashSet<String>>()
+        )
+    }
+    .into()
+}

--- a/redisgears_macros_internals/src/lib.rs
+++ b/redisgears_macros_internals/src/lib.rs
@@ -1,0 +1,8 @@
+use proc_macro::TokenStream;
+
+mod allow_deny_lists;
+
+#[proc_macro]
+pub fn get_allow_deny_lists(item: TokenStream) -> TokenStream {
+    allow_deny_lists::get_allow_deny_lists(item)
+}

--- a/redisgears_v8_plugin/Cargo.toml
+++ b/redisgears_v8_plugin/Cargo.toml
@@ -13,6 +13,7 @@ v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs", branch = "master"}
 redisgears_plugin_api = { path="../redisgears_plugin_api/" }
 serde_json = "1"
 serde = "1"
+lazy_static = "1"
 
 [build-dependencies]
 

--- a/redisgears_v8_plugin/Cargo.toml
+++ b/redisgears_v8_plugin/Cargo.toml
@@ -11,6 +11,7 @@ redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", bra
 v8_rs = { git = "https://github.com/RedisGears/v8-rs" }
 v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs" }
 redisgears_plugin_api = { path = "../redisgears_plugin_api/" }
+redisgears-macros-internals = { path = "../redisgears_macros_internals/" }
 serde_json = "1"
 serde = "1"
 lazy_static = "1"

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -24,11 +24,80 @@ use crate::v8_redisai::get_tensor_object_template;
 use crate::v8_script_ctx::V8LibraryCtx;
 
 use std::alloc::{GlobalAlloc, Layout, System};
+use std::collections::HashSet;
 use std::str;
 
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex, Weak};
+lazy_static::lazy_static! {
+    static ref GLOBALS_ALLOW_LIST: HashSet<String> = HashSet::from([
+        "Object".to_owned(),
+        "Function".to_owned(),
+        "Array".to_owned(),
+        "Number".to_owned(),
+        "parseFloat".to_owned(),
+        "parseInt".to_owned(),
+        "Infinity".to_owned(),
+        "NaN".to_owned(),
+        "undefined".to_owned(),
+        "Boolean".to_owned(),
+        "String".to_owned(),
+        "Symbol".to_owned(),
+        "Date".to_owned(),
+        "Promise".to_owned(),
+        "RegExp".to_owned(),
+        "Error".to_owned(),
+        "AggregateError".to_owned(),
+        "RangeError".to_owned(),
+        "ReferenceError".to_owned(),
+        "SyntaxError".to_owned(),
+        "TypeError".to_owned(),
+        "URIError".to_owned(),
+        "globalThis".to_owned(),
+        "JSON".to_owned(),
+        "Math".to_owned(),
+        "Intl".to_owned(),
+        "ArrayBuffer".to_owned(),
+        "Uint8Array".to_owned(),
+        "Int8Array".to_owned(),
+        "Uint16Array".to_owned(),
+        "Int16Array".to_owned(),
+        "Uint32Array".to_owned(),
+        "Int32Array".to_owned(),
+        "Float32Array".to_owned(),
+        "Float64Array".to_owned(),
+        "Uint8ClampedArray".to_owned(),
+        "BigUint64Array".to_owned(),
+        "BigInt64Array".to_owned(),
+        "DataView".to_owned(),
+        "Map".to_owned(),
+        "BigInt".to_owned(),
+        "Set".to_owned(),
+        "WeakMap".to_owned(),
+        "WeakSet".to_owned(),
+        "Proxy".to_owned(),
+        "Reflect".to_owned(),
+        "FinalizationRegistry".to_owned(),
+        "WeakRef".to_owned(),
+        "decodeURI".to_owned(),
+        "decodeURIComponent".to_owned(),
+        "encodeURI".to_owned(),
+        "encodeURIComponent".to_owned(),
+        "escape".to_owned(),
+        "unescape".to_owned(),
+        "isFinite".to_owned(),
+        "isNaN".to_owned(),
+        "console".to_owned(),
+        "WebAssembly".to_owned(),
+    ]);
 
+    static ref GLOBALS_DENY_LIST: HashSet<String> = HashSet::from([
+        "eval".to_owned(), // Might be considered dangerous.
+        "EvalError".to_owned(), // Sense we remove eval, this one is also not needed.
+        "SharedArrayBuffer".to_owned(), // Needed for web workers which we are not supporting
+        "Atomics".to_owned(), // Needed for web workers which we are not supporting
+    ]);
+}
 struct Globals {
     backend_ctx: Option<BackendCtx>,
 }
@@ -206,6 +275,26 @@ impl BackendCtxInterfaceInitialised for V8Backend {
                 let isolate_scope = isolate.enter();
                 let ctx = isolate_scope.new_context(None);
                 let ctx_scope = ctx.enter(&isolate_scope);
+
+                let globals = ctx_scope.get_globals();
+                let propeties = globals.get_own_property_names(&ctx_scope);
+                propeties.iter(&ctx_scope).try_for_each(|v| {
+                    let s = v.to_utf8().ok_or(GearsApiError::new("Failed converting global property name to string"))?;
+                    if !GLOBALS_ALLOW_LIST.contains(s.as_str())
+                    {
+                        if !GLOBALS_DENY_LIST.contains(s.as_str()) {
+                            compiled_library_api.log(&format!(
+                                "Found global '{}' which is not on the allowed list nor on the deny list.",
+                                s.as_str()
+                            ));
+                        }
+                        // property does not exists on the allow list. lets drop it.
+                        if !globals.delete(&ctx_scope, &v) {
+                            return Err(GearsApiError::new(format!("Failed deleting global '{}' which is not on the allowed list, can not load the library.", s.as_str())));
+                        }
+                    }
+                    Ok(())
+                })?;
 
                 let v8code_str = isolate_scope.new_string(code);
 

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -30,73 +30,73 @@ use std::str;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex, Weak};
 lazy_static::lazy_static! {
-    static ref GLOBALS_ALLOW_LIST: HashSet<String> = HashSet::from([
-        "Object".to_owned(),
-        "Function".to_owned(),
-        "Array".to_owned(),
-        "Number".to_owned(),
-        "parseFloat".to_owned(),
-        "parseInt".to_owned(),
-        "Infinity".to_owned(),
-        "NaN".to_owned(),
-        "undefined".to_owned(),
-        "Boolean".to_owned(),
-        "String".to_owned(),
-        "Symbol".to_owned(),
-        "Date".to_owned(),
-        "Promise".to_owned(),
-        "RegExp".to_owned(),
-        "Error".to_owned(),
-        "AggregateError".to_owned(),
-        "RangeError".to_owned(),
-        "ReferenceError".to_owned(),
-        "SyntaxError".to_owned(),
-        "TypeError".to_owned(),
-        "URIError".to_owned(),
-        "globalThis".to_owned(),
-        "JSON".to_owned(),
-        "Math".to_owned(),
-        "Intl".to_owned(),
-        "ArrayBuffer".to_owned(),
-        "Uint8Array".to_owned(),
-        "Int8Array".to_owned(),
-        "Uint16Array".to_owned(),
-        "Int16Array".to_owned(),
-        "Uint32Array".to_owned(),
-        "Int32Array".to_owned(),
-        "Float32Array".to_owned(),
-        "Float64Array".to_owned(),
-        "Uint8ClampedArray".to_owned(),
-        "BigUint64Array".to_owned(),
-        "BigInt64Array".to_owned(),
-        "DataView".to_owned(),
-        "Map".to_owned(),
-        "BigInt".to_owned(),
-        "Set".to_owned(),
-        "WeakMap".to_owned(),
-        "WeakSet".to_owned(),
-        "Proxy".to_owned(),
-        "Reflect".to_owned(),
-        "FinalizationRegistry".to_owned(),
-        "WeakRef".to_owned(),
-        "decodeURI".to_owned(),
-        "decodeURIComponent".to_owned(),
-        "encodeURI".to_owned(),
-        "encodeURIComponent".to_owned(),
-        "escape".to_owned(),
-        "unescape".to_owned(),
-        "isFinite".to_owned(),
-        "isNaN".to_owned(),
-        "console".to_owned(),
-        "WebAssembly".to_owned(),
-    ]);
+    static ref GLOBALS_ALLOW_LIST: HashSet<String> = [
+        "Object",
+        "Function",
+        "Array",
+        "Number",
+        "parseFloat",
+        "parseInt",
+        "Infinity",
+        "NaN",
+        "undefined",
+        "Boolean",
+        "String",
+        "Symbol",
+        "Date",
+        "Promise",
+        "RegExp",
+        "Error",
+        "AggregateError",
+        "RangeError",
+        "ReferenceError",
+        "SyntaxError",
+        "TypeError",
+        "URIError",
+        "globalThis",
+        "JSON",
+        "Math",
+        "Intl",
+        "ArrayBuffer",
+        "Uint8Array",
+        "Int8Array",
+        "Uint16Array",
+        "Int16Array",
+        "Uint32Array",
+        "Int32Array",
+        "Float32Array",
+        "Float64Array",
+        "Uint8ClampedArray",
+        "BigUint64Array",
+        "BigInt64Array",
+        "DataView",
+        "Map",
+        "BigInt",
+        "Set",
+        "WeakMap",
+        "WeakSet",
+        "Proxy",
+        "Reflect",
+        "FinalizationRegistry",
+        "WeakRef",
+        "decodeURI",
+        "decodeURIComponent",
+        "encodeURI",
+        "encodeURIComponent",
+        "escape",
+        "unescape",
+        "isFinite",
+        "isNaN",
+        "console",
+        "WebAssembly",
+    ].into_iter().map(|v| v.to_owned()).collect();
 
-    static ref GLOBALS_DENY_LIST: HashSet<String> = HashSet::from([
-        "eval".to_owned(), // Might be considered dangerous.
-        "EvalError".to_owned(), // Sense we remove eval, this one is also not needed.
-        "SharedArrayBuffer".to_owned(), // Needed for web workers which we are not supporting
-        "Atomics".to_owned(), // Needed for web workers which we are not supporting
-    ]);
+    static ref GLOBALS_DENY_LIST: HashSet<String> = [
+        "eval",              // Might be considered dangerous.
+        "EvalError",         // Because we remove eval, this one is also not needed.
+        "SharedArrayBuffer", // Needed for workers which we are not supporting
+        "Atomics",           // Needed for workers which we are not supporting
+    ].into_iter().map(|v| v.to_owned()).collect();
 }
 struct Globals {
     backend_ctx: Option<BackendCtx>,
@@ -280,8 +280,7 @@ impl BackendCtxInterfaceInitialised for V8Backend {
                 let propeties = globals.get_own_property_names(&ctx_scope);
                 propeties.iter(&ctx_scope).try_for_each(|v| {
                     let s = v.to_utf8().ok_or(GearsApiError::new("Failed converting global property name to string"))?;
-                    if !GLOBALS_ALLOW_LIST.contains(s.as_str())
-                    {
+                    if !GLOBALS_ALLOW_LIST.contains(s.as_str()) {
                         if !GLOBALS_DENY_LIST.contains(s.as_str()) {
                             compiled_library_api.log(&format!(
                                 "Found global '{}' which is not on the allowed list nor on the deny list.",


### PR DESCRIPTION
Fix #902 add allow list and deny list to filter JS globals.

Any global which are not on the allow list will be removed. If the global is also not appear of the deny list, we will output a log message indicating we have a global which we do not considered and we should check the porpose of this global and decide if we want to filter it or not.

List of allow globals:

* Object
* Function
* Array
* Number
* parseFloat
* parseInt
* Infinity
* NaN
* undefined
* Boolean
* String
* Symbol
* Date
* Promise
* RegExp
* Error
* AggregateError
* RangeError
* ReferenceError
* SyntaxError
* TypeError
* URIError
* globalThis
* JSON
* Math
* Intl
* ArrayBuffer
* Uint8Array
* Int8Array
* Uint16Array
* Int16Array
* Uint32Array
* Int32Array
* Float32Array
* Float64Array
* Uint8ClampedArray
* BigUint64Array
* BigInt64Array
* DataView
* Map
* BigInt
* Set
* WeakMap
* WeakSet
* Proxy
* Reflect
* FinalizationRegistry
* WeakRef
* decodeURI
* decodeURIComponent
* encodeURI
* encodeURIComponent
* escape
* unescape
* isFinite
* isNaN
* console
* WebAssembly

List of deny globals:

* eval - Might be considered dangerous.
* EvalError - Sense we remove eval, this one is also not needed.
* SharedArrayBuffer - Needed for web workers which we are not supporting
* Atomics - Needed for web workers which we are not supporting

Require - https://github.com/RedisGears/v8-rs/pull/22