### PR TITLE
Maxmemory support for total V8 isolates.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,9 +95,9 @@ _Runtime Configurability_
 
 No
 
-## v8-library-initial-mem-usage
+## v8-library-initial-memory-usage
 
-The `v8-library-initial-mem-usage` configuration option controls the initial memory given to a single V8 library. This value can not be greater then [`v8-library-initial-mem-limit`](#v8-library-initial-mem-limit) or [v8-maxmemory](#v8-maxmemory).
+The `v8-library-initial-memory-usage` configuration option controls the initial memory given to a single V8 library. This value can not be greater then [`v8-library-initial-memory-limit`](#v8-library-initial-memory-limit) or [v8-maxmemory](#v8-maxmemory).
 
 _Expected Value_
 
@@ -119,9 +119,9 @@ _Runtime Configurability_
 
 No
 
-## v8-library-initial-mem-limit
+## v8-library-initial-memory-limit
 
-The `v8-library-initial-mem-limit` configuration option controls the initial memory limit on a single V8 library. This value can not be greater then [v8-maxmemory](#v8-maxmemory).
+The `v8-library-initial-memory-limit` configuration option controls the initial memory limit on a single V8 library. This value can not be greater then [v8-maxmemory](#v8-maxmemory).
 
 _Expected Value_
 
@@ -143,9 +143,9 @@ _Runtime Configurability_
 
 No
 
-## v8-library-mem-usage-delta
+## v8-library-memory-usage-delta
 
-The `v8-library-mem-usage-delta` configuration option controls the delta by which we will increase the V8 library memory limit once the limit reached. This value can not be greater then [v8-maxmemory](#v8-maxmemory).
+The `v8-library-memory-usage-delta` configuration option controls the delta by which we will increase the V8 library memory limit once the limit reached. This value can not be greater then [v8-maxmemory](#v8-maxmemory).
 
 _Expected Value_
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,7 @@ No
 The `library-fatal-failure-policy` configuration option controls how to handle a fatal error. Fatal error is consider one of the following:
 
 * Block timeout - The function blocks the Redis processes for to long (configurable using [lock-redis-timeout](#lock-redis-timeout) configuration value)
-* OOM - The function consumer to much memory (configurable using [library-maxmemory](#library-maxmemory) configuration value).
+* OOM - The function consumer to much memory (configurable using [v8-maxmemory](#v8-maxmemory) configuration value).
 
 This configuration basically allow choosing between 2 options:
 
@@ -71,9 +71,9 @@ _Runtime Configurability_
 
 Yes
 
-## library-maxmemory
+## v8-maxmemory
 
-The `library-maxmemory` configuration option controls the maximum amount of memory a single library is allowed to consume. Exceeding this limit is considered a fatal error and will be handled base of the [library-fatal-failure-policy](#library-fatal-failure-policy) configuration value.
+The `v8-maxmemory` configuration option controls the maximum amount of memory used by all V8 libraries. Exceeding this limit is considered a fatal error and will be handled base of the [library-fatal-failure-policy](#library-fatal-failure-policy) configuration value.
 
 _Expected Value_
 
@@ -81,15 +81,87 @@ Integer
 
 _Default_
 
-1G
+200M
 
 _Minimum Value_
 
-16M
+50M
 
 _Maximum Value_
 
-2G
+1G
+
+_Runtime Configurability_
+
+No
+
+## v8-library-initial-mem-usage
+
+The `v8-library-initial-mem-usage` configuration option controls the initial memory given to a single V8 library. This value can not be greater then [`v8-library-initial-mem-limit`](#v8-library-initial-mem-limit) or [v8-maxmemory](#v8-maxmemory).
+
+_Expected Value_
+
+Integer
+
+_Default_
+
+2M
+
+_Minimum Value_
+
+1M
+
+_Maximum Value_
+
+10M
+
+_Runtime Configurability_
+
+No
+
+## v8-library-initial-mem-limit
+
+The `v8-library-initial-mem-limit` configuration option controls the initial memory limit on a single V8 library. This value can not be greater then [v8-maxmemory](#v8-maxmemory).
+
+_Expected Value_
+
+Integer
+
+_Default_
+
+3M
+
+_Minimum Value_
+
+2M
+
+_Maximum Value_
+
+20M
+
+_Runtime Configurability_
+
+No
+
+## v8-library-mem-usage-delta
+
+The `v8-library-mem-usage-delta` configuration option controls the delta by which we will increase the V8 library memory limit once the limit reached. This value can not be greater then [v8-maxmemory](#v8-maxmemory).
+
+_Expected Value_
+
+Integer
+
+_Default_
+
+1M
+
+_Minimum Value_
+
+1M
+
+_Maximum Value_
+
+10M
 
 _Runtime Configurability_
 

--- a/redisgears_core/Cargo.toml
+++ b/redisgears_core/Cargo.toml
@@ -23,6 +23,7 @@ serde_derive = "1"
 sha256 = "1"
 lazy_static = "1"
 log = "0.4"
+byte-unit = "4"
 
 [build-dependencies]
 regex = "1"

--- a/redisgears_core/src/compiled_library_api.rs
+++ b/redisgears_core/src/compiled_library_api.rs
@@ -87,11 +87,11 @@ impl CompiledLibraryInterface for CompiledLibraryAPI {
         log::debug!("{msg}");
     }
 
-    fn log_notice(&self, msg: &str) {
+    fn log_info(&self, msg: &str) {
         log::info!("{msg}");
     }
 
-    fn log_verbose(&self, msg: &str) {
+    fn log_trace(&self, msg: &str) {
         log::trace!("{msg}");
     }
 

--- a/redisgears_core/src/compiled_library_api.rs
+++ b/redisgears_core/src/compiled_library_api.rs
@@ -4,14 +4,12 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
-use crate::config::LIBRARY_MAX_MEMORY;
 use crate::{execute_on_pool, DETACHED_CONTEXT};
 use redisai_rs::redisai::redisai_tensor::RedisAITensor;
 use redisgears_plugin_api::redisgears_plugin_api::backend_ctx::CompiledLibraryInterface;
 use redisgears_plugin_api::redisgears_plugin_api::redisai_interface::AITensorInterface;
 use redisgears_plugin_api::redisgears_plugin_api::GearsApiError;
 use std::collections::LinkedList;
-use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
 pub(crate) struct CompiledLibraryInternals {
@@ -85,16 +83,24 @@ impl CompiledLibraryAPI {
 }
 
 impl CompiledLibraryInterface for CompiledLibraryAPI {
-    fn log(&self, msg: &str) {
+    fn log_debug(&self, msg: &str) {
+        DETACHED_CONTEXT.log_debug(msg);
+    }
+
+    fn log_notice(&self, msg: &str) {
         DETACHED_CONTEXT.log_notice(msg);
+    }
+
+    fn log_verbose(&self, msg: &str) {
+        DETACHED_CONTEXT.log_verbose(msg);
+    }
+
+    fn log_warning(&self, msg: &str) {
+        DETACHED_CONTEXT.log_warning(msg);
     }
 
     fn run_on_background(&self, job: Box<dyn FnOnce() + Send>) {
         self.add_job(job);
-    }
-
-    fn get_maxmemory(&self) -> usize {
-        LIBRARY_MAX_MEMORY.load(Ordering::Relaxed) as usize
     }
 
     fn redisai_create_tensor(

--- a/redisgears_core/src/config.rs
+++ b/redisgears_core/src/config.rs
@@ -19,14 +19,52 @@ enum_configuration! {
 }
 
 lazy_static! {
+    /// Configuration value indicates how verbose the error messages will be give
+    /// to the user. Value 1 means simple one line error message. Value of 2
+    /// means a full stack trace.
     pub(crate) static ref ERROR_VERBOSITY: AtomicI64 = AtomicI64::default();
+
+    /// Configuration value indicates the number of execution threads for
+    /// background tasks.
     pub(crate) static ref EXECUTION_THREADS: RedisGILGuard<i64> = RedisGILGuard::default();
+
+    /// Configuration value indicates the timeout for remote tasks that runs on a remote shard.
     pub(crate) static ref REMOTE_TASK_DEFAULT_TIMEOUT: AtomicI64 = AtomicI64::default();
-    pub(crate) static ref LIBRARY_MAX_MEMORY: AtomicI64 = AtomicI64::default();
+
+    /// Configuration value indicates the timeout for locking Redis.
     pub(crate) static ref LOCK_REDIS_TIMEOUT: AtomicI64 = AtomicI64::default();
+
+    /// Configuration value indicates the gears box url.
     pub(crate) static ref GEARS_BOX_ADDRESS: RedisGILGuard<String> = RedisGILGuard::default();
+
+    /// Configuration value indicates policy for fatal errors such as timeout or OOM.
     pub(crate) static ref FATAL_FAILURE_POLICY: Mutex<FatalFailurePolicyConfiguration> =
         Mutex::new(FatalFailurePolicyConfiguration::Abort);
+
+    /// Configuration value indicates if it is allowed to run debug commands.
     pub(crate) static ref ENABLE_DEBUG_COMMAND: RedisGILGuard<bool> = RedisGILGuard::default();
+
+    // V8 specific configuration
+
+    /// Configuration value indicates the path to the V8 plugin.
     pub(crate) static ref V8_PLUGIN_PATH: RedisGILGuard<String> = RedisGILGuard::default();
+
+    /// Configuration value indicates the maximum memory usage for the V8 engine.
+    pub(crate) static ref V8_MAX_MEMORY: AtomicI64 = AtomicI64::default();
+
+    /// Configuration value indicates the initial memory usage for a V8 library.
+    pub(crate) static ref V8_LIBRARY_INITIAL_MEMORY_USAGE: AtomicI64 = AtomicI64::default();
+
+    /// Configuration value indicates the initial memory limit for a V8 library.
+    pub(crate) static ref V8_LIBRARY_INITIAL_MEMORY_LIMIT: AtomicI64 = AtomicI64::default();
+
+    /// Configuration value indicates the delta by which we allow the library to consume more
+    /// memory. For example, assumming the initial library memory limit is 2M, and this value
+    /// is also 1M, when the library reaches 2M memory usage we will allow it to consume
+    /// 1M more memory, but if the total memory usage used by all the libraries will not bypass
+    /// the `V8_MAX_MEMORY` configuration.
+    ///
+    /// This basically means that we might bypass the `V8_MAX_MEMORY` configuration by at most
+    /// `V8_LIBRARY_MEMORY_USAGE_DELTA`.
+    pub(crate) static ref V8_LIBRARY_MEMORY_USAGE_DELTA: AtomicI64 = AtomicI64::default();
 }

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -19,7 +19,8 @@ use serde::{Deserialize, Serialize};
 
 use config::{
     FatalFailurePolicyConfiguration, ENABLE_DEBUG_COMMAND, ERROR_VERBOSITY, EXECUTION_THREADS,
-    FATAL_FAILURE_POLICY, LOCK_REDIS_TIMEOUT, V8_PLUGIN_PATH,
+    FATAL_FAILURE_POLICY, LOCK_REDIS_TIMEOUT, V8_LIBRARY_INITIAL_MEMORY_LIMIT,
+    V8_LIBRARY_INITIAL_MEMORY_USAGE, V8_LIBRARY_MEMORY_USAGE_DELTA, V8_MAX_MEMORY, V8_PLUGIN_PATH,
 };
 
 use redis_module::raw::RedisModule__Assert;
@@ -476,6 +477,39 @@ pub(crate) fn call_redis_command(
     ctx.call_ext(command, call_options, args)
 }
 
+fn verify_v8_mem_usage_values() -> Result<(), RedisError> {
+    let v8_max_memory = V8_MAX_MEMORY.load(Ordering::Relaxed);
+    let v8_lib_initial_mem = V8_LIBRARY_INITIAL_MEMORY_USAGE.load(Ordering::Relaxed);
+    let v8_lib_initial_mem_limit = V8_LIBRARY_INITIAL_MEMORY_LIMIT.load(Ordering::Relaxed);
+    let v8_lib_mem_delta = V8_LIBRARY_MEMORY_USAGE_DELTA.load(Ordering::Relaxed);
+
+    if v8_lib_initial_mem > v8_max_memory {
+        return Err(RedisError::Str(
+            "V8 library initial memory usage can not bypass the v8 max memory.",
+        ));
+    }
+
+    if v8_lib_initial_mem_limit > v8_max_memory {
+        return Err(RedisError::Str(
+            "V8 library initial memory limit can not bypass the v8 max memory.",
+        ));
+    }
+
+    if v8_lib_mem_delta > v8_max_memory {
+        return Err(RedisError::Str(
+            "V8 library memory delta can not bypass the v8 max memory.",
+        ));
+    }
+
+    if v8_lib_initial_mem > v8_lib_initial_mem_limit {
+        return Err(RedisError::Str(
+            "V8 library initial initial memory usage can not bypass the initial memory limit.",
+        ));
+    }
+
+    Ok(())
+}
+
 fn js_init(ctx: &Context, _args: &[RedisString]) -> Status {
     mr_init(ctx, 1, None);
 
@@ -494,10 +528,17 @@ fn js_init(ctx: &Context, _args: &[RedisString]) -> Status {
         BUILD_OS_NICK.unwrap_or_default(),
         BUILD_OS_ARCH.unwrap_or_default()
     ));
+
     if let Err(e) = check_redis_version_compatible(ctx) {
         ctx.log_warning(&e);
         return Status::Err;
     }
+
+    if let Err(e) = verify_v8_mem_usage_values() {
+        ctx.log_warning(&e.to_string());
+        return Status::Err;
+    }
+
     std::panic::set_hook(Box::new(|panic_info| {
         DETACHED_CONTEXT.log_warning(&format!("Application panicked, {}", panic_info));
         let (file, line) = match panic_info.location() {
@@ -610,6 +651,16 @@ fn js_init(ctx: &Context, _args: &[RedisString]) -> Status {
                 FatalFailurePolicyConfiguration::Kill => LibraryFatalFailurePolicy::Kill,
             }),
             get_lock_timeout: Box::new(|| LOCK_REDIS_TIMEOUT.load(Ordering::Relaxed) as u128),
+            get_v8_maxmemory: Box::new(|| V8_MAX_MEMORY.load(Ordering::Relaxed) as usize),
+            get_v8_library_initial_memory: Box::new(|| {
+                V8_LIBRARY_INITIAL_MEMORY_USAGE.load(Ordering::Relaxed) as usize
+            }),
+            get_v8_library_initial_memory_limit: Box::new(|| {
+                V8_LIBRARY_INITIAL_MEMORY_LIMIT.load(Ordering::Relaxed) as usize
+            }),
+            get_v8_library_memory_delta: Box::new(|| {
+                V8_LIBRARY_MEMORY_USAGE_DELTA.load(Ordering::Relaxed) as usize
+            }),
         }) {
             Ok(b) => b,
             Err(e) => {
@@ -1000,7 +1051,10 @@ macro_rules! get_allocator {
 #[allow(missing_docs)]
 mod gears_module {
     use super::*;
-    use config::{GEARS_BOX_ADDRESS, LIBRARY_MAX_MEMORY, REMOTE_TASK_DEFAULT_TIMEOUT};
+    use config::{
+        GEARS_BOX_ADDRESS, REMOTE_TASK_DEFAULT_TIMEOUT, V8_LIBRARY_INITIAL_MEMORY_LIMIT,
+        V8_LIBRARY_INITIAL_MEMORY_USAGE, V8_LIBRARY_MEMORY_USAGE_DELTA, V8_MAX_MEMORY,
+    };
     use rdb::REDIS_GEARS_TYPE;
     use redis_module::configuration::ConfigurationFlags;
 
@@ -1029,8 +1083,12 @@ mod gears_module {
                 ["error-verbosity", &*ERROR_VERBOSITY ,1, 1, 2, ConfigurationFlags::DEFAULT, None],
                 ["execution-threads", &*EXECUTION_THREADS ,1, 1, 32, ConfigurationFlags::IMMUTABLE, None],
                 ["remote-task-default-timeout", &*REMOTE_TASK_DEFAULT_TIMEOUT , 500, 1, i64::MAX, ConfigurationFlags::DEFAULT, None],
-                ["library-maxmemory", &*LIBRARY_MAX_MEMORY , 1024 * 1024 * 1024, 16 * 1024 * 1024, 2 * 1024 * 1024 * 1024, ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE, None],
                 ["lock-redis-timeout", &*LOCK_REDIS_TIMEOUT , 500, 100, 1000000000, ConfigurationFlags::DEFAULT, None],
+
+                ["v8-maxmemory", &*V8_MAX_MEMORY , 200 * 1024 * 1024, 50 * 1024 * 1024, 1024 * 1024 * 1024, ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE, None],
+                ["v8-library-initial-mem-usage", &*V8_LIBRARY_INITIAL_MEMORY_USAGE , 2 * 1024 * 1024, 1 * 1024 * 1024, 10 * 1024 * 1024, ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE, None],
+                ["v8-library-initial-mem-limit", &*V8_LIBRARY_INITIAL_MEMORY_LIMIT , 3 * 1024 * 1024, 2 * 1024 * 1024, 20 * 1024 * 1024, ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE, None],
+                ["v8-library-mem-usage-delta", &*V8_LIBRARY_MEMORY_USAGE_DELTA , 1 * 1024 * 1024, 1 * 1024 * 1024, 10 * 1024 * 1024, ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE, None],
             ],
             string: [
                 ["gearsbox-address", &*GEARS_BOX_ADDRESS , "http://localhost:3000", ConfigurationFlags::DEFAULT, None],

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -1090,9 +1090,9 @@ mod gears_module {
                 ["lock-redis-timeout", &*LOCK_REDIS_TIMEOUT , 500, 100, 1000000000, ConfigurationFlags::DEFAULT, None],
 
                 ["v8-maxmemory", &*V8_MAX_MEMORY , 200 * 1024 * 1024, 50 * 1024 * 1024, 1024 * 1024 * 1024, ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE, None],
-                ["v8-library-initial-mem-usage", &*V8_LIBRARY_INITIAL_MEMORY_USAGE , 2 * 1024 * 1024, 1 * 1024 * 1024, 10 * 1024 * 1024, ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE, None],
-                ["v8-library-initial-mem-limit", &*V8_LIBRARY_INITIAL_MEMORY_LIMIT , 3 * 1024 * 1024, 2 * 1024 * 1024, 20 * 1024 * 1024, ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE, None],
-                ["v8-library-mem-usage-delta", &*V8_LIBRARY_MEMORY_USAGE_DELTA , 1 * 1024 * 1024, 1 * 1024 * 1024, 10 * 1024 * 1024, ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE, None],
+                ["v8-library-initial-memory-usage", &*V8_LIBRARY_INITIAL_MEMORY_USAGE , 2 * 1024 * 1024, 1 * 1024 * 1024, 10 * 1024 * 1024, ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE, None],
+                ["v8-library-initial-memory-limit", &*V8_LIBRARY_INITIAL_MEMORY_LIMIT , 3 * 1024 * 1024, 2 * 1024 * 1024, 20 * 1024 * 1024, ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE, None],
+                ["v8-library-memory-usage-delta", &*V8_LIBRARY_MEMORY_USAGE_DELTA , 1 * 1024 * 1024, 1 * 1024 * 1024, 10 * 1024 * 1024, ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE, None],
             ],
             string: [
                 ["gearsbox-address", &*GEARS_BOX_ADDRESS , "http://localhost:3000", ConfigurationFlags::DEFAULT, None],

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -644,7 +644,11 @@ fn js_init(ctx: &Context, _args: &[RedisString]) -> Status {
         }
         let initialised_backend = match backend.initialize(BackendCtx {
             allocator: &RedisAlloc,
-            log: Box::new(|msg| log::info!("{msg}")),
+            log_info: Box::new(|msg| log::info!("{msg}")),
+            log_trace: Box::new(|msg| log::trace!("{msg}")),
+            log_debug: Box::new(|msg| log::debug!("{msg}")),
+            log_error: Box::new(|msg| log::error!("{msg}")),
+            log_warning: Box::new(|msg| log::warn!("{msg}")),
             get_on_oom_policy: Box::new(|| match *FATAL_FAILURE_POLICY.lock().unwrap() {
                 FatalFailurePolicyConfiguration::Abort => LibraryFatalFailurePolicy::Abort,
                 FatalFailurePolicyConfiguration::Kill => LibraryFatalFailurePolicy::Kill,

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -564,7 +564,7 @@ fn js_init(ctx: &Context, _args: &[RedisString]) -> Status {
     }
 
     if let Err(e) = verify_v8_mem_usage_values() {
-        ctx.log_warning(&e.to_string());
+        log::error!("{e}");
         return Status::Err;
     }
 
@@ -1181,10 +1181,42 @@ mod gears_module {
                 ["remote-task-default-timeout", &*REMOTE_TASK_DEFAULT_TIMEOUT , 500, 1, i64::MAX, ConfigurationFlags::DEFAULT, None],
                 ["lock-redis-timeout", &*LOCK_REDIS_TIMEOUT , 500, 100, 1000000000, ConfigurationFlags::DEFAULT, None],
 
-                ["v8-maxmemory", &*V8_MAX_MEMORY , 200 * 1024 * 1024, 50 * 1024 * 1024, 1024 * 1024 * 1024, ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE, None],
-                ["v8-library-initial-memory-usage", &*V8_LIBRARY_INITIAL_MEMORY_USAGE , 2 * 1024 * 1024, 1 * 1024 * 1024, 10 * 1024 * 1024, ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE, None],
-                ["v8-library-initial-memory-limit", &*V8_LIBRARY_INITIAL_MEMORY_LIMIT , 3 * 1024 * 1024, 2 * 1024 * 1024, 20 * 1024 * 1024, ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE, None],
-                ["v8-library-memory-usage-delta", &*V8_LIBRARY_MEMORY_USAGE_DELTA , 1 * 1024 * 1024, 1 * 1024 * 1024, 10 * 1024 * 1024, ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE, None],
+                [
+                    "v8-maxmemory",
+                    &*V8_MAX_MEMORY,
+                    byte_unit::n_mb_bytes!(200) as i64,
+                    byte_unit::n_mb_bytes!(50) as i64,
+                    byte_unit::n_gb_bytes!(1) as i64,
+                    ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE,
+                    None
+                ],
+                [
+                    "v8-library-initial-memory-usage",
+                    &*V8_LIBRARY_INITIAL_MEMORY_USAGE,
+                    byte_unit::n_mb_bytes!(2) as i64,
+                    byte_unit::n_mb_bytes!(1) as i64,
+                    byte_unit::n_mb_bytes!(10) as i64,
+                    ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE,
+                    None
+                ],
+                [
+                    "v8-library-initial-memory-limit",
+                    &*V8_LIBRARY_INITIAL_MEMORY_LIMIT,
+                    byte_unit::n_mb_bytes!(3) as i64,
+                    byte_unit::n_mb_bytes!(2) as i64,
+                    byte_unit::n_mb_bytes!(20) as i64,
+                    ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE,
+                    None
+                ],
+                [
+                    "v8-library-memory-usage-delta",
+                    &*V8_LIBRARY_MEMORY_USAGE_DELTA,
+                    byte_unit::n_mb_bytes!(1) as i64,
+                    byte_unit::n_mb_bytes!(1) as i64,
+                    byte_unit::n_mb_bytes!(10) as i64,
+                    ConfigurationFlags::MEMORY | ConfigurationFlags::IMMUTABLE,
+                    None
+                ],
             ],
             string: [
                 ["gearsbox-address", &*GEARS_BOX_ADDRESS , "http://localhost:3000", ConfigurationFlags::DEFAULT, None],

--- a/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
@@ -16,8 +16,8 @@ use super::prologue::ApiVersion;
 
 pub trait CompiledLibraryInterface {
     fn log_debug(&self, msg: &str);
-    fn log_notice(&self, msg: &str);
-    fn log_verbose(&self, msg: &str);
+    fn log_info(&self, msg: &str);
+    fn log_trace(&self, msg: &str);
     fn log_warning(&self, msg: &str);
     fn log_error(&self, msg: &str);
     fn run_on_background(&self, job: Box<dyn FnOnce() + Send>);
@@ -37,7 +37,11 @@ pub enum LibraryFatalFailurePolicy {
 
 pub struct BackendCtx {
     pub allocator: &'static dyn GlobalAlloc,
-    pub log: Box<dyn Fn(&str) + 'static>,
+    pub log_info: Box<dyn Fn(&str) + 'static>,
+    pub log_debug: Box<dyn Fn(&str) + 'static>,
+    pub log_trace: Box<dyn Fn(&str) + 'static>,
+    pub log_warning: Box<dyn Fn(&str) + 'static>,
+    pub log_error: Box<dyn Fn(&str) + 'static>,
     pub get_on_oom_policy: Box<dyn Fn() -> LibraryFatalFailurePolicy + 'static>,
     pub get_lock_timeout: Box<dyn Fn() -> u128 + 'static>,
     pub get_v8_maxmemory: Box<dyn Fn() -> usize + 'static>,

--- a/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
@@ -15,9 +15,11 @@ use crate::redisgears_plugin_api::GearsApiError;
 use super::prologue::ApiVersion;
 
 pub trait CompiledLibraryInterface {
-    fn log(&self, msg: &str);
+    fn log_debug(&self, msg: &str);
+    fn log_notice(&self, msg: &str);
+    fn log_verbose(&self, msg: &str);
+    fn log_warning(&self, msg: &str);
     fn run_on_background(&self, job: Box<dyn FnOnce() + Send>);
-    fn get_maxmemory(&self) -> usize;
     fn redisai_create_tensor(
         &self,
         data_type: &str,
@@ -37,6 +39,10 @@ pub struct BackendCtx {
     pub log: Box<dyn Fn(&str) + 'static>,
     pub get_on_oom_policy: Box<dyn Fn() -> LibraryFatalFailurePolicy + 'static>,
     pub get_lock_timeout: Box<dyn Fn() -> u128 + 'static>,
+    pub get_v8_maxmemory: Box<dyn Fn() -> usize + 'static>,
+    pub get_v8_library_initial_memory: Box<dyn Fn() -> usize + 'static>,
+    pub get_v8_library_initial_memory_limit: Box<dyn Fn() -> usize + 'static>,
+    pub get_v8_library_memory_delta: Box<dyn Fn() -> usize + 'static>,
 }
 
 /// The trait which is only implemented for a successfully initialised

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -414,7 +414,7 @@ impl BackendCtxInterfaceInitialised for V8Backend {
 
                         let msg = format!("{msg}, library={}, used_heap_size={}, total_heap_size={}", script_ctx.name, script_ctx.isolate.used_heap_size(), script_ctx.isolate.total_heap_size());
                         let memory_delta = memory_delta();
-                        let new_isolate_limit = (script_ctx.isolate.total_heap_size() + memory_delta) as usize;
+                        let new_isolate_limit = (usize::max(script_ctx.isolate.total_heap_size(), curr_limit) + memory_delta) as usize;
 
                         if calc_isolates_used_memory() + memory_delta >= max_memory_limit() {
                             script_ctx.compiled_library_api.log_warning(&msg);

--- a/redisgears_v8_plugin/src/v8_function_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_function_ctx.rs
@@ -21,7 +21,7 @@ use v8_rs::v8::{
 
 use crate::v8_native_functions::{get_backgrounnd_client, RedisClient};
 use crate::v8_script_ctx::V8ScriptCtx;
-use crate::{get_error_from_object, get_exception_msg};
+use crate::{get_error_from_object, get_exception_msg, v8_backend::is_safe_to_run_code};
 
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
@@ -423,6 +423,13 @@ impl V8Function {
 
 impl FunctionCtxInterface for V8Function {
     fn call(&self, run_ctx: &dyn RunFunctionCtxInterface) -> FunctionCallResult {
+        if !is_safe_to_run_code() {
+            run_ctx.send_reply(Err(RedisError::Str(
+                "JS engine reached OOM state and can not run any more code",
+            )));
+            return FunctionCallResult::Done;
+        }
+
         if self.is_async {
             let bg_client = match run_ctx.get_background_client() {
                 Ok(bc) => bc,

--- a/redisgears_v8_plugin/src/v8_native_functions.rs
+++ b/redisgears_v8_plugin/src/v8_native_functions.rs
@@ -25,7 +25,7 @@ use v8_derive::new_native_function;
 
 use crate::v8_redisai::{get_redisai_api, get_redisai_client};
 
-use crate::v8_backend::log;
+use crate::v8_backend::log_warning;
 use crate::v8_function_ctx::V8Function;
 use crate::v8_notifications_ctx::V8NotificationsCtx;
 use crate::v8_script_ctx::V8ScriptCtx;
@@ -307,7 +307,7 @@ pub(crate) fn get_backgrounnd_client<'isolate_scope, 'isolate>(
                 Some(s) => s,
                 None => {
                     resolver.forget();
-                    log("Library was delete while not all the remote jobs were done");
+                    log_warning("Library was delete while not all the remote jobs were done");
                     return;
                 }
             };
@@ -317,7 +317,7 @@ pub(crate) fn get_backgrounnd_client<'isolate_scope, 'isolate>(
                     Some(s) => s,
                     None => {
                         resolver.forget();
-                        log("Library was delete while not all the remote jobs were done");
+                        log_warning("Library was delete while not all the remote jobs were done");
                         return;
                     }
                 };
@@ -377,7 +377,7 @@ pub(crate) fn get_backgrounnd_client<'isolate_scope, 'isolate>(
                 Some(s) => s,
                 None => {
                     resolver.forget();
-                    log("Library was delete while not all the remote jobs were done");
+                    log_warning("Library was delete while not all the remote jobs were done");
                     return;
                 }
             };
@@ -387,7 +387,7 @@ pub(crate) fn get_backgrounnd_client<'isolate_scope, 'isolate>(
                     Some(s) => s,
                     None => {
                         resolver.forget();
-                        log("Library was delete while not all the remote jobs were done");
+                        log_warning("Library was delete while not all the remote jobs were done");
                         return;
                     }
                 };
@@ -1242,8 +1242,8 @@ pub(crate) fn initialize_globals_1_0(
         "log",
         new_native_function!(move |_isolate, _curr_ctx_scope, msg: V8LocalUtf8| {
             match script_ctx_ref.upgrade() {
-                Some(s) => s.compiled_library_api.log_notice(msg.as_str()),
-                None => crate::v8_backend::log(msg.as_str()), /* do not abort logs */
+                Some(s) => s.compiled_library_api.log_info(msg.as_str()),
+                None => crate::v8_backend::log_info(msg.as_str()), /* do not abort logs */
             }
             Ok::<Option<V8LocalValue>, String>(None)
         }),
@@ -1301,17 +1301,18 @@ pub(crate) fn initialize_globals_1_0(
                         script_ctx_ref_resolve
                             .compiled_library_api
                             .run_on_background(Box::new(move || {
-                                let new_script_ctx_ref_resolve = match new_script_ctx_ref_resolve
-                                    .upgrade()
-                                {
-                                    Some(s) => s,
-                                    None => {
-                                        resolver_resolve.ref_cell.borrow_mut().forget();
-                                        res.forget();
-                                        log("Library was delete while not all the jobs were done");
-                                        return;
-                                    }
-                                };
+                                let new_script_ctx_ref_resolve =
+                                    match new_script_ctx_ref_resolve.upgrade() {
+                                        Some(s) => s,
+                                        None => {
+                                            resolver_resolve.ref_cell.borrow_mut().forget();
+                                            res.forget();
+                                            log_warning(
+                                            "Library was delete while not all the jobs were done",
+                                        );
+                                            return;
+                                        }
+                                    };
                                 let isolate_scope = new_script_ctx_ref_resolve.isolate.enter();
                                 let ctx_scope =
                                     new_script_ctx_ref_resolve.ctx.enter(&isolate_scope);
@@ -1344,17 +1345,18 @@ pub(crate) fn initialize_globals_1_0(
                         script_ctx_ref_reject
                             .compiled_library_api
                             .run_on_background(Box::new(move || {
-                                let new_script_ctx_ref_reject = match new_script_ctx_ref_reject
-                                    .upgrade()
-                                {
-                                    Some(s) => s,
-                                    None => {
-                                        res.forget();
-                                        resolver_reject.ref_cell.borrow_mut().forget();
-                                        log("Library was delete while not all the jobs were done");
-                                        return;
-                                    }
-                                };
+                                let new_script_ctx_ref_reject =
+                                    match new_script_ctx_ref_reject.upgrade() {
+                                        Some(s) => s,
+                                        None => {
+                                            res.forget();
+                                            resolver_reject.ref_cell.borrow_mut().forget();
+                                            log_warning(
+                                            "Library was delete while not all the jobs were done",
+                                        );
+                                            return;
+                                        }
+                                    };
                                 let isolate_scope = new_script_ctx_ref_reject.isolate.enter();
                                 let ctx_scope = new_script_ctx_ref_reject.ctx.enter(&isolate_scope);
                                 let _trycatch = isolate_scope.new_try_catch();

--- a/redisgears_v8_plugin/src/v8_native_functions.rs
+++ b/redisgears_v8_plugin/src/v8_native_functions.rs
@@ -1242,7 +1242,7 @@ pub(crate) fn initialize_globals_1_0(
         "log",
         new_native_function!(move |_isolate, _curr_ctx_scope, msg: V8LocalUtf8| {
             match script_ctx_ref.upgrade() {
-                Some(s) => s.compiled_library_api.log(msg.as_str()),
+                Some(s) => s.compiled_library_api.log_notice(msg.as_str()),
                 None => crate::v8_backend::log(msg.as_str()), /* do not abort logs */
             }
             Ok::<Option<V8LocalValue>, String>(None)

--- a/redisgears_v8_plugin/src/v8_notifications_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_notifications_ctx.rs
@@ -17,7 +17,7 @@ use v8_rs::v8::{v8_promise::V8PromiseState, v8_value::V8PersistValue};
 
 use crate::v8_native_functions::{get_backgrounnd_client, get_redis_client, RedisClient};
 use crate::v8_script_ctx::V8ScriptCtx;
-use crate::{get_error_from_object, get_exception_msg};
+use crate::{get_error_from_object, get_exception_msg, v8_backend::is_safe_to_run_code};
 
 use std::any::Any;
 use std::cell::RefCell;
@@ -311,6 +311,13 @@ impl KeysNotificationsConsumerCtxInterface for V8NotificationsCtx {
         notification_ctx: &dyn NotificationRunCtxInterface,
         ack_callback: Box<dyn FnOnce(Result<(), GearsApiError>) + Send + Sync>,
     ) {
+        if !is_safe_to_run_code() {
+            ack_callback(Err(GearsApiError::new(
+                "JS engine reached OOM state and can not run any more code",
+            )));
+            return;
+        }
+
         let notificaion_data = notificaion_data
             .unwrap()
             .downcast::<V8NotificationCtxData>()

--- a/redisgears_v8_plugin/src/v8_redisai.rs
+++ b/redisgears_v8_plugin/src/v8_redisai.rs
@@ -194,7 +194,7 @@ pub(crate) fn get_redisai_client<'isolate, 'isolate_scope>(
                         Some(s) => s,
                         None => {
                             persisted_resolver.forget();
-                            crate::v8_backend::log("Use of invalid function context on redisai on_done");
+                            crate::v8_backend::log_warning("Use of invalid function context on redisai on_done");
                             return;
                         }
                     };
@@ -204,7 +204,7 @@ pub(crate) fn get_redisai_client<'isolate, 'isolate_scope>(
                             Some(s) => s,
                             None => {
                                 persisted_resolver.forget();
-                                crate::v8_backend::log("Use of invalid function context on redisai on_done");
+                                crate::v8_backend::log_warning("Use of invalid function context on redisai on_done");
                                 return;
                             }
                         };
@@ -276,7 +276,7 @@ pub(crate) fn get_redisai_client<'isolate, 'isolate_scope>(
                         Some(s) => s,
                         None => {
                             persisted_resolver.forget();
-                            crate::v8_backend::log("Use of invalid function context on redisai on_done");
+                            crate::v8_backend::log_warning("Use of invalid function context on redisai on_done");
                             return;
                         }
                     };
@@ -286,7 +286,7 @@ pub(crate) fn get_redisai_client<'isolate, 'isolate_scope>(
                             Some(s) => s,
                             None => {
                                 persisted_resolver.forget();
-                                crate::v8_backend::log("Use of invalid function context on redisai on_done");
+                                crate::v8_backend::log_warning("Use of invalid function context on redisai on_done");
                                 return;
                             }
                         };

--- a/redisgears_v8_plugin/src/v8_script_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_script_ctx.rs
@@ -78,6 +78,7 @@ impl GilStateCtx {
 }
 
 pub(crate) struct V8ScriptCtx {
+    pub(crate) name: String,
     pub(crate) script: V8PersistedScript,
     pub(crate) tensor_object_template: V8PersistedObjectTemplate,
     pub(crate) ctx: V8Context,
@@ -89,6 +90,7 @@ pub(crate) struct V8ScriptCtx {
 
 impl V8ScriptCtx {
     pub(crate) fn new(
+        name: String,
         isolate: V8Isolate,
         ctx: V8Context,
         script: V8PersistedScript,
@@ -96,6 +98,7 @@ impl V8ScriptCtx {
         compiled_library_api: Box<dyn CompiledLibraryInterface + Send + Sync>,
     ) -> Self {
         Self {
+            name,
             isolate,
             ctx,
             script,

--- a/redisgears_v8_plugin/src/v8_stream_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_stream_ctx.rs
@@ -4,6 +4,7 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
+use redisgears_plugin_api::redisgears_plugin_api::GearsApiError;
 use v8_rs::v8::{v8_promise::V8PromiseState, v8_value::V8LocalValue, v8_value::V8PersistValue};
 
 use redisgears_plugin_api::redisgears_plugin_api::stream_ctx::{
@@ -12,6 +13,7 @@ use redisgears_plugin_api::redisgears_plugin_api::stream_ctx::{
 
 use redisgears_plugin_api::redisgears_plugin_api::run_function_ctx::BackgroundRunFunctionCtxInterface;
 
+use crate::v8_backend::is_safe_to_run_code;
 use crate::v8_native_functions::{get_backgrounnd_client, get_redis_client, RedisClient};
 use crate::v8_script_ctx::V8ScriptCtx;
 
@@ -325,6 +327,11 @@ impl StreamCtxInterface for V8StreamCtx {
         run_ctx: &dyn StreamProcessCtxInterface,
         ack_callback: Box<dyn FnOnce(StreamRecordAck) + Send>,
     ) -> Option<StreamRecordAck> {
+        if !is_safe_to_run_code() {
+            return Some(StreamRecordAck::Nack(GearsApiError::new(
+                "JS engine reached OOM state and can not run any more code",
+            )));
+        }
         if self.is_async {
             let internals = Arc::clone(&self.internals);
             let stream_name: Vec<u8> = stream_name.to_vec();


### PR DESCRIPTION
V8 allows to limit the memory usage of a single isolates. Unfortunately, RedisGears uses multiple isolates and so increasing the memory usage of each isolate separately is not good enough. We want to limit a total memory usage of all the isolates. The following PR attempt to do so.

The idea is to start each isolate with a respectively small memory usage (few MB), and slowly increase the limit once reach while checking that we are not increasing to much and bypass the total limit.

The PR introduces 4 new configuration values:

1. `v8-maxmemory` - the total memory limit allowed to be used by all the open isolates, default 200MB.
2. `v8-library-initial-memory-usage` - the initial memory given to a new isolate, default 2MB.
3. `v8-library-initial-memory-limit` - the initial limit given to an isolate, default 3MB
4. `v8-library-memory-usage-delta` - the delta value to increase the memory limit of an isolate when the limit reached, default 1MB.

Each time we get a notification that some isolate is about to reach its max memory we do the following:

1. Increase the isolate memory limit by `v8-library-memory-usage-delta`. We must increase the limit, otherwise V8 will abort the processes.
2. Calculate the total memory usage currently used by all isolates, if this value bypass `v8-maxmemory` we enter V8 OOM state. In such state we do the following:
   * Depends on the `library-fatal-failure-policy` we might kill the currently running isolate. 
   * Sending memory pressure notification to each isolate (to trigger GC).
   * We will not allow to run any more JS code until the total memory usage will drop bellow the `v8-maxmemory` value (we will recalculate the total isolates used memory each time we will try to run a JS code up until the value will drop).