### PR TITLE
Added optional `onTriggerFired` argument to notification consumer API.

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -57,3 +57,4 @@ oss
 MSRV
 utf
 FCALLASYNC
+Lua

--- a/docs/databse_triggers.md
+++ b/docs/databse_triggers.md
@@ -114,7 +114,7 @@ When upgrading the trigger code (using the `UPGRADE` option of [`RG.FUNCTION LOA
 
 ## Advance Usage
 
-For most usecases, `register_notifications_consumer` API is enough. But there are some usecases where you might need a better garentees on when the trigger will be fired. Lets look at the following example:
+For most use cases, `register_notifications_consumer` API is enough. But there are some use cases where you might need a better guaranteed on when the trigger will be fired. Lets look at the following example:
 
 ```js
 #!js api_version=1.0 name=lib
@@ -160,7 +160,7 @@ QUEUED
 "2"
 ```
 
-What just happened? `name_bar` was increased once while `name_foo` was not increaed at all. This happened because in case of a `multi`/`exec` or Lua, the notifications are fire at the end of the transaction, so all the notifications will see the last value that was written which is `bar`.
+What just happened? `name_bar` was increased once while `name_foo` was not increased at all. This happened because in case of a `multi`/`exec` or Lua, the notifications are fire at the end of the transaction, so all the notifications will see the last value that was written which is `bar`.
 
 To fix the code and still get the expected results even on `multi`/`exec`. RedisGears allow to specify an optional callback that will run exactly when the notification happened (and not at the end of the transaction). The constrains on this callback is that it can only **read** data without performing any writes. The new code will be as follow:
 

--- a/docs/databse_triggers.md
+++ b/docs/databse_triggers.md
@@ -112,7 +112,7 @@ If the callback is a Coroutine, it will be executed in the background and there 
 
 When upgrading the trigger code (using the `UPGRADE` option of [`RG.FUNCTION LOAD`](commands.md#rgfunction-load) command) all the trigger parameters can be modified.
 
-## Advance Usage
+## Advanced Usage
 
 For most use cases, `register_notifications_consumer` API is enough. But there are some use cases where you might need a better guaranteed on when the trigger will be fired. Lets look at the following example:
 

--- a/docs/databse_triggers.md
+++ b/docs/databse_triggers.md
@@ -142,7 +142,7 @@ Whenever a hash key is changing, the example above will read the field `name` fr
 "1"
 ```
 
-We can see that the key `name_foo` was increased once, and the key `name_bar` was increased once. Will we get the same results if we wrap the `hset`'s in a `multi`/`exec`?
+We can see that the key `name_foo` was increased once, and the key `name_bar` was increased once. Will we get the same results if we wrap the `hset`'s with a `multi`/`exec`?
 
 ```bash
 127.0.0.1:6379> multi
@@ -160,7 +160,7 @@ QUEUED
 "2"
 ```
 
-What just happened? `name_bar` was increased once while `name_foo` was not increased at all. This happened because in case of a `multi`/`exec` or Lua, the notifications are fire at the end of the transaction, so all the notifications will see the last value that was written which is `bar`.
+What just happened? `name_bar` was increased twice while `name_foo` was not increased at all. This happened because in case of a `multi`/`exec` or Lua, the notifications are fire at the end of the transaction, so all the notifications will see the last value that was written which is `bar`.
 
 To fix the code and still get the expected results even on `multi`/`exec`. RedisGears allow to specify an optional callback that will run exactly when the notification happened (and not at the end of the transaction). The constrains on this callback is that it can only **read** data without performing any writes. The new code will be as follow:
 

--- a/redisai_rs/Cargo.toml
+++ b/redisai_rs/Cargo.toml
@@ -7,7 +7,7 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
 redis-module-macros = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master" }
 redisgears_plugin_api = { path = "../redisgears_plugin_api/" }
 

--- a/redisgears_core/Cargo.toml
+++ b/redisgears_core/Cargo.toml
@@ -7,9 +7,9 @@ rust-version = "1.63"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
 redis-module-macros = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master" }
-lib_mr = { git = "https://github.com/RedisGears/LibMR.git", branch = "refactoring_rust_api_2" }
+lib_mr = { git = "https://github.com/RedisGears/LibMR.git", branch = "refactoring_rust_api_2", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
 lib_mr_derive = { git = "https://github.com/RedisGears/LibMR.git", branch = "refactoring_rust_api_2" }
 linkme = "0.3"
 redisai_rs = { path = "../redisai_rs" }

--- a/redisgears_core/src/keys_notifications_ctx.rs
+++ b/redisgears_core/src/keys_notifications_ctx.rs
@@ -5,9 +5,7 @@
  */
 
 use redis_module::Context;
-use redisgears_plugin_api::redisgears_plugin_api::keys_notifications_consumer_ctx::{
-    NotificationCtxInterface, NotificationPostJobCtxInterface,
-};
+use redisgears_plugin_api::redisgears_plugin_api::keys_notifications_consumer_ctx::NotificationPostJobCtxInterface;
 use redisgears_plugin_api::redisgears_plugin_api::load_library_ctx::FunctionFlags;
 use redisgears_plugin_api::redisgears_plugin_api::{
     keys_notifications_consumer_ctx::NotificationRunCtxInterface,
@@ -70,5 +68,3 @@ impl<'ctx> NotificationPostJobCtxInterface for KeySpaceNotificationsCtx<'ctx> {
         });
     }
 }
-
-impl<'ctx> NotificationCtxInterface for KeySpaceNotificationsCtx<'ctx> {}

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -10,6 +10,7 @@
 
 #![deny(missing_docs)]
 
+use keys_notifications_ctx::KeySpaceNotificationsCtx;
 use redis_module::redisvalue::RedisValueKey;
 use redis_module::{CallResult, ContextFlags, ErrorReply};
 use redisgears_plugin_api::redisgears_plugin_api::backend_ctx::BackendCtxInterfaceInitialised;
@@ -66,7 +67,6 @@ use std::vec::IntoIter;
 use crate::compiled_library_api::CompiledLibraryInternals;
 use crate::gears_box::{gears_box_search, GearsBoxLibraryInfo};
 use crate::keys_notifications::{KeysNotificationsCtx, NotificationCallback, NotificationConsumer};
-use crate::keys_notifications_ctx::KeysNotificationsRunCtx;
 use crate::stream_run_ctx::{GearsStreamConsumer, GearsStreamRecord};
 
 use std::cell::RefCell;
@@ -363,16 +363,16 @@ impl<'ctx, 'lib_ctx> LoadLibraryCtxInterface for GearsLoadLibraryCtx<'ctx, 'lib_
                     return;
                 }
                 let _notification_blocker = get_notification_blocker();
-                let val = keys_notifications_consumer_ctx.on_notification_fired(
+                keys_notifications_consumer_ctx.on_notification_fired(
                     event,
                     key,
-                    &KeysNotificationsRunCtx::new(ctx, meta_data.clone(), FunctionFlags::empty()),
-                );
-                keys_notifications_consumer_ctx.post_command_notification(
-                    val,
-                    &KeysNotificationsRunCtx::new(ctx, meta_data.clone(), FunctionFlags::empty()),
+                    &KeySpaceNotificationsCtx::new(
+                        ctx,
+                        meta_data.clone(),
+                        FunctionFlags::NO_WRITES,
+                    ),
                     done_callback,
-                )
+                );
             });
 
         let consumer = if let Some(old_notification_consumer) = self

--- a/redisgears_plugin_api/Cargo.toml
+++ b/redisgears_plugin_api/Cargo.toml
@@ -7,7 +7,7 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
 serde = { version = "1", features = ["derive"] }
 serde_derive = "1"
 bitflags = "1"

--- a/redisgears_plugin_api/src/redisgears_plugin_api/keys_notifications_consumer_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/keys_notifications_consumer_ctx.rs
@@ -6,15 +6,21 @@
 
 use crate::redisgears_plugin_api::run_function_ctx::BackgroundRunFunctionCtxInterface;
 use crate::redisgears_plugin_api::run_function_ctx::RedisClientCtxInterface;
-use std::any::Any;
 
 use super::GearsApiError;
-
-pub trait NotificationFiredDataInterface {}
 
 pub trait NotificationRunCtxInterface {
     fn get_redis_client(&self) -> Box<dyn RedisClientCtxInterface + '_>;
     fn get_background_redis_client(&self) -> Box<dyn BackgroundRunFunctionCtxInterface>;
+}
+
+pub trait NotificationPostJobCtxInterface {
+    fn add_post_notification_job(&self, job: Box<dyn FnOnce(&dyn NotificationRunCtxInterface)>);
+}
+
+pub trait NotificationCtxInterface:
+    NotificationPostJobCtxInterface + NotificationRunCtxInterface
+{
 }
 
 pub trait KeysNotificationsConsumerCtxInterface {
@@ -22,13 +28,7 @@ pub trait KeysNotificationsConsumerCtxInterface {
         &self,
         event: &str,
         key: &[u8],
-        notification_ctx: &dyn NotificationRunCtxInterface,
-    ) -> Option<Box<dyn Any>>;
-
-    fn post_command_notification(
-        &self,
-        notificaion_data: Option<Box<dyn Any>>,
-        notification_ctx: &dyn NotificationRunCtxInterface,
+        notification_ctx: &dyn NotificationCtxInterface,
         ack_callback: Box<dyn FnOnce(Result<(), GearsApiError>) + Send + Sync>,
     );
 }

--- a/redisgears_plugin_api/src/redisgears_plugin_api/keys_notifications_consumer_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/keys_notifications_consumer_ctx.rs
@@ -23,6 +23,11 @@ pub trait NotificationCtxInterface:
 {
 }
 
+impl<T> NotificationCtxInterface for T where
+    T: NotificationPostJobCtxInterface + NotificationRunCtxInterface
+{
+}
+
 pub trait KeysNotificationsConsumerCtxInterface {
     fn on_notification_fired(
         &self,

--- a/redisgears_v8_plugin/Cargo.toml
+++ b/redisgears_v8_plugin/Cargo.toml
@@ -7,7 +7,7 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
 v8_rs = { git = "https://github.com/RedisGears/v8-rs" }
 v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs" }
 redisgears_plugin_api = { path = "../redisgears_plugin_api/" }

--- a/redisgears_v8_plugin/src/v8_native_functions.rs
+++ b/redisgears_v8_plugin/src/v8_native_functions.rs
@@ -36,6 +36,8 @@ use std::cell::RefCell;
 use std::ptr::NonNull;
 use std::sync::{Arc, Weak};
 
+const REGISTER_NOTIFICATIONS_CONSUMER: &str = "register_notifications_consumer";
+
 pub(crate) fn call_result_to_js_object<'isolate_scope, 'isolate>(
     isolate_scope: &'isolate_scope V8IsolateScope<'isolate>,
     ctx_scope: &V8ContextScope,
@@ -983,7 +985,7 @@ fn add_register_notification_consumer_api(
     ctx_scope: &V8ContextScope,
 ) {
     let script_ctx_ref = Arc::downgrade(script_ctx);
-    redis.set_native_function(ctx_scope, "register_notifications_consumer", new_native_function!(move|
+    redis.set_native_function(ctx_scope, REGISTER_NOTIFICATIONS_CONSUMER, new_native_function!(move|
         _isolate_scope,
         curr_ctx_scope,
         registration_name_utf8: V8LocalUtf8,
@@ -992,31 +994,23 @@ fn add_register_notification_consumer_api(
         optional_args: Option<NoficationConsumerOptionalArgs>,
     | {
         if !function_callback.is_function() {
-            return Err("Third argument to 'register_notifications_consumer' must be a function".into());
+            return Err(format!("Third argument to '{REGISTER_NOTIFICATIONS_CONSUMER}' must be a function"));
         }
         let persisted_function = function_callback.persist();
 
         let on_trigger_fired = optional_args.map_or(Result::<_, String>::Ok(None), |v| {
             v.onTriggerFired.map_or(Ok(None), |v|{
                 if !v.is_function() || v.is_async_function() {
-                    return Err("'onTriggerFired' argument to 'register_notifications_consumer' must be a function".into());
+                    return Err(format!("'onTriggerFired' argument to '{REGISTER_NOTIFICATIONS_CONSUMER}' must be a function"));
                 }
                 Ok(Some(v.persist()))
             })
         })?;
 
-        let load_ctx = curr_ctx_scope.get_private_data_mut::<&mut dyn LoadLibraryCtxInterface, _>(0);
-        if load_ctx.is_none() {
-            return Err("Called 'register_notifications_consumer' out of context".into());
-        }
-        let load_ctx = load_ctx.unwrap();
+        let load_ctx = curr_ctx_scope.get_private_data_mut::<&mut dyn LoadLibraryCtxInterface, _>(0).ok_or_else(|| format!("Called '{REGISTER_NOTIFICATIONS_CONSUMER}' out of context"))?;
 
-        let script_ctx_ref = match script_ctx_ref.upgrade() {
-            Some(s) => s,
-            None => {
-                return Err("Use of uninitialized script context".into());
-            }
-        };
+        let script_ctx_ref = script_ctx_ref.upgrade().ok_or_else(|| "Use of uninitialized script context".to_owned())?;
+
         let v8_notification_ctx = V8NotificationsCtx::new(persisted_function, on_trigger_fired, &script_ctx_ref, function_callback.is_async_function());
 
         let res = if prefix.is_string() {
@@ -1026,7 +1020,7 @@ fn add_register_notification_consumer_api(
             let prefix = prefix.as_array_buffer();
             load_ctx.register_key_space_notification_consumer(registration_name_utf8.as_str(), RegisteredKeys::Prefix(prefix.data()), Box::new(v8_notification_ctx))
         } else {
-            return Err("Second argument to 'register_notifications_consumer' must be a string or ArrayBuffer representing the prefix".into());
+            return Err(format!("Second argument to '{REGISTER_NOTIFICATIONS_CONSUMER}' must be a string or ArrayBuffer representing the prefix"));
         };
         if let Err(err) = res {
             return Err(err.get_msg().to_string());

--- a/redisgears_v8_plugin/src/v8_notifications_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_notifications_ctx.rs
@@ -4,10 +4,10 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
+use redisgears_plugin_api::redisgears_plugin_api::keys_notifications_consumer_ctx::NotificationCtxInterface;
 use redisgears_plugin_api::redisgears_plugin_api::GearsApiError;
 use redisgears_plugin_api::redisgears_plugin_api::{
     keys_notifications_consumer_ctx::KeysNotificationsConsumerCtxInterface,
-    keys_notifications_consumer_ctx::NotificationFiredDataInterface,
     keys_notifications_consumer_ctx::NotificationRunCtxInterface,
     run_function_ctx::BackgroundRunFunctionCtxInterface,
 };
@@ -19,18 +19,10 @@ use crate::v8_native_functions::{get_backgrounnd_client, get_redis_client, Redis
 use crate::v8_script_ctx::V8ScriptCtx;
 use crate::{get_error_from_object, get_exception_msg};
 
-use std::any::Any;
 use std::cell::RefCell;
 use std::sync::Arc;
 
 use v8_derive::new_native_function;
-
-struct V8NotificationCtxData {
-    event: String,
-    key: Vec<u8>,
-}
-
-impl NotificationFiredDataInterface for V8NotificationCtxData {}
 
 struct V8AckCallbackInternal {
     ack_callback: Box<dyn FnOnce(Result<(), GearsApiError>) + Send + Sync>,
@@ -43,6 +35,7 @@ struct V8AckCallback {
 
 struct V8NotificationsCtxInternal {
     persisted_function: V8PersistValue,
+    on_trigger_fired: Option<V8PersistValue>,
     script_ctx: Arc<V8ScriptCtx>,
 }
 
@@ -50,7 +43,7 @@ impl V8NotificationsCtxInternal {
     fn run_sync(
         &self,
         notification_ctx: &dyn NotificationRunCtxInterface,
-        data: &V8NotificationCtxData,
+        mut data: V8PersistValue,
         ack_callback: Box<dyn FnOnce(Result<(), GearsApiError>) + Send + Sync>,
     ) {
         let res = {
@@ -58,26 +51,7 @@ impl V8NotificationsCtxInternal {
             let ctx_scope = self.script_ctx.ctx.enter(&isolate_scope);
             let try_catch = isolate_scope.new_try_catch();
 
-            let notification_data = isolate_scope.new_object();
-            notification_data.set(
-                &ctx_scope,
-                &isolate_scope.new_string("event").to_value(),
-                &isolate_scope.new_string(&data.event).to_value(),
-            );
-
-            notification_data.set(
-                &ctx_scope,
-                &isolate_scope.new_string("key").to_value(),
-                &std::str::from_utf8(&data.key).map_or(isolate_scope.new_null(), |v| {
-                    isolate_scope.new_string(v).to_value()
-                }),
-            );
-
-            notification_data.set(
-                &ctx_scope,
-                &isolate_scope.new_string("key_raw").to_value(),
-                &isolate_scope.new_array_buffer(&data.key).to_value(),
-            );
+            let notification_data = data.take_local(&isolate_scope);
 
             let c = notification_ctx.get_redis_client();
             let redis_client = Arc::new(RefCell::new(RedisClient::with_client(c.as_ref())));
@@ -90,7 +64,7 @@ impl V8NotificationsCtxInternal {
             self.script_ctx.after_lock_gil();
             let res = self.persisted_function.as_local(&isolate_scope).call(
                 &ctx_scope,
-                Some(&[&r_client.to_value(), &notification_data.to_value()]),
+                Some(&[&r_client.to_value(), &notification_data]),
             );
             self.script_ctx.before_release_gil();
             self.script_ctx.after_run();
@@ -163,7 +137,7 @@ impl V8NotificationsCtxInternal {
         &self,
         background_client: Box<dyn BackgroundRunFunctionCtxInterface>,
         locker: Box<dyn BackgroundRunFunctionCtxInterface>,
-        data: &V8NotificationCtxData,
+        mut data: V8PersistValue,
         ack_callback: Box<dyn FnOnce(Result<(), GearsApiError>) + Send + Sync>,
     ) {
         let res = {
@@ -171,26 +145,7 @@ impl V8NotificationsCtxInternal {
             let ctx_scope = self.script_ctx.ctx.enter(&isolate_scope);
             let trycatch = isolate_scope.new_try_catch();
 
-            let notification_data = isolate_scope.new_object();
-            notification_data.set(
-                &ctx_scope,
-                &isolate_scope.new_string("event").to_value(),
-                &isolate_scope.new_string(&data.event).to_value(),
-            );
-
-            notification_data.set(
-                &ctx_scope,
-                &isolate_scope.new_string("key").to_value(),
-                &std::str::from_utf8(&data.key).map_or(isolate_scope.new_null(), |v| {
-                    isolate_scope.new_string(v).to_value()
-                }),
-            );
-
-            notification_data.set(
-                &ctx_scope,
-                &isolate_scope.new_string("key_raw").to_value(),
-                &isolate_scope.new_array_buffer(&data.key).to_value(),
-            );
+            let notification_data = data.take_local(&isolate_scope);
 
             let r_client = get_backgrounnd_client(
                 &self.script_ctx,
@@ -202,7 +157,7 @@ impl V8NotificationsCtxInternal {
             self.script_ctx.before_run();
             let res = self.persisted_function.as_local(&isolate_scope).call(
                 &ctx_scope,
-                Some(&[&r_client.to_value(), &notification_data.to_value()]),
+                Some(&[&r_client.to_value(), &notification_data]),
             );
             self.script_ctx.after_run();
 
@@ -278,13 +233,19 @@ pub(crate) struct V8NotificationsCtx {
 impl V8NotificationsCtx {
     pub(crate) fn new(
         mut persisted_function: V8PersistValue,
+        on_trigger_fired: Option<V8PersistValue>,
         script_ctx: &Arc<V8ScriptCtx>,
         is_async: bool,
     ) -> Self {
         persisted_function.forget();
+        let on_trigger_fired = on_trigger_fired.map(|mut v| {
+            v.forget();
+            v
+        });
         Self {
             internal: Arc::new(V8NotificationsCtxInternal {
                 persisted_function,
+                on_trigger_fired,
                 script_ctx: Arc::clone(script_ctx),
             }),
             is_async,
@@ -297,42 +258,96 @@ impl KeysNotificationsConsumerCtxInterface for V8NotificationsCtx {
         &self,
         event: &str,
         key: &[u8],
-        _notification_ctx: &dyn NotificationRunCtxInterface,
-    ) -> Option<Box<dyn Any>> {
-        Some(Box::new(V8NotificationCtxData {
-            event: event.to_string(),
-            key: key.to_vec(),
-        }))
-    }
-
-    fn post_command_notification(
-        &self,
-        notificaion_data: Option<Box<dyn Any>>,
-        notification_ctx: &dyn NotificationRunCtxInterface,
+        notification_ctx: &dyn NotificationCtxInterface,
         ack_callback: Box<dyn FnOnce(Result<(), GearsApiError>) + Send + Sync>,
     ) {
-        let notificaion_data = notificaion_data
-            .unwrap()
-            .downcast::<V8NotificationCtxData>()
-            .unwrap();
-        if self.is_async {
-            let redis_background_client = notification_ctx.get_background_redis_client();
-            let locker = notification_ctx.get_background_redis_client();
-            let internal = Arc::clone(&self.internal);
-            self.internal
-                .script_ctx
-                .compiled_library_api
-                .run_on_background(Box::new(move || {
-                    internal.run_async(
-                        redis_background_client,
-                        locker,
-                        &notificaion_data,
-                        ack_callback,
-                    );
-                }));
-        } else {
-            self.internal
-                .run_sync(notification_ctx, &notificaion_data, ack_callback);
-        }
+        let data = {
+            let isolate_scope = self.internal.script_ctx.isolate.enter();
+            let ctx_scope = self.internal.script_ctx.ctx.enter(&isolate_scope);
+            let try_catch = isolate_scope.new_try_catch();
+
+            let notification_data = isolate_scope.new_object();
+            notification_data.set(
+                &ctx_scope,
+                &isolate_scope.new_string("event").to_value(),
+                &isolate_scope.new_string(event).to_value(),
+            );
+
+            notification_data.set(
+                &ctx_scope,
+                &isolate_scope.new_string("key").to_value(),
+                &std::str::from_utf8(key).map_or(isolate_scope.new_null(), |v| {
+                    isolate_scope.new_string(v).to_value()
+                }),
+            );
+
+            notification_data.set(
+                &ctx_scope,
+                &isolate_scope.new_string("key_raw").to_value(),
+                &isolate_scope.new_array_buffer(key).to_value(),
+            );
+            let val = notification_data.to_value();
+
+            // possibly enhance the data with more information
+            let res = self.internal.on_trigger_fired.as_ref().map_or(Ok(()), |v| {
+                let on_trigger_fired = v.as_local(&isolate_scope);
+
+                let c = notification_ctx.get_redis_client();
+                let redis_client = Arc::new(RefCell::new(RedisClient::with_client(c.as_ref())));
+                let r_client = get_redis_client(
+                    &self.internal.script_ctx,
+                    &isolate_scope,
+                    &ctx_scope,
+                    &redis_client,
+                );
+
+                let _block_guard = ctx_scope.set_private_data(0, &true); // indicate we are blocked
+
+                self.internal.script_ctx.before_run();
+                self.internal.script_ctx.after_lock_gil();
+
+                let res = on_trigger_fired.call(&ctx_scope, Some(&[&r_client.to_value(), &val]));
+
+                self.internal.script_ctx.before_release_gil();
+                self.internal.script_ctx.after_run();
+
+                redis_client.borrow_mut().make_invalid();
+
+                res.map_or_else(
+                    || {
+                        Err(get_exception_msg(
+                            &self.internal.script_ctx.isolate,
+                            try_catch,
+                            &ctx_scope,
+                        ))
+                    },
+                    |_| Ok(()),
+                )
+            });
+
+            if let Err(res) = res {
+                ack_callback(Err(res));
+                return;
+            }
+
+            val.persist()
+        };
+        let internal = Arc::clone(&self.internal);
+        let is_async = self.is_async;
+        notification_ctx.add_post_notification_job(Box::new(move |notification_run_ctx| {
+            if is_async {
+                let redis_background_client = notification_run_ctx.get_background_redis_client();
+                let locker = notification_run_ctx.get_background_redis_client();
+                let new_internal = Arc::clone(&internal);
+                internal
+                    .script_ctx
+                    .compiled_library_api
+                    .run_on_background(Box::new(move || {
+                        new_internal.run_async(redis_background_client, locker, data, ack_callback);
+                    }));
+            } else {
+                internal.run_sync(notification_run_ctx, data, ack_callback);
+            }
+        }));
     }
 }


### PR DESCRIPTION
Fix #896.

The PR adds a new optional argument, `onTriggerFired`, that allows specify a function that will be invoke exactly when a notification happened and allows to read the data as it was at the time of the notification.

In addition, the PR refactor the API to use Redis post notification job where it is safe to perform write operations.

Example of the new API usage was added to the docs: https://github.com/RedisGears/RedisGears/blob/74af30b35c223e4589dfe878fe1c3af0a9d55d03/docs/databse_triggers.md#advance-usage