### PR TITLE
Use AUX save V2.

### DIFF
--- a/pytests/test_cluster.py
+++ b/pytests/test_cluster.py
@@ -77,7 +77,7 @@ redis.registerAsyncFunction("test",
             continue
         failTest(env, 'error was not raised by command')
 
-@gearsTest(cluster=True)
+@gearsTest(cluster=True, gearsConfig={"remote-task-default-timeout": "10000"})
 def testRecursiveLookup(env, cluster_conn):
     """#!js api_version=1.0 name=foo
 const recursive_get = "recursive_get";

--- a/redisgears_core/src/rdb.rs
+++ b/redisgears_core/src/rdb.rs
@@ -47,7 +47,7 @@ pub(crate) static REDIS_GEARS_TYPE: RedisType = RedisType::new(
 
 extern "C" fn aux_save(rdb: *mut raw::RedisModuleIO, _when: c_int) {
     let libraries = get_libraries();
-    if libraries.len() == 0 {
+    if libraries.is_empty() {
         // no libraries to save, we will save nothing to the RDB so it will be
         // possible to load the RDB even without loading RedisGears.
         return;

--- a/redisgears_core/src/rdb.rs
+++ b/redisgears_core/src/rdb.rs
@@ -29,7 +29,8 @@ pub(crate) static REDIS_GEARS_TYPE: RedisType = RedisType::new(
 
         // Auxiliary data (v2)
         aux_load: Some(aux_load),
-        aux_save: Some(aux_save),
+        aux_save: None,
+        aux_save2: Some(aux_save),
         aux_save_triggers: REDISMODULE_AUX_BEFORE_RDB as i32,
 
         free_effort: None,
@@ -46,6 +47,11 @@ pub(crate) static REDIS_GEARS_TYPE: RedisType = RedisType::new(
 
 extern "C" fn aux_save(rdb: *mut raw::RedisModuleIO, _when: c_int) {
     let libraries = get_libraries();
+    if libraries.len() == 0 {
+        // no libraries to save, we will save nothing to the RDB so it will be
+        // possible to load the RDB even without loading RedisGears.
+        return;
+    }
 
     // save the number of libraries
     raw::save_unsigned(rdb, libraries.len() as u64);

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -426,7 +426,12 @@ impl BackendCtxInterfaceUninitialised for V8Backend {
 
 impl BackendCtxInterfaceInitialised for V8Backend {
     fn get_version(&self) -> String {
-        format!("Version: {}, v8-rs: {}", v8_version(), v8_rs::GIT_SEMVER)
+        format!(
+            "Version: {}, v8-rs: {}, profile:{}",
+            v8_version(),
+            v8_rs::GIT_SEMVER,
+            v8_rs::PROFILE
+        )
     }
 
     fn compile_library(

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -385,7 +385,8 @@ impl V8Backend {
                 panic!("{}", msg);
             }),
             1,
-        );
+        )
+        .expect("Failed loading V8");
     }
 
     fn spone_background_maintenance_thread(&self) {


### PR DESCRIPTION
Fixes #934.

Use AUX save V2 so if the user do not use RedisGears he will be able to load the RDB even if RedisGears module is not loaded.