### PR TITLE
Combine library and function name to a single argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Assuming we put the following code on a file `lib.js`, we can register our funct
 OK
 ```
 
-And now we can execute our function using [`TFCALL`](docs/commands.md#rgfcal) command, the command gets the library name and the function name:
+And now we can execute our function using [`TFCALL`](docs/commands.md#rgfcal) command, the command gets the library name and the function name `.` separated:
 
 ```bash
-> redis-cli TFCALL lib hello_world 0
+> redis-cli TFCALL lib.hello_world 0
 "hello_world"
 ```
 
@@ -84,7 +84,7 @@ OK
 
 And now we can invoke `my_ping` using [`TFCALL`](docs/commands.md#rgfcal) :
 ```bash
-> redis-cli TFCALL lib my_ping 0
+> redis-cli TFCALL lib.my_ping 0
 "PONG"
 ```
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -97,7 +97,7 @@ Information about the requested libraries.
 Invoke a function.
 
 ```
-RFCALL <library name> <function name> <number of keys> [<key1> ... <keyn>] [<arg1> ... <argn>]
+RFCALL <library name>.<function name> <number of keys> [<key1> ... <keyn>] [<arg1> ... <argn>]
 ```
 
 _Arguments_
@@ -114,7 +114,7 @@ The return value from the function on error in case of failure.
 
 **Example**
 ```bash
-> TFCALL lib foo 0
+> TFCALL lib.foo 0
 "bar"
 ```
 
@@ -123,7 +123,7 @@ The return value from the function on error in case of failure.
 Invoke an async function (Coroutine).
 
 ```
-TFCALLASYNC <library name> <function name> <number of keys> [<key1> ... <keyn>] [<arg1> ... <argn>]
+TFCALLASYNC <library name>.<function name> <number of keys> [<key1> ... <keyn>] [<arg1> ... <argn>]
 ```
 
 _Arguments_
@@ -140,6 +140,6 @@ The return value from the async function on error in case of failure.
 
 **Example**
 ```bash
-> TFCALLASYNC lib foo 0
+> TFCALLASYNC lib.foo 0
 "bar"
 ```

--- a/docs/create_development_environment.md
+++ b/docs/create_development_environment.md
@@ -97,7 +97,7 @@ redis-cli -x TFUNCTION LOAD < ./dist/main.js
 An `OK` reply will indicating that the library was loaded successfully. Test the library functionality by running the following:
 
 ```bash
-> redis-cli TFCALL foo foo 0
+> redis-cli TFCALL foo.foo 0
 "foo"
 ```
 
@@ -141,7 +141,7 @@ redis-cli -x TFUNCTION LOAD REPLACE < ./dist/main.js
 And we can test our function:
 
 ```bash
-> redis-cli TFCALL foo foo 0
+> redis-cli TFCALL foo.foo 0
 "test"
 ```
 
@@ -178,7 +178,7 @@ redis-cli -x TFUNCTION LOAD REPLACE < ./dist/main.js
 And run it:
 
 ```bash
-> redis-cli TFCALL foo foo 0
+> redis-cli TFCALL foo.foo 0
 "3.1415926535897931"
 ```
 
@@ -478,10 +478,10 @@ Deploying
 OK
 ```
 
-Now if we will call `foo` function using [`FCALL`](commands.md#tfcall), we will see that `Hello, World!` is printed to the Redis log file.
+Now if we will call `foo` function using [`TFCALL`](commands.md#tfcall), we will see that `Hello, World!` is printed to the Redis log file.
 
 ```bash
-> redis-cli TFCALL foo foo 0
+> redis-cli TFCALL foo.foo 0
 "undefined"
 ```
 
@@ -548,11 +548,11 @@ We define a new `Client` type and declare its `get` function. Then we use it on 
 
 ```bash
 > redis-cli
-127.0.0.1:6379> TFCALL foo foo 0
+127.0.0.1:6379> TFCALL foo.foo 0
 "undefined"
 127.0.0.1:6379> set x 1
 OK
-127.0.0.1:6379> TFCALL foo foo 0
+127.0.0.1:6379> TFCALL foo.foo 0
 "1"
 ```
 

--- a/docs/function_advance_topics.md
+++ b/docs/function_advance_topics.md
@@ -23,11 +23,11 @@ Example of running the following function:
 ```bash
 127.0.0.1:6379> set x 1
 OK
-127.0.0.1:6379> TFCALL foo my_get 1 x
+127.0.0.1:6379> TFCALL foo.my_get 1 x
 "1"
 127.0.0.1:6379> hset h foo bar x y
 (integer) 2
-127.0.0.1:6379> TFCALL foo my_get 1 h
+127.0.0.1:6379> TFCALL foo.my_get 1 h
 1) "foo"
 2) "bar"
 3) "x"
@@ -62,7 +62,7 @@ redis.registerFunction('my_get', function(client, ...keys){
 Run example:
 
 ```bash
-127.0.0.1:6379> TFCALL foo my_get 2 x h
+127.0.0.1:6379> TFCALL foo.my_get 2 x h
 1) "1"
 2) 1) "foo"
    2) "bar"
@@ -95,11 +95,11 @@ redis.registerFunction('my_ping',
 Run example:
 
 ```bash
-127.0.0.1:6379> TFCALL foo my_ping 0
+127.0.0.1:6379> TFCALL foo.my_ping 0
 "PONG"
 127.0.0.1:6379> config set maxmemory 1
 OK
-127.0.0.1:6379> TFCALL foo my_ping 0
+127.0.0.1:6379> TFCALL foo.my_ping 0
 "PONG"
 
 ```
@@ -121,7 +121,7 @@ redis.registerFunction("hset", function(client, key, field, val){
 Run example:
 
 ```bash
-127.0.0.1:6379> TFCALL lib hset k foo bar 0
+127.0.0.1:6379> TFCALL lib.hset k foo bar 0
 (integer) 2
 127.0.0.1:6379> hgetall k
 1) "foo"
@@ -161,7 +161,7 @@ OK
 And we can see that the last update field name is `last_update`:
 
 ```bash
-127.0.0.1:6379> TFCALL lib hset h foo bar 0
+127.0.0.1:6379> TFCALL lib.hset h foo bar 0
 (integer) 2
 127.0.0.1:6379> hgetall h
 1) "foo"
@@ -254,7 +254,7 @@ redis.registerFunction("my_set",
 The above example will allow us to set `key` and `val` even if those are binary data. Run example:
 
 ```bash
-127.0.0.1:6379> TFCALL lib my_set 1 "\xaa" "\xaa"
+127.0.0.1:6379> TFCALL lib.my_set 1 "\xaa" "\xaa"
 "OK"
 127.0.0.1:6379> get "\xaa"
 "\xaa"
@@ -283,7 +283,7 @@ The above example will be able to fetch binary data and return it to the user. R
 ```bash
 27.0.0.1:6379> set "\xaa" "\xaa"
 OK
-127.0.0.1:6379> TFCALL lib my_get 1 "\xaa"
+127.0.0.1:6379> TFCALL lib.my_get 1 "\xaa"
 "\xaa"
 ```
 
@@ -321,7 +321,7 @@ Run example:
 ```bash
 127.0.0.1:6379> set "\xaa" "\xaa"
 OK
-127.0.0.1:6379> TFCALL lib notifications_stats 0
+127.0.0.1:6379> TFCALL lib.notifications_stats 0
 1) (integer) 1
 2) (nil)
 3) "\xaa"
@@ -361,7 +361,7 @@ Run Example:
 ```bash
 127.0.0.1:6379> xadd "\xff\xff" * "\xaa" "\xaa"
 "1659515146671-0"
-127.0.0.1:6379> TFCALL foo stats 0
+127.0.0.1:6379> TFCALL foo.stats 0
 1) (nil)
 2) "\xff\xff"
 3) 1) 1) (nil)

--- a/docs/sync_and_async_run.md
+++ b/docs/sync_and_async_run.md
@@ -36,7 +36,7 @@ redis.registerFunction('test', async function(client){
 Running this function will return a `pong` reply:
 
 ```bash
-127.0.0.1:6379> TFCALLASYNC lib test 0
+127.0.0.1:6379> TFCALLASYNC lib.test 0
 "PONG"
 ```
 

--- a/pytests/common.py
+++ b/pytests/common.py
@@ -111,6 +111,26 @@ def verifyClusterInitialized(env):
             if not allConnected:
                 time.sleep(0.1)
 
+def extendEnvWithGearsFunctionality(env):
+    def expectTfcall(lib, func, keys=[], args=[]):
+        return env.expect('TFCALL', '%s.%s' % (lib, func), str(len(keys)), *(keys + args))
+    
+    def tfcall(lib, func, keys=[], args=[], c=None):
+        c = c if c else env
+        return c.execute_command('TFCALL', '%s.%s' % (lib, func), str(len(keys)), *(keys + args))
+
+    def expectTfcallAsync(lib, func, keys=[], args=[]):
+        return env.expect('TFCALLASYNC', '%s.%s' % (lib, func), str(len(keys)), *(keys + args))
+    
+    def tfcallAsync(lib, func, keys=[], args=[], c=None):
+        c = c if c else env
+        return c.execute_command('TFCALLASYNC', '%s.%s' % (lib, func), str(len(keys)), *(keys + args))
+    
+    env.expectTfcall = expectTfcall
+    env.tfcall = tfcall
+    env.expectTfcallAsync = expectTfcallAsync
+    env.tfcallAsync = tfcallAsync
+
 def gearsTest(skipTest=False,
               skipOnCluster=False,
               skipCleanups=False,
@@ -217,6 +237,7 @@ def gearsTest(skipTest=False,
                             return status
 
                         runUntil(env, 1, synchronise_replicas, timeout=10)
+            extendEnvWithGearsFunctionality(env)
             test_args = [env]
             if cluster:
                 test_args.append(env.envRunner.getClusterConnection())

--- a/pytests/test_acl.py
+++ b/pytests/test_acl.py
@@ -14,11 +14,11 @@ redis.registerFunction("get", function(client, dummy, key){
     env.expect('ACL', 'SETUSER', 'alice', 'on', '>pass', '~cached:*', '+get', '+tfunction', '+TFCALL').equal('OK')
     env.expect('set', 'x', '1').equal(True)
     env.expect('set', 'cached:x', '1').equal(True)
-    env.expect('TFCALL', 'lib', 'get', '1', 'x', 'x').equal('1')
-    env.expect('TFCALL', 'lib', 'get', '1', 'x', 'cached:x').equal('1')
+    env.expect('TFCALL', 'lib.get', '1', 'x', 'x').equal('1')
+    env.expect('TFCALL', 'lib.get', '1', 'x', 'cached:x').equal('1')
     env.expect('AUTH', 'alice', 'pass').equal(True)
-    env.expect('TFCALL', 'lib', 'get', '1', 'cached:x', 'x').error().contains(NO_PERMISSIONS_ERROR_MSG)
-    env.expect('TFCALL', 'lib', 'get', '1', 'cached:x', 'cached:x').equal('1')
+    env.expect('TFCALL', 'lib.get', '1', 'cached:x', 'x').error().contains(NO_PERMISSIONS_ERROR_MSG)
+    env.expect('TFCALL', 'lib.get', '1', 'cached:x', 'cached:x').equal('1')
 
 @gearsTest()
 def testAclOnAsyncFunction(env):
@@ -32,11 +32,11 @@ redis.registerAsyncFunction("get", async function(client, dummy, key){
     env.expect('ACL', 'SETUSER', 'alice', 'on', '>pass', '~cached:*', '+get', '+tfunction', '+TFCALLasync').equal('OK')
     env.expect('set', 'x', '1').equal(True)
     env.expect('set', 'cached:x', '1').equal(True)
-    env.expect('TFCALLASYNC', 'lib', 'get', '1', 'x', 'x').equal('1')
-    env.expect('TFCALLASYNC', 'lib', 'get', '1', 'x', 'cached:x').equal('1')
+    env.expect('TFCALLASYNC', 'lib.get', '1', 'x', 'x').equal('1')
+    env.expect('TFCALLASYNC', 'lib.get', '1', 'x', 'cached:x').equal('1')
     env.expect('AUTH', 'alice', 'pass').equal(True)
-    env.expect('TFCALLASYNC', 'lib', 'get', '1', 'cached:x', 'x').error().contains(NO_PERMISSIONS_ERROR_MSG)
-    env.expect('TFCALLASYNC', 'lib', 'get', '1', 'cached:x', 'cached:x').equal('1')
+    env.expect('TFCALLASYNC', 'lib.get', '1', 'cached:x', 'x').error().contains(NO_PERMISSIONS_ERROR_MSG)
+    env.expect('TFCALLASYNC', 'lib.get', '1', 'cached:x', 'cached:x').equal('1')
 
 @gearsTest()
 def testAclOnAsyncComplex(env):
@@ -54,11 +54,11 @@ redis.registerAsyncFunction("get", async function(client, dummy, key){
     env.expect('ACL', 'SETUSER', 'alice', 'on', '>pass', '~cached:*', '+get', '+tfunction', '+TFCALLasync').equal('OK')
     env.expect('set', 'x', '1').equal(True)
     env.expect('set', 'cached:x', '1').equal(True)
-    env.expect('TFCALLASYNC', 'lib', 'get', '1', 'x', 'x').equal('1')
-    env.expect('TFCALLASYNC', 'lib', 'get', '1', 'x', 'cached:x').equal('1')
+    env.expect('TFCALLASYNC', 'lib.get', '1', 'x', 'x').equal('1')
+    env.expect('TFCALLASYNC', 'lib.get', '1', 'x', 'cached:x').equal('1')
     env.expect('AUTH', 'alice', 'pass').equal(True)
-    env.expect('TFCALLASYNC', 'lib', 'get', '1', 'cached:x', 'x').error().contains(NO_PERMISSIONS_ERROR_MSG)
-    env.expect('TFCALLASYNC', 'lib', 'get', '1', 'cached:x', 'cached:x').equal('1')
+    env.expect('TFCALLASYNC', 'lib.get', '1', 'cached:x', 'x').error().contains(NO_PERMISSIONS_ERROR_MSG)
+    env.expect('TFCALLASYNC', 'lib.get', '1', 'cached:x', 'cached:x').equal('1')
 
 @gearsTest()
 def testAclUserDeletedWhileFunctionIsRunning(env):
@@ -94,30 +94,30 @@ redis.registerFunction("async_get_start", function(client, dummy, key){
     env.expect('ACL', 'SETUSER', 'alice', 'on', '>pass', '~cached:*', '+get', '+tfunction', '+TFCALLasync').equal('OK')
     env.expect('set', 'x', '1').equal(True)
     env.expect('set', 'cached:x', '1').equal(True)
-    env.expect('TFCALLASYNC', 'lib', 'async_get_start', '1', 'cached:x', 'x').equal('OK')
-    env.expect('TFCALLASYNC', 'lib', 'async_get_continue', '0').equal('1')
-    env.expect('TFCALLASYNC', 'lib', 'async_get_start', '1', 'cached:x', 'cached:x').equal('OK')
-    env.expect('TFCALLASYNC', 'lib', 'async_get_continue', '0').equal('1')
+    env.expect('TFCALLASYNC', 'lib.async_get_start', '1', 'cached:x', 'x').equal('OK')
+    env.expect('TFCALLASYNC', 'lib.async_get_continue', '0').equal('1')
+    env.expect('TFCALLASYNC', 'lib.async_get_start', '1', 'cached:x', 'cached:x').equal('OK')
+    env.expect('TFCALLASYNC', 'lib.async_get_continue', '0').equal('1')
     c = env.getConnection()
     c.execute_command('AUTH', 'alice', 'pass')
 
-    env.assertEqual(c.execute_command('TFCALLASYNC', 'lib', 'async_get_start', '1', 'cached:x', 'x'), "OK")
+    env.assertEqual(c.execute_command('TFCALLASYNC', 'lib.async_get_start', '1', 'cached:x', 'x'), "OK")
     try:
-        c.execute_command('TFCALLASYNC', 'lib', 'async_get_continue', '0')
+        c.execute_command('TFCALLASYNC', 'lib.async_get_continue', '0')
         env.assertTrue(False, message='Command succeed though should failed')
     except Exception as e:
         env.assertContains(NO_PERMISSIONS_ERROR_MSG, str(e))
 
-    env.assertEqual(c.execute_command('TFCALLASYNC', 'lib', 'async_get_start', '1', 'cached:x', 'cached:x'), "OK")
+    env.assertEqual(c.execute_command('TFCALLASYNC', 'lib.async_get_start', '1', 'cached:x', 'cached:x'), "OK")
     try:
-        env.assertEqual(c.execute_command('TFCALLASYNC', 'lib', 'async_get_continue', '0'), '1')
+        env.assertEqual(c.execute_command('TFCALLASYNC', 'lib.async_get_continue', '0'), '1')
     except Exception as e:
         env.assertTrue(False, message='Command failed though should success, %s' % str(e))
 
-    env.assertEqual(c.execute_command('TFCALLASYNC', 'lib', 'async_get_start', '1', 'cached:x', 'cached:x'), "OK")
+    env.assertEqual(c.execute_command('TFCALLASYNC', 'lib.async_get_start', '1', 'cached:x', 'cached:x'), "OK")
     env.expect('ACL', 'DELUSER', 'alice').equal(1) # delete alice user while function is running
     try:
-        c.execute_command('TFCALLASYNC', 'lib', 'async_get_continue', '0')
+        c.execute_command('TFCALLASYNC', 'lib.async_get_continue', '0')
         env.assertTrue(False, message='Command succeed though should failed')
     except Exception as e:
         env.assertContains("User does not exists or disabled", str(e))

--- a/pytests/test_acl.py
+++ b/pytests/test_acl.py
@@ -14,11 +14,11 @@ redis.registerFunction("get", function(client, dummy, key){
     env.expect('ACL', 'SETUSER', 'alice', 'on', '>pass', '~cached:*', '+get', '+tfunction', '+TFCALL').equal('OK')
     env.expect('set', 'x', '1').equal(True)
     env.expect('set', 'cached:x', '1').equal(True)
-    env.expect('TFCALL', 'lib.get', '1', 'x', 'x').equal('1')
-    env.expect('TFCALL', 'lib.get', '1', 'x', 'cached:x').equal('1')
+    env.expectTfcall('lib', 'get', ['x'], ['x']).equal('1')
+    env.expectTfcall('lib', 'get', ['x'], ['cached:x']).equal('1')
     env.expect('AUTH', 'alice', 'pass').equal(True)
-    env.expect('TFCALL', 'lib.get', '1', 'cached:x', 'x').error().contains(NO_PERMISSIONS_ERROR_MSG)
-    env.expect('TFCALL', 'lib.get', '1', 'cached:x', 'cached:x').equal('1')
+    env.expectTfcall('lib', 'get', ['cached:x'], ['x']).error().contains(NO_PERMISSIONS_ERROR_MSG)
+    env.expectTfcall('lib', 'get', ['cached:x'], ['cached:x']).equal('1')
 
 @gearsTest()
 def testAclOnAsyncFunction(env):
@@ -32,11 +32,11 @@ redis.registerAsyncFunction("get", async function(client, dummy, key){
     env.expect('ACL', 'SETUSER', 'alice', 'on', '>pass', '~cached:*', '+get', '+tfunction', '+TFCALLasync').equal('OK')
     env.expect('set', 'x', '1').equal(True)
     env.expect('set', 'cached:x', '1').equal(True)
-    env.expect('TFCALLASYNC', 'lib.get', '1', 'x', 'x').equal('1')
-    env.expect('TFCALLASYNC', 'lib.get', '1', 'x', 'cached:x').equal('1')
+    env.expectTfcallAsync('lib', 'get', ['x'], ['x']).equal('1')
+    env.expectTfcallAsync('lib', 'get', ['x'], ['cached:x']).equal('1')
     env.expect('AUTH', 'alice', 'pass').equal(True)
-    env.expect('TFCALLASYNC', 'lib.get', '1', 'cached:x', 'x').error().contains(NO_PERMISSIONS_ERROR_MSG)
-    env.expect('TFCALLASYNC', 'lib.get', '1', 'cached:x', 'cached:x').equal('1')
+    env.expectTfcallAsync('lib', 'get', ['cached:x'], ['x']).error().contains(NO_PERMISSIONS_ERROR_MSG)
+    env.expectTfcallAsync('lib', 'get', ['cached:x'], ['cached:x']).equal('1')
 
 @gearsTest()
 def testAclOnAsyncComplex(env):
@@ -54,11 +54,11 @@ redis.registerAsyncFunction("get", async function(client, dummy, key){
     env.expect('ACL', 'SETUSER', 'alice', 'on', '>pass', '~cached:*', '+get', '+tfunction', '+TFCALLasync').equal('OK')
     env.expect('set', 'x', '1').equal(True)
     env.expect('set', 'cached:x', '1').equal(True)
-    env.expect('TFCALLASYNC', 'lib.get', '1', 'x', 'x').equal('1')
-    env.expect('TFCALLASYNC', 'lib.get', '1', 'x', 'cached:x').equal('1')
+    env.expectTfcallAsync('lib', 'get', ['x'], ['x']).equal('1')
+    env.expectTfcallAsync('lib', 'get', ['x'], ['cached:x']).equal('1')
     env.expect('AUTH', 'alice', 'pass').equal(True)
-    env.expect('TFCALLASYNC', 'lib.get', '1', 'cached:x', 'x').error().contains(NO_PERMISSIONS_ERROR_MSG)
-    env.expect('TFCALLASYNC', 'lib.get', '1', 'cached:x', 'cached:x').equal('1')
+    env.expectTfcallAsync('lib', 'get', ['cached:x'], ['x']).error().contains(NO_PERMISSIONS_ERROR_MSG)
+    env.expectTfcallAsync('lib', 'get', ['cached:x'], ['cached:x']).equal('1')
 
 @gearsTest()
 def testAclUserDeletedWhileFunctionIsRunning(env):
@@ -94,30 +94,30 @@ redis.registerFunction("async_get_start", function(client, dummy, key){
     env.expect('ACL', 'SETUSER', 'alice', 'on', '>pass', '~cached:*', '+get', '+tfunction', '+TFCALLasync').equal('OK')
     env.expect('set', 'x', '1').equal(True)
     env.expect('set', 'cached:x', '1').equal(True)
-    env.expect('TFCALLASYNC', 'lib.async_get_start', '1', 'cached:x', 'x').equal('OK')
-    env.expect('TFCALLASYNC', 'lib.async_get_continue', '0').equal('1')
-    env.expect('TFCALLASYNC', 'lib.async_get_start', '1', 'cached:x', 'cached:x').equal('OK')
-    env.expect('TFCALLASYNC', 'lib.async_get_continue', '0').equal('1')
+    env.expectTfcallAsync('lib', 'async_get_start', ['cached:x'], ['x']).equal('OK')
+    env.expectTfcallAsync('lib', 'async_get_continue').equal('1')
+    env.expectTfcallAsync('lib', 'async_get_start', ['cached:x'], ['cached:x']).equal('OK')
+    env.expectTfcallAsync('lib', 'async_get_continue').equal('1')
     c = env.getConnection()
     c.execute_command('AUTH', 'alice', 'pass')
 
-    env.assertEqual(c.execute_command('TFCALLASYNC', 'lib.async_get_start', '1', 'cached:x', 'x'), "OK")
+    env.assertEqual(env.tfcallAsync('lib', 'async_get_start', ['cached:x'], ['x'], c), "OK")
     try:
-        c.execute_command('TFCALLASYNC', 'lib.async_get_continue', '0')
+        env.tfcallAsync('lib', 'async_get_continue', c=c)
         env.assertTrue(False, message='Command succeed though should failed')
     except Exception as e:
         env.assertContains(NO_PERMISSIONS_ERROR_MSG, str(e))
 
-    env.assertEqual(c.execute_command('TFCALLASYNC', 'lib.async_get_start', '1', 'cached:x', 'cached:x'), "OK")
+    env.assertEqual(env.tfcallAsync('lib', 'async_get_start', ['cached:x'], ['cached:x'], c), "OK")
     try:
-        env.assertEqual(c.execute_command('TFCALLASYNC', 'lib.async_get_continue', '0'), '1')
+        env.assertEqual(env.tfcallAsync('lib', 'async_get_continue', c=c), '1')
     except Exception as e:
         env.assertTrue(False, message='Command failed though should success, %s' % str(e))
 
-    env.assertEqual(c.execute_command('TFCALLASYNC', 'lib.async_get_start', '1', 'cached:x', 'cached:x'), "OK")
+    env.assertEqual(env.tfcallAsync('lib', 'async_get_start', ['cached:x'], ['cached:x'], c=c), "OK")
     env.expect('ACL', 'DELUSER', 'alice').equal(1) # delete alice user while function is running
     try:
-        c.execute_command('TFCALLASYNC', 'lib.async_get_continue', '0')
+        env.tfcallAsync('lib', 'async_get_continue', c=c)
         env.assertTrue(False, message='Command succeed though should failed')
     except Exception as e:
         env.assertContains("User does not exists or disabled", str(e))

--- a/pytests/test_basics.py
+++ b/pytests/test_basics.py
@@ -15,7 +15,7 @@ redis.registerFunction("test", function(){
     return 1
 })
     """
-    env.expect('TFCALL', 'foo.test', 0).equal(1)
+    env.expectTfcall('foo', 'test').equal(1)
 
 @gearsTest()
 def testCommandInvocation(env):
@@ -24,7 +24,7 @@ redis.registerFunction("test", function(client){
     return client.call('ping')
 })
     """
-    env.expect('TFCALL', 'foo.test', 0).equal('PONG')
+    env.expectTfcall('foo', 'test').equal('PONG')
 
 @gearsTest(enableGearsDebugCommands=True)
 def testLibraryUpgrade(env):
@@ -38,9 +38,9 @@ redis.registerFunction("test", function(client){
     return 2
 })
     '''
-    env.expect('TFCALL', 'foo.test', 0).equal(1)
+    env.expectTfcall('foo', 'test').equal(1)
     env.expect('TFUNCTION', 'LOAD', 'REPLACE', script).equal('OK')
-    env.expect('TFCALL', 'foo.test', 0).equal(2)
+    env.expectTfcall('foo', 'test').equal(2)
 
     # make sure isolate was released
     isolate_stats = toDictionary(env.cmd('TFUNCTION', 'DEBUG', 'js', 'isolates_aggregated_stats'))
@@ -60,9 +60,9 @@ redis.registerFunction("test", function(client){
 })
 redis.registerFunction("test", "bar"); // this will fail
     '''
-    env.expect('TFCALL', 'foo.test', 0).equal(1)
+    env.expectTfcall('foo', 'test').equal(1)
     env.expect('TFUNCTION', 'LOAD', 'REPLACE', script).error().contains('must be a function')
-    env.expect('TFCALL', 'foo.test', 0).equal(1)
+    env.expectTfcall('foo', 'test').equal(1)
 
     # make sure isolate was released
     isolate_stats = toDictionary(env.cmd('TFUNCTION', 'DEBUG', 'js', 'isolates_aggregated_stats'))
@@ -132,7 +132,7 @@ redis.registerFunction("test", function(client){
     return client.call('get', 'x');
 })
     """
-    env.expect('TFCALL', 'foo.test', 0).equal(None)
+    env.expectTfcall('foo', 'test').equal(None)
 
 @gearsTest()
 def testRedisOOM(env):
@@ -141,9 +141,9 @@ redis.registerFunction("set", function(client, key, val){
     return client.call('set', key, val);
 })
     """
-    env.expect('TFCALL', 'lib.set', '1', 'x', '1').equal('OK')
+    env.expectTfcall('lib', 'set', ['x'], ['1']).equal('OK')
     env.expect('CONFIG', 'SET', 'maxmemory', '1')
-    env.expect('TFCALL', 'lib.set', '1', 'x', '1').error().contains('OOM can not run the function when out of memory')
+    env.expectTfcall('lib', 'set', ['x'], ['1']).error().contains('OOM can not run the function when out of memory')
 
 @gearsTest()
 def testRedisOOMOnAsyncFunction(env):
@@ -186,9 +186,9 @@ redis.registerFunction("async_set_trigger", function(client, key, val){
     return "OK";
 });
     """
-    env.expect('TFCALL', 'lib.async_set_trigger', '1', 'x', '1').equal('OK')
+    env.expectTfcall('lib', 'async_set_trigger', ['x'], ['1']).equal('OK')
     env.expect('CONFIG', 'SET', 'maxmemory', '1')
-    env.expect('TFCALLASYNC', 'lib.async_set_continue', '0').error().contains('OOM Can not lock redis for write')
+    env.expectTfcallAsync('lib', 'async_set_continue').error().contains('OOM Can not lock redis for write')
 
 @gearsTest(withReplicas=True)
 def testRunOnReplica(env):
@@ -210,12 +210,12 @@ redis.registerFunction("test1",
     env.expect('WAIT', '1', '7000').equal(1)
 
     try:
-        replica.execute_command('TFCALL', 'lib.test1', '0')
+        env.tfcall('lib', 'test1', c=replica)
         env.assertTrue(False, message='Command succeed though should failed')
     except Exception as e:
         env.assertContains('can not run a function that might perform writes on a replica', str(e))
 
-    env.assertEqual(1, replica.execute_command('TFCALL', 'lib.test2', '0'))
+    env.assertEqual(1, env.tfcall('lib', 'test2', c=replica))
 
 @gearsTest(withReplicas=True)
 def testFunctionDelReplicatedToReplica(env):
@@ -230,11 +230,11 @@ redis.registerFunction("test",
 );
     """
     replica = env.getSlaveConnection()
-    res = replica.execute_command('TFCALL', 'lib.test', '0')
+    res = env.tfcall('lib', 'test', c=replica)
     env.expect('TFUNCTION', 'DELETE', 'lib').equal('OK')
     env.expect('WAIT', '1', '7000').equal(1)
     try:
-        replica.execute_command('TFCALL', 'lib.test', '0')
+        env.tfcall('lib', 'test', c=replica)
         env.assertTrue(False, message='Command succeed though should failed')
     except Exception as e:
         env.assertContains('Unknown library', str(e))
@@ -252,7 +252,7 @@ redis.registerFunction("my_set",
     }
 );
     """
-    env.expect('TFCALL', 'lib.my_set', '1', 'foo', 'bar').error().contains('was called while write is not allowed')
+    env.expectTfcall('lib', 'my_set', ['foo'], ['bar']).error().contains('was called while write is not allowed')
 
 @gearsTest()
 def testBecomeReplicaWhenFunctionRunning(env):
@@ -295,9 +295,9 @@ redis.registerFunction("async_set_trigger", function(client, key, val){
     return "OK";
 });
     """
-    env.expect('TFCALL', 'lib.async_set_trigger', '1', 'x', '1').equal('OK')
+    env.expectTfcall('lib', 'async_set_trigger', ['x'], ['1']).equal('OK')
     env.expect('replicaof', '127.0.0.1', '33333')
-    env.expect('TFCALLASYNC', 'lib.async_set_continue', '0').error().contains('Can not lock redis for write on replica')
+    env.expectTfcallAsync('lib', 'async_set_continue').error().contains('Can not lock redis for write on replica')
     env.expect('replicaof', 'no', 'one')
 
 @gearsTest()
@@ -308,7 +308,7 @@ redis.registerFunction("test1", function(client){
 });
     """
     env.expect('config', 'set', 'redisgears_2.lock-redis-timeout', '100').equal('OK')
-    env.expect('TFCALL', 'lib.test1', '0').error().contains('Execution was terminated due to OOM or timeout')
+    env.expectTfcall('lib', 'test1').error().contains('Execution was terminated due to OOM or timeout')
 
 @gearsTest()
 def testAsyncScriptTimeout(env):
@@ -320,7 +320,7 @@ redis.registerAsyncFunction("test1", async function(client){
 });
     """
     env.expect('config', 'set', 'redisgears_2.lock-redis-timeout', '100').equal('OK')
-    env.expect('TFCALLASYNC', 'lib.test1', '0').error().contains('Execution was terminated due to OOM or timeout')
+    env.expectTfcallAsync('lib', 'test1').error().contains('Execution was terminated due to OOM or timeout')
 
 @gearsTest()
 def testTimeoutErrorNotCatchable(env):
@@ -336,7 +336,7 @@ redis.registerAsyncFunction("test1", async function(client){
 });
     """
     env.expect('config', 'set', 'redisgears_2.lock-redis-timeout', '100').equal('OK')
-    env.expect('TFCALLASYNC', 'lib.test1', '0').error().contains('Execution was terminated due to OOM or timeout')
+    env.expectTfcallAsync('lib', 'test1').error().contains('Execution was terminated due to OOM or timeout')
 
 @gearsTest()
 def testScriptLoadTimeout(env):
@@ -440,8 +440,8 @@ redis.registerStreamTrigger(
     env.expect('config', 'set', 'redisgears_2.lock-redis-timeout', '1000000000').equal('OK')
     env.expect('TFUNCTION', 'LOAD', code).equal('OK')
 
-    env.expect('TFCALL', 'lib.test1', '0').error().contains('Execution was terminated due to OOM or timeout')
-    env.expect('TFCALL', 'lib.test', '0').error().contains('JS engine reached OOM state and can not run any more code')
+    env.expectTfcall('lib', 'test1').error().contains('Execution was terminated due to OOM or timeout')
+    env.expectTfcall('lib', 'test').error().contains('JS engine reached OOM state and can not run any more code')
 
     # make sure JS code is not running on key space notifications
     env.expect('set', 'x', '1').equal(True)
@@ -457,7 +457,7 @@ redis.registerStreamTrigger(
     # delete the library and make sure we can run JS code again
     env.expect('TFUNCTION', 'DELETE', 'lib').equal('OK')
     env.expect('TFUNCTION', 'LOAD', code).equal('OK')
-    env.expect('TFCALL', 'lib.test', '0').equal('OK')
+    env.expectTfcall('lib', 'test').equal('OK')
 
 @gearsTest()
 def testLibraryConfiguration(env):
@@ -467,7 +467,7 @@ redis.registerFunction("test1", function(){
 });
     """
     env.expect('TFUNCTION', 'LOAD', 'CONFIG', '{"foo":"bar"}', code).equal("OK")
-    env.expect('TFCALL', 'lib.test1', '0').equal(['foo', 'bar'])
+    env.expectTfcall('lib', 'test1').equal(['foo', 'bar'])
 
 @gearsTest()
 def testLibraryConfigurationPersistAfterLoading(env):
@@ -478,7 +478,7 @@ redis.registerFunction("test1", function(){
     """
     env.expect('TFUNCTION', 'LOAD', 'CONFIG', '{"foo":"bar"}', code).equal("OK")
     env.expect('debug', 'reload').equal("OK")
-    env.expect('TFCALL', 'lib.test1', '0').equal(['foo', 'bar'])
+    env.expectTfcall('lib', 'test1').equal(['foo', 'bar'])
 
 @gearsTest(enableGearsDebugCommands=True)
 def testCallTypeParsing(env):
@@ -545,7 +545,7 @@ redis.registerFunction("test", function(client){
 });
     """
     env.expect('TFUNCTION', 'DEBUG', 'allow_unsafe_redis_commands').equal("OK")
-    env.expect('TFCALL', 'lib.test', '0').equal("OK")
+    env.expectTfcall('lib', 'test').equal("OK")
 
 @gearsTest(enableGearsDebugCommands=True)
 def testResp3Types(env):
@@ -560,32 +560,32 @@ redis.registerFunction("debug_protocol", function(client, arg){
     # test resp3
     conn = Redis('localhost', port, protocol=3, decode_responses=True)
     
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'string'), 'Hello World')
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'integer'), 12345)
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'double'), 3.141)
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'bignum'), '1234567999999999999999999999999999999')
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'null'), None)
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'array'), [0, 1, 2])
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'set'), set([0, 1, 2]))
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'map'), {1: True, 2: False, 0: False})
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'verbatim'), 'txt:This is a verbatim\nstring')
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'true'), True)
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'false'), False)
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['string'], c=conn), 'Hello World')
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['integer'], c=conn), 12345)
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['double'], c=conn), 3.141)
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['bignum'], c=conn), '1234567999999999999999999999999999999')
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['null'], c=conn), None)
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['array'], c=conn), [0, 1, 2])
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['set'], c=conn), set([0, 1, 2]))
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['map'], c=conn), {1: True, 2: False, 0: False})
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['verbatim'], c=conn), 'txt:This is a verbatim\nstring')
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['true'], c=conn), True)
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['false'], c=conn), False)
 
     # test resp2
     conn = env.getConnection()
 
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'string'), 'Hello World')
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'integer'), 12345)
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'double'), "3.141")
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'bignum'), '1234567999999999999999999999999999999')
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'null'), None)
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'array'), [0, 1, 2])
-    env.assertEqual(sorted(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'set')), sorted([0, 1, 2]))
-    env.assertEqual(sorted(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'map')), sorted([1, 1, 0, 0, 2, 0]))
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'verbatim'), 'This is a verbatim\nstring')
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'true'), True)
-    env.assertEqual(conn.execute_command('TFCALL', 'lib.debug_protocol', '0', 'false'), False)
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['string'], c=conn), 'Hello World')
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['integer'], c=conn), 12345)
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['double'], c=conn), "3.141")
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['bignum'], c=conn), '1234567999999999999999999999999999999')
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['null'], c=conn), None)
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['array'], c=conn), [0, 1, 2])
+    env.assertEqual(sorted(env.tfcall('lib', 'debug_protocol', [], ['set'], c=conn)), sorted([0, 1, 2]))
+    env.assertEqual(sorted(env.tfcall('lib', 'debug_protocol', [], ['map'], c=conn)), sorted([1, 1, 0, 0, 2, 0]))
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['verbatim'], c=conn), 'This is a verbatim\nstring')
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['true'], c=conn), True)
+    env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['false'], c=conn), False)
 
 @gearsTest(enableGearsDebugCommands=True)
 def testFunctionListResp3(env):
@@ -621,7 +621,7 @@ redis.registerAsyncFunction("test", async() => {return 'test'});
     """
     conn = env.getConnection()
     p = conn.pipeline()
-    p.execute_command('TFCALLASYNC', 'lib.test', '0')
+    env.tfcallAsync('lib', 'test', c=p)
     try:
         p.execute()
         env.assertTrue(False, message='Except error on async function inside transaction')
@@ -635,7 +635,7 @@ redis.registerFunction("test", () => {return new Promise((resume, reject) => {})
     """
     conn = env.getConnection()
     p = conn.pipeline()
-    p.execute_command('TFCALL', 'lib.test', '0')
+    env.tfcall('lib', 'test', c=p)
     try:
         p.execute()
         env.assertTrue(False, message='Except error on async function inside transaction')
@@ -647,12 +647,12 @@ def testAllowBlockAPI(env):
     """#!js api_version=1.0 name=lib
 redis.registerFunction("test", (c) => {return c.isBlockAllowed()});
     """
-    env.expect('TFCALL', 'lib.test', '0').equal(0)
-    env.expect('TFCALLASYNC', 'lib.test', '0').equal(1)
+    env.expectTfcall('lib', 'test').equal(0)
+    env.expectTfcallAsync('lib', 'test').equal(1)
     conn = env.getConnection()
     p = conn.pipeline()
-    p.execute_command('TFCALL', 'lib.test', '0')
-    p.execute_command('TFCALLASYNC', 'lib.test', '0')
+    env.tfcall('lib', 'test', c=p)
+    env.tfcallAsync('lib', 'test', c=p)
     res = p.execute()
     env.assertEqual(res, [0, 0])
 
@@ -668,9 +668,9 @@ redis.registerFunction("my_set",
     }
 );
     """
-    env.expect('TFCALL', 'lib.my_set', '1', "x", "1").equal(b'OK')
+    env.expectTfcall('lib', 'my_set', ["x"], ["1"]).equal(b'OK')
     env.expect('get', 'x').equal(b'1')
-    env.expect('TFCALL', 'lib.my_set', '1', b'\xaa', b'\xaa').equal(b'OK')
+    env.expectTfcall('lib', 'my_set', [b'\xaa'], [b'\xaa']).equal(b'OK')
     env.expect('get', b'\xaa').equal(b'\xaa')
 
 @gearsTest(decodeResponses=False)
@@ -687,9 +687,9 @@ redis.registerAsyncFunction("my_set",
     }
 );
     """
-    env.expect('TFCALLASYNC', 'lib.my_set', '1', "x", "1").equal(b'OK')
+    env.expectTfcallAsync('lib', 'my_set', ["x"], ["1"]).equal(b'OK')
     env.expect('get', 'x').equal(b'1')
-    env.expect('TFCALLASYNC', 'lib.my_set', '1', b'\xaa', b'\xaa').equal(b'OK')
+    env.expectTfcallAsync('lib', 'my_set', [b'\xaa'], [b'\xaa']).equal(b'OK')
     env.expect('get', b'\xaa').equal(b'\xaa')
 
 @gearsTest(decodeResponses=False)
@@ -699,7 +699,7 @@ redis.registerFunction("test", () => {
     return new Uint8Array([255, 255, 255, 255]).buffer;
 });
     """
-    env.expect('TFCALL', 'lib.test', '0').equal(b'\xff\xff\xff\xff')
+    env.expectTfcall('lib', 'test').equal(b'\xff\xff\xff\xff')
 
 @gearsTest(decodeResponses=False)
 def testRawCall(env):
@@ -714,7 +714,7 @@ redis.registerFunction("test",
 );
     """
     env.expect('set', b'\xaa', b'\xaa').equal(True)
-    env.expect('TFCALL', 'lib.test', '1', b'\xaa').equal(b'\xaa')
+    env.expectTfcall('lib', 'test', [b'\xaa']).equal(b'\xaa')
 
 @gearsTest()
 def testSimpleHgetall(env):
@@ -729,7 +729,7 @@ redis.registerFunction("test",
 );
     """
     env.expect('hset', 'k', 'f', 'v').equal(True)
-    env.expect('TFCALL', 'lib.test', '1', 'k').equal(['f', 'v'])
+    env.expectTfcall('lib', 'test', ['k']).equal(['f', 'v'])
 
 
 @gearsTest(decodeResponses=False)
@@ -745,7 +745,7 @@ redis.registerFunction("test",
 );
     """
     env.expect('hset', b'\xaa', b'foo', b'\xaa').equal(True)
-    env.expect('TFCALL', 'lib.test', '1', b'\xaa').error().contains('Could not decode value as string')
+    env.expectTfcall('lib', 'test', [b'\xaa']).error().contains('Could not decode value as string')
 
 @gearsTest(decodeResponses=False)
 def testBinaryFieldsNamesOnHash(env):
@@ -760,7 +760,7 @@ redis.registerFunction("test",
 );
     """
     env.expect('hset', b'\xaa', b'\xaa', b'\xaa').equal(True)
-    env.expect('TFCALL', 'lib.test', '1', b'\xaa').error().contains('Binary map key is not supported')
+    env.expectTfcall('lib', 'test', [b'\xaa']).error().contains('Binary map key is not supported')
 
 @gearsTest()
 def testFunctionListWithLibraryOption(env):
@@ -795,7 +795,7 @@ redis.registerAsyncFunction("test", async () => {
     return res;
 });
     """
-    env.expect('TFCALLASYNC', 'lib.test', '0').equal("test")
+    env.expectTfcallAsync('lib', 'test').equal("test")
 
 @gearsTest()
 def testReplyWithDouble(env):
@@ -804,7 +804,7 @@ redis.registerFunction("test", () => {
     return 1.1;
 });
     """
-    env.expect('TFCALL', 'lib.test', '0').contains("1.1")
+    env.expectTfcall('lib', 'test').contains("1.1")
 
 @gearsTest()
 def testReplyWithDoubleAsync(env):
@@ -813,7 +813,7 @@ redis.registerAsyncFunction("test", async () => {
     return 1.1;
 });
     """
-    env.expect('TFCALLASYNC', 'lib.test', '0').contains("1.1")
+    env.expectTfcallAsync('lib', 'test').contains("1.1")
 
 @gearsTest()
 def testRunOnBackgroundThatRaisesError(env):
@@ -824,7 +824,7 @@ redis.registerFunction("test", (c) => {
     });
 });
     """
-    env.expect('TFCALLASYNC', 'lib.test', '0').error().equal("Some Error")
+    env.expectTfcallAsync('lib', 'test').error().equal("Some Error")
 
 @gearsTest()
 def testRunOnBackgroundThatReturnInteger(env):
@@ -835,7 +835,7 @@ redis.registerFunction("test", (c) => {
     });
 });
     """
-    env.expect('TFCALLASYNC', 'lib.test', '0').equal(1)
+    env.expectTfcallAsync('lib', 'test').equal(1)
 
 @gearsTest()
 def testOver100Isolates(env):

--- a/pytests/test_cluster.py
+++ b/pytests/test_cluster.py
@@ -20,7 +20,7 @@ redis.registerAsyncFunction("test", async (async_client, key) => {
     """
     cluster_conn.execute_command('set', 'x', '1')
     for conn in shardsConnections(env):
-        res = conn.execute_command('TFCALLASYNC', 'foo.test', '1', 'x')
+        res = env.tfcallAsync('foo', 'test', ['x'], c=conn)
         env.assertEqual(res, '1')
 
 @gearsTest(cluster=True)
@@ -46,7 +46,7 @@ redis.registerAsyncFunction("test",
     """
     cluster_conn.execute_command('set', 'x', '1')
     for conn in shardsConnections(env):
-        res = conn.execute_command('TFCALLASYNC', 'foo.test', '1', 'x')
+        res = env.tfcallAsync('foo', 'test', ['x'], c=conn)
         env.assertEqual(res, '1')
 
 @gearsTest(cluster=True)
@@ -70,7 +70,7 @@ redis.registerAsyncFunction("test",
     cluster_conn.execute_command('set', 'x', '1')
     for conn in shardsConnections(env):
         try:
-            conn.execute_command('TFCALLASYNC', 'foo.test', '1', 'x')
+            env.tfcallAsync('foo', 'test', ['x'], c=conn)
             pass
         except Exception as e:
             env.assertContains('Remote function failure', str(e))
@@ -103,7 +103,7 @@ redis.registerAsyncFunction("test", async(async_client, key) => {
         cluster_conn.execute_command('hset', 'key%d' % i, 'lookup', 'key%d' % (i + 1))
     cluster_conn.execute_command('set', 'key%d' % i, 'final_value')
     for conn in shardsConnections(env):
-        res = conn.execute_command('TFCALLASYNC', 'foo.test', '1', 'key0')
+        res = env.tfcallAsync('foo', 'test', ['key0'], c=conn)
         env.assertEqual(res, 'final_value')
 
 @gearsTest(cluster=True, gearsConfig={'remote-task-default-timeout': '1'})
@@ -121,7 +121,7 @@ redis.registerAsyncFunction("test", async (async_client, key) => {
 });
     """
     cluster_conn.execute_command('set', 'x', '1')
-    env.expect('TFCALLASYNC', 'foo.test', '1', 'x').error().contains('Remote task timeout')
+    env.expectTfcallAsync('foo', 'test', ['x']).error().contains('Remote task timeout')
 
 @gearsTest(cluster=True)
 def testRunOnAllShards(env, cluster_conn):
@@ -149,7 +149,7 @@ redis.registerAsyncFunction("test", async(async_client) => {
     for i in range(1000):
         cluster_conn.execute_command('set', 'key%d' % i, '1')
     for conn in shardsConnections(env):
-        res = conn.execute_command('TFCALLASYNC', 'foo.test', '0')
+        res = env.tfcallAsync('foo', 'test', c=conn)
         env.assertEqual(res, 1000)
 
 @gearsTest(cluster=True, gearsConfig={'remote-task-default-timeout': '1'})
@@ -180,4 +180,4 @@ redis.registerAsyncFunction("test", async (async_client) => {
 });
     """
     cluster_conn.execute_command('set', 'z', '1')
-    env.expect('TFCALLASYNC', 'foo.test', '1', 'z').error().contains('Timeout')
+    env.expectTfcallAsync('foo', 'test', ['z']).error().contains('Timeout')

--- a/pytests/test_cluster.py
+++ b/pytests/test_cluster.py
@@ -20,7 +20,7 @@ redis.registerAsyncFunction("test", async (async_client, key) => {
     """
     cluster_conn.execute_command('set', 'x', '1')
     for conn in shardsConnections(env):
-        res = conn.execute_command('TFCALLASYNC', 'foo', 'test', '1', 'x')
+        res = conn.execute_command('TFCALLASYNC', 'foo.test', '1', 'x')
         env.assertEqual(res, '1')
 
 @gearsTest(cluster=True)
@@ -46,7 +46,7 @@ redis.registerAsyncFunction("test",
     """
     cluster_conn.execute_command('set', 'x', '1')
     for conn in shardsConnections(env):
-        res = conn.execute_command('TFCALLASYNC', 'foo', 'test', '1', 'x')
+        res = conn.execute_command('TFCALLASYNC', 'foo.test', '1', 'x')
         env.assertEqual(res, '1')
 
 @gearsTest(cluster=True)
@@ -70,7 +70,7 @@ redis.registerAsyncFunction("test",
     cluster_conn.execute_command('set', 'x', '1')
     for conn in shardsConnections(env):
         try:
-            conn.execute_command('TFCALLASYNC', 'foo', 'test', '1', 'x')
+            conn.execute_command('TFCALLASYNC', 'foo.test', '1', 'x')
             pass
         except Exception as e:
             env.assertContains('Remote function failure', str(e))
@@ -103,7 +103,7 @@ redis.registerAsyncFunction("test", async(async_client, key) => {
         cluster_conn.execute_command('hset', 'key%d' % i, 'lookup', 'key%d' % (i + 1))
     cluster_conn.execute_command('set', 'key%d' % i, 'final_value')
     for conn in shardsConnections(env):
-        res = conn.execute_command('TFCALLASYNC', 'foo', 'test', '1', 'key0')
+        res = conn.execute_command('TFCALLASYNC', 'foo.test', '1', 'key0')
         env.assertEqual(res, 'final_value')
 
 @gearsTest(cluster=True, gearsConfig={'remote-task-default-timeout': '1'})
@@ -121,7 +121,7 @@ redis.registerAsyncFunction("test", async (async_client, key) => {
 });
     """
     cluster_conn.execute_command('set', 'x', '1')
-    env.expect('TFCALLASYNC', 'foo', 'test', '1', 'x').error().contains('Remote task timeout')
+    env.expect('TFCALLASYNC', 'foo.test', '1', 'x').error().contains('Remote task timeout')
 
 @gearsTest(cluster=True)
 def testRunOnAllShards(env, cluster_conn):
@@ -149,7 +149,7 @@ redis.registerAsyncFunction("test", async(async_client) => {
     for i in range(1000):
         cluster_conn.execute_command('set', 'key%d' % i, '1')
     for conn in shardsConnections(env):
-        res = conn.execute_command('TFCALLASYNC', 'foo', 'test', '0')
+        res = conn.execute_command('TFCALLASYNC', 'foo.test', '0')
         env.assertEqual(res, 1000)
 
 @gearsTest(cluster=True, gearsConfig={'remote-task-default-timeout': '1'})
@@ -180,4 +180,4 @@ redis.registerAsyncFunction("test", async (async_client) => {
 });
     """
     cluster_conn.execute_command('set', 'z', '1')
-    env.expect('TFCALLASYNC', 'foo', 'test', '1', 'z').error().contains('Timeout')
+    env.expect('TFCALLASYNC', 'foo.test', '1', 'z').error().contains('Timeout')

--- a/pytests/test_errors.py
+++ b/pytests/test_errors.py
@@ -71,7 +71,7 @@ redis.registerAsyncFunction('test', async function(c1){
     });
 })
     """
-    env.expect('TFCALLASYNC', 'foo', 'test', '0').error().contains('thread is already blocked')
+    env.expect('TFCALLASYNC', 'foo.test', '0').error().contains('thread is already blocked')
 
 @gearsTest()
 def testCallRedisWhenNotBlocked(env):
@@ -84,7 +84,7 @@ redis.registerAsyncFunction('test', async function(c){
     });
 })
     """
-    env.expect('TFCALLASYNC', 'foo', 'test', '0').error().contains('thread is not locked')
+    env.expect('TFCALLASYNC', 'foo.test', '0').error().contains('thread is not locked')
 
 @gearsTest()
 def testCommandsNotAllowedOnScript(env):
@@ -98,8 +98,8 @@ redis.registerAsyncFunction('test2', async function(c1){
     });
 })
     """
-    env.expect('TFCALL', 'foo', 'test1', '0').error().contains('is not allowed on script mode')
-    env.expect('TFCALLASYNC', 'foo', 'test2', '0').error().contains('is not allowed on script mode')
+    env.expect('TFCALL', 'foo.test1', '0').error().contains('is not allowed on script mode')
+    env.expect('TFCALLASYNC', 'foo.test2', '0').error().contains('is not allowed on script mode')
 
 @gearsTest(gearsConfig={"v8-flags": "'--stack-size=50'"})
 def testJSStackOverflow(env):
@@ -109,7 +109,7 @@ function test() {
 }
 redis.registerFunction('test', test);
     """
-    env.expect('TFCALL', 'foo', 'test', '0').error().contains('Maximum call stack size exceeded')
+    env.expect('TFCALL', 'foo.test', '0').error().contains('Maximum call stack size exceeded')
 
 @gearsTest(gearsConfig={"v8-flags": "'--stack-size=50'"})
 def testJSStackOverflowOnLoading(env):
@@ -166,7 +166,7 @@ function test() {
 }
 redis.registerFunction('test', test);
     """
-    env.expect('TFCALL', 'foo', 'test', '0')
+    env.expect('TFCALL', 'foo.test', '0')
     env.expect('PING').equal(True)
 
 @gearsTest()
@@ -177,8 +177,8 @@ function test() {
 }
 redis.registerFunction('test', test);
     """
-    env.expect('TFCALL', 'foo', 'test', '10', 'bar').error().contains('Not enough arguments was given')
-    env.expect('TFCALL', 'foo', 'test').error().contains('wrong number of arguments ')
+    env.expect('TFCALL', 'foo.test', '10', 'bar').error().contains('Not enough arguments was given')
+    env.expect('TFCALL', 'foo.test').error().contains('wrong number of arguments ')
 
 @gearsTest()
 def testNotExistsRemoteFunction(env):
@@ -187,7 +187,7 @@ redis.registerAsyncFunction("test", async (async_client) => {
     return await async_client.runOnKey('x', 'not_exists');
 });
     """
-    env.expect('TFCALLASYNC', 'foo', 'test', '0').error().contains('Remote function not_exists does not exists')
+    env.expect('TFCALLASYNC', 'foo.test', '0').error().contains('Remote function not_exists does not exists')
 
 @gearsTest()
 def testRemoteFunctionNotSerializableInput(env):
@@ -205,7 +205,7 @@ redis.registerAsyncFunction("test", async (async_client, key) => {
     return await async_client.runOnKey(key, remote_get, ()=>{return 1;});
 });
     """
-    env.expect('TFCALLASYNC', 'foo', 'test', '1', '1').error().contains('Failed deserializing remote function argument')
+    env.expect('TFCALLASYNC', 'foo.test', '1', '1').error().contains('Failed deserializing remote function argument')
 
 @gearsTest()
 def testRemoteFunctionNotSerializableOutput(env):
@@ -220,7 +220,7 @@ redis.registerAsyncFunction("test", async (async_client, key) => {
     return await async_client.runOnKey(key, remote_get, key);
 });
     """
-    env.expect('TFCALLASYNC', 'foo', 'test', '1', '1').error().contains('Failed deserializing remote function result')
+    env.expect('TFCALLASYNC', 'foo.test', '1', '1').error().contains('Failed deserializing remote function result')
 
 @gearsTest()
 def testRegisterRemoteFunctionWorngNumberOfArgs(env):
@@ -261,7 +261,7 @@ redis.registerFunction("test", (client) => {
     return redis.redisai.create_tensor("FLOAT", [1, 3], new Uint8Array(16).buffer);
 });
     """
-    env.expect('TFCALL', 'foo', 'test', '0').error().contains('RedisAI is not initialize')
+    env.expect('TFCALL', 'foo.test', '0').error().contains('RedisAI is not initialize')
 
 @gearsTest()
 def testRedisAIModelCreateWithoutRedisAI(env):
@@ -270,7 +270,7 @@ redis.registerFunction("test", (client) => {
     return client.redisai.open_model("foo");
 });
     """
-    env.expect('TFCALL', 'foo', 'test', '0').error().contains('RedisAI is not initialize')
+    env.expect('TFCALL', 'foo.test', '0').error().contains('RedisAI is not initialize')
 
 @gearsTest()
 def testRedisAIScriptCreateWithoutRedisAI(env):
@@ -279,7 +279,7 @@ redis.registerFunction("test", (client) => {
     return client.redisai.open_script("foo");
 });
     """
-    env.expect('TFCALL', 'foo', 'test', '0').error().contains('RedisAI is not initialize')
+    env.expect('TFCALL', 'foo.test', '0').error().contains('RedisAI is not initialize')
 
 @gearsTest()
 def testUseOfInvalidClient(env):
@@ -292,7 +292,7 @@ redis.registerFunction("test", (client) => {
     });
 });
     """
-    env.expect('TFCALLASYNC', 'foo', 'test', '0').error().contains('Used on invalid client')
+    env.expect('TFCALLASYNC', 'foo.test', '0').error().contains('Used on invalid client')
 
 @gearsTest()
 def testCallWithoutBlock(env):
@@ -303,7 +303,7 @@ redis.registerFunction("test", (client) => {
     });
 });
     """
-    env.expect('TFCALLASYNC', 'foo', 'test', '0').error().contains('Main thread is not locked')
+    env.expect('TFCALLASYNC', 'foo.test', '0').error().contains('Main thread is not locked')
 
 @gearsTest()
 def testDelNoneExistingFunction(env):
@@ -406,7 +406,7 @@ def testUnknownFunctionName(env):
     '''#!js api_version=1.0 name=lib
 redis.registerFunction('test', () => {return 1})
     '''
-    env.expect('TFCALL', 'lib', 'foo', '0').error().contains("Unknown function")
+    env.expect('TFCALL', 'lib.foo', '0').error().contains("Unknown function")
 
 @gearsTest()
 def testCallFunctionOnOOM(env):
@@ -414,7 +414,7 @@ def testCallFunctionOnOOM(env):
 redis.registerFunction('test', () => {return 1})
     '''
     env.expect('config', 'set', 'maxmemory', '1').equal('OK')
-    env.expect('TFCALL', 'lib', 'test', '0').error().contains("OOM can not run the function when out of memory")
+    env.expect('TFCALL', 'lib.test', '0').error().contains("OOM can not run the function when out of memory")
 
 @gearsTest()
 def testRegisterSameConsumerTwice(env):
@@ -486,21 +486,21 @@ def testArgDecodeFailure(env):
     '''#!js api_version=1.0 name=lib
 redis.registerFunction('test', () => {return 1})
     '''
-    env.expect('TFCALL', 'lib', 'test', '0', b'\xaa').error().contains('Can not convert argument to string')
+    env.expect('TFCALL', 'lib.test', '0', b'\xaa').error().contains('Can not convert argument to string')
 
 @gearsTest()
 def testArgDecodeFailureAsync(env):
     '''#!js api_version=1.0 name=lib
 redis.registerAsyncFunction('test', async () => {return 1})
     '''
-    env.expect('TFCALLASYNC', 'lib', 'test', '0', b'\xaa').error().contains('Can not convert argument to string')
+    env.expect('TFCALLASYNC', 'lib.test', '0', b'\xaa').error().contains('Can not convert argument to string')
 
 @gearsTest()
 def testCallAsyncFunctionWithTFCALL(env):
     '''#!js api_version=1.0 name=lib
 redis.registerAsyncFunction('test', async () => {return 1})
     '''
-    env.expect('TFCALL', 'lib', 'test', '0').error().contains('function is declared as async and was called while blocking was not allowed')
+    env.expect('TFCALL', 'lib.test', '0').error().contains('function is declared as async and was called while blocking was not allowed')
 
 @gearsTest()
 def testBlockOnTFCall(env):
@@ -511,4 +511,58 @@ redis.registerFunction('test', (c) => {
     });
 });
     '''
-    env.expect('TFCALL', 'lib', 'test', '0').error().contains('Can not block client for background execution')
+    env.expect('TFCALL', 'lib.test', '0').error().contains('Can not block client for background execution')
+
+@gearsTest()
+def testUnallowedLibraryName(env):
+    code = '''#!js api_version=1.0 name=foo.bar
+redis.registerFunction("test", (client) => {
+    return 1;
+});
+    '''
+    env.expect('TFUNCTION', 'LOAD', code).error().contains('Unallowed library name \'foo.bar\'')
+
+@gearsTest()
+def testUnallowedFunctionName(env):
+    code = '''#!js api_version=1.0 name=foo
+redis.registerFunction("test.test", (client) => {
+    return 1;
+});
+    '''
+    env.expect('TFUNCTION', 'LOAD', code).error().contains('Unallowed function name \'test.test\'')
+
+@gearsTest()
+def testUnallowedAsyncFunctionName(env):
+    code = '''#!js api_version=1.0 name=foo
+redis.registerAsyncFunction("test.test", async (client) => {
+    return 1;
+});
+    '''
+    env.expect('TFUNCTION', 'LOAD', code).error().contains('Unallowed function name \'test.test\'')
+
+@gearsTest()
+def testUnallowedStreamTriggerName(env):
+    code = '''#!js api_version=1.0 name=foo
+redis.registerStreamTrigger("test.test", "stream", async (client) => {
+    return 1;
+});
+    '''
+    env.expect('TFUNCTION', 'LOAD', code).error().contains('Unallowed stream trigger name \'test.test\'')
+
+@gearsTest()
+def testUnallowedKeySpaceTriggerName(env):
+    code = '''#!js api_version=1.0 name=foo
+redis.registerKeySpaceTrigger("test.test", "key", async (client) => {
+    return 1;
+});
+    '''
+    env.expect('TFUNCTION', 'LOAD', code).error().contains('Unallowed key space trigger name \'test.test\'')
+
+@gearsTest()
+def testUnallowedClusterFunctionName(env):
+    code = '''#!js api_version=1.0 name=foo
+redis.registerClusterFunction("test.test", async (client) => {
+    return 1;
+});
+    '''
+    env.expect('TFUNCTION', 'LOAD', code).error().contains('Unallowed cluster function name \'test.test\'')

--- a/pytests/test_notifications_consumers.py
+++ b/pytests/test_notifications_consumers.py
@@ -18,13 +18,13 @@ redis.registerFunction("n_notifications", function(){
 })
     """
 
-    env.expect('TFCALL', 'lib.n_notifications', '0').equal(0)
+    env.expectTfcall('lib', 'n_notifications').equal(0)
     env.expect('SET', 'X', '1').equal(True)
-    env.expect('TFCALL', 'lib.n_notifications', '0').equal(1)
+    env.expectTfcall('lib', 'n_notifications').equal(1)
     env.expect('SET', 'X', '2').equal(True)
-    env.expect('TFCALL', 'lib.n_notifications', '0').equal(2)
+    env.expectTfcall('lib', 'n_notifications').equal(2)
     env.expect('SET', 'X', '1').equal(True)
-    env.expect('TFCALL', 'lib.n_notifications', '0').equal(3)
+    env.expectTfcall('lib', 'n_notifications').equal(3)
 
 @gearsTest()
 def testAsyncNotification(env):
@@ -39,13 +39,13 @@ redis.registerAsyncFunction("n_notifications", async function(){
 })
     """
 
-    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(0)
+    env.expectTfcallAsync('lib', 'n_notifications').equal(0)
     env.expect('SET', 'X', '1').equal(True)
-    runUntil(env, 1, lambda: env.cmd('TFCALLASYNC', 'lib.n_notifications', '0'))
+    runUntil(env, 1, lambda: env.tfcallAsync('lib', 'n_notifications'))
     env.expect('SET', 'X', '2').equal(True)
-    runUntil(env, 2, lambda: env.cmd('TFCALLASYNC', 'lib.n_notifications', '0'))
+    runUntil(env, 2, lambda: env.tfcallAsync('lib', 'n_notifications'))
     env.expect('SET', 'X', '1').equal(True)
-    runUntil(env, 3, lambda: env.cmd('TFCALLASYNC', 'lib.n_notifications', '0'))
+    runUntil(env, 3, lambda: env.tfcallAsync('lib', 'n_notifications'))
 
 @gearsTest()
 def testCallRedisOnNotification(env):
@@ -81,11 +81,11 @@ redis.registerFunction("simple_set", function(client){
     return client.call('set', 'x', '1');
 });
     """
-    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(0)
+    env.expectTfcallAsync('lib', 'n_notifications').equal(0)
     env.expect('SET', 'X', '1').equal(True)
-    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(1)
-    env.expect('TFCALL', 'lib.simple_set', '0').equal('OK')
-    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(1)
+    env.expectTfcallAsync('lib', 'n_notifications').equal(1)
+    env.expectTfcall('lib', 'simple_set').equal('OK')
+    env.expectTfcallAsync('lib', 'n_notifications').equal(1)
 
 @gearsTest()
 def testNotificationsAreNotFiredFromWithinAsyncFunction(env):
@@ -105,11 +105,11 @@ redis.registerAsyncFunction("simple_set", async function(client){
     });
 });
     """
-    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(0)
+    env.expectTfcallAsync('lib', 'n_notifications').equal(0)
     env.expect('SET', 'X', '1').equal(True)
-    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(1)
-    env.expect('TFCALLASYNC', 'lib.simple_set', '0').equal('OK')
-    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(1)
+    env.expectTfcallAsync('lib', 'n_notifications').equal(1)
+    env.expectTfcallAsync('lib', 'simple_set').equal('OK')
+    env.expectTfcallAsync('lib', 'n_notifications').equal(1)
 
 @gearsTest()
 def testNotificationsAreNotFiredFromWithinAnotherNotification(env):
@@ -124,9 +124,9 @@ redis.registerAsyncFunction("n_notifications", async function(){
     return n_notifications
 });
     """
-    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(0)
+    env.expectTfcallAsync('lib', 'n_notifications').equal(0)
     env.expect('SET', 'X', '1').equal(True)
-    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(1)
+    env.expectTfcallAsync('lib', 'n_notifications').equal(1)
 
 @gearsTest()
 def testNotificationsAreNotFiredFromWithinStreamConsumer(env):
@@ -152,12 +152,12 @@ redis.registerStreamTrigger("consumer", "stream",
     }
 );
     """
-    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(0)
+    env.expectTfcallAsync('lib', 'n_notifications').equal(0)
     env.expect('SET', 'X', '1').equal(True)
-    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(1)
+    env.expectTfcallAsync('lib', 'n_notifications').equal(1)
     env.cmd('XADD', 'stream:1', '*', 'foo', 'bar')
     env.expect('GET', 'X').equal('2')
-    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(1)
+    env.expectTfcallAsync('lib', 'n_notifications').equal(1)
 
 @gearsTest(decodeResponses=False)
 def testNotificationsOnBinaryKey(env):
@@ -181,9 +181,9 @@ redis.registerAsyncFunction("notifications_stats", async function(){
     ];
 });
     """
-    env.expect('TFCALLASYNC', 'lib.notifications_stats', '0').equal([0, None, None])
+    env.expectTfcallAsync('lib', 'notifications_stats').equal([0, None, None])
     env.expect('SET', b'\xff\xff', b'\xaa').equal(True)
-    env.expect('TFCALLASYNC', 'lib.notifications_stats', '0').equal([1, None, b'\xff\xff'])
+    env.expectTfcallAsync('lib', 'notifications_stats').equal([1, None, b'\xff\xff'])
 
 @gearsTest()
 def testSyncNotificationsReturnPromise(env):

--- a/pytests/test_notifications_consumers.py
+++ b/pytests/test_notifications_consumers.py
@@ -18,13 +18,13 @@ redis.registerFunction("n_notifications", function(){
 })
     """
 
-    env.expect('TFCALL', 'lib', 'n_notifications', '0').equal(0)
+    env.expect('TFCALL', 'lib.n_notifications', '0').equal(0)
     env.expect('SET', 'X', '1').equal(True)
-    env.expect('TFCALL', 'lib', 'n_notifications', '0').equal(1)
+    env.expect('TFCALL', 'lib.n_notifications', '0').equal(1)
     env.expect('SET', 'X', '2').equal(True)
-    env.expect('TFCALL', 'lib', 'n_notifications', '0').equal(2)
+    env.expect('TFCALL', 'lib.n_notifications', '0').equal(2)
     env.expect('SET', 'X', '1').equal(True)
-    env.expect('TFCALL', 'lib', 'n_notifications', '0').equal(3)
+    env.expect('TFCALL', 'lib.n_notifications', '0').equal(3)
 
 @gearsTest()
 def testAsyncNotification(env):
@@ -39,13 +39,13 @@ redis.registerAsyncFunction("n_notifications", async function(){
 })
     """
 
-    env.expect('TFCALLASYNC', 'lib', 'n_notifications', '0').equal(0)
+    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(0)
     env.expect('SET', 'X', '1').equal(True)
-    runUntil(env, 1, lambda: env.cmd('TFCALLASYNC', 'lib', 'n_notifications', '0'))
+    runUntil(env, 1, lambda: env.cmd('TFCALLASYNC', 'lib.n_notifications', '0'))
     env.expect('SET', 'X', '2').equal(True)
-    runUntil(env, 2, lambda: env.cmd('TFCALLASYNC', 'lib', 'n_notifications', '0'))
+    runUntil(env, 2, lambda: env.cmd('TFCALLASYNC', 'lib.n_notifications', '0'))
     env.expect('SET', 'X', '1').equal(True)
-    runUntil(env, 3, lambda: env.cmd('TFCALLASYNC', 'lib', 'n_notifications', '0'))
+    runUntil(env, 3, lambda: env.cmd('TFCALLASYNC', 'lib.n_notifications', '0'))
 
 @gearsTest()
 def testCallRedisOnNotification(env):
@@ -81,11 +81,11 @@ redis.registerFunction("simple_set", function(client){
     return client.call('set', 'x', '1');
 });
     """
-    env.expect('TFCALLASYNC', 'lib', 'n_notifications', '0').equal(0)
+    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(0)
     env.expect('SET', 'X', '1').equal(True)
-    env.expect('TFCALLASYNC', 'lib', 'n_notifications', '0').equal(1)
-    env.expect('TFCALL', 'lib', 'simple_set', '0').equal('OK')
-    env.expect('TFCALLASYNC', 'lib', 'n_notifications', '0').equal(1)
+    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(1)
+    env.expect('TFCALL', 'lib.simple_set', '0').equal('OK')
+    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(1)
 
 @gearsTest()
 def testNotificationsAreNotFiredFromWithinAsyncFunction(env):
@@ -105,11 +105,11 @@ redis.registerAsyncFunction("simple_set", async function(client){
     });
 });
     """
-    env.expect('TFCALLASYNC', 'lib', 'n_notifications', '0').equal(0)
+    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(0)
     env.expect('SET', 'X', '1').equal(True)
-    env.expect('TFCALLASYNC', 'lib', 'n_notifications', '0').equal(1)
-    env.expect('TFCALLASYNC', 'lib', 'simple_set', '0').equal('OK')
-    env.expect('TFCALLASYNC', 'lib', 'n_notifications', '0').equal(1)
+    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(1)
+    env.expect('TFCALLASYNC', 'lib.simple_set', '0').equal('OK')
+    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(1)
 
 @gearsTest()
 def testNotificationsAreNotFiredFromWithinAnotherNotification(env):
@@ -124,9 +124,9 @@ redis.registerAsyncFunction("n_notifications", async function(){
     return n_notifications
 });
     """
-    env.expect('TFCALLASYNC', 'lib', 'n_notifications', '0').equal(0)
+    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(0)
     env.expect('SET', 'X', '1').equal(True)
-    env.expect('TFCALLASYNC', 'lib', 'n_notifications', '0').equal(1)
+    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(1)
 
 @gearsTest()
 def testNotificationsAreNotFiredFromWithinStreamConsumer(env):
@@ -152,12 +152,12 @@ redis.registerStreamTrigger("consumer", "stream",
     }
 );
     """
-    env.expect('TFCALLASYNC', 'lib', 'n_notifications', '0').equal(0)
+    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(0)
     env.expect('SET', 'X', '1').equal(True)
-    env.expect('TFCALLASYNC', 'lib', 'n_notifications', '0').equal(1)
+    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(1)
     env.cmd('XADD', 'stream:1', '*', 'foo', 'bar')
     env.expect('GET', 'X').equal('2')
-    env.expect('TFCALLASYNC', 'lib', 'n_notifications', '0').equal(1)
+    env.expect('TFCALLASYNC', 'lib.n_notifications', '0').equal(1)
 
 @gearsTest(decodeResponses=False)
 def testNotificationsOnBinaryKey(env):
@@ -181,9 +181,9 @@ redis.registerAsyncFunction("notifications_stats", async function(){
     ];
 });
     """
-    env.expect('TFCALLASYNC', 'lib', 'notifications_stats', '0').equal([0, None, None])
+    env.expect('TFCALLASYNC', 'lib.notifications_stats', '0').equal([0, None, None])
     env.expect('SET', b'\xff\xff', b'\xaa').equal(True)
-    env.expect('TFCALLASYNC', 'lib', 'notifications_stats', '0').equal([1, None, b'\xff\xff'])
+    env.expect('TFCALLASYNC', 'lib.notifications_stats', '0').equal([1, None, b'\xff\xff'])
 
 @gearsTest()
 def testSyncNotificationsReturnPromise(env):

--- a/pytests/test_stream_reader.py
+++ b/pytests/test_stream_reader.py
@@ -21,11 +21,11 @@ redis.registerStreamTrigger("consumer", "stream", function(){
     num_events++;
 })
     """
-    env.expect('TFCALL', 'lib', 'num_events', '0').equal(0)
+    env.expect('TFCALL', 'lib.num_events', '0').equal(0)
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    env.expect('TFCALL', 'lib', 'num_events', '0').equal(1)
+    env.expect('TFCALL', 'lib.num_events', '0').equal(1)
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    env.expect('TFCALL', 'lib', 'num_events', '0').equal(2)
+    env.expect('TFCALL', 'lib.num_events', '0').equal(2)
 
 @gearsTest(decodeResponses=False)
 def testBasicStreamReaderWithBinaryData(env):
@@ -49,9 +49,9 @@ redis.registerStreamTrigger("consumer", new Uint8Array([255]).buffer, function(c
     last_data_raw = data.record_raw;
 })
     """
-    env.expect('TFCALL', 'lib', 'stats', '0').equal([None, None, None, None])
+    env.expect('TFCALL', 'lib.stats', '0').equal([None, None, None, None])
     env.cmd('xadd', b'\xff\xff', '*', b'\xaa', b'\xaa')
-    env.expect('TFCALL', 'lib', 'stats', '0').equal([None, b'\xff\xff', [[None, None]], [[b'\xaa', b'\xaa']]])
+    env.expect('TFCALL', 'lib.stats', '0').equal([None, b'\xff\xff', [[None, None]], [[b'\xaa', b'\xaa']]])
 
 @gearsTest()
 def testAsyncStreamReader(env):
@@ -64,11 +64,11 @@ redis.registerStreamTrigger("consumer", "stream", async function(){
     num_events++;
 })
     """
-    env.expect('TFCALL', 'lib', 'num_events', '0').equal(0)
+    env.expect('TFCALL', 'lib.num_events', '0').equal(0)
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib', 'num_events', '0'))
+    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib.num_events', '0'))
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib', 'num_events', '0'))
+    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib.num_events', '0'))
 
 @gearsTest()
 def testStreamTrim(env):
@@ -86,13 +86,13 @@ redis.registerStreamTrigger("consumer", "stream",
     }
 );
     """
-    env.expect('TFCALL', 'lib', 'num_events', '0').equal(0)
+    env.expect('TFCALL', 'lib.num_events', '0').equal(0)
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
     env.expect('xlen', 'stream:1').equal(0)
-    env.expect('TFCALL', 'lib', 'num_events', '0').equal(1)
+    env.expect('TFCALL', 'lib.num_events', '0').equal(1)
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
     env.expect('xlen', 'stream:1').equal(0)
-    env.expect('TFCALL', 'lib', 'num_events', '0').equal(2)
+    env.expect('TFCALL', 'lib.num_events', '0').equal(2)
 
 @gearsTest()
 def testStreamProccessError(env):
@@ -134,37 +134,37 @@ redis.registerStreamTrigger("consumer", "stream",
     }
 );
     """
-    env.expect('TFCALL', 'lib', 'num_pending', '0').equal(0)
-    env.expect('TFCALL', 'lib', 'continue', '0').error().contains('No pending records')
+    env.expect('TFCALL', 'lib.num_pending', '0').equal(0)
+    env.expect('TFCALL', 'lib.continue', '0').error().contains('No pending records')
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
     res = toDictionary(env.cmd('TFUNCTION', 'LIST', 'vvv'), 6)
     env.assertEqual(3, len(res[0]['stream_triggers'][0]['streams'][0]['pending_ids']))
 
-    env.expect('TFCALL', 'lib', 'continue', '0').equal('OK')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    env.expect('TFCALL', 'lib.continue', '0').equal('OK')
+    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
     runUntil(env, 2, lambda: len(toDictionary(env.cmd('TFUNCTION', 'LIST', 'vvv'), 6)[0]['stream_triggers'][0]['streams'][0]['pending_ids']))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
     res = toDictionary(env.cmd('TFUNCTION', 'LIST', 'vvv'), 6)
     env.assertEqual(3, len(res[0]['stream_triggers'][0]['streams'][0]['pending_ids']))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runFor(3, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    runFor(3, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
-    env.expect('TFCALL', 'lib', 'continue', '0').equal('OK')
-    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    env.expect('TFCALL', 'lib.continue', '0').equal('OK')
+    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
     res = toDictionary(env.cmd('TFUNCTION', 'LIST', 'vvv'), 6)
     env.assertEqual(2, res[0]['stream_triggers'][0]['streams'][0]['total_record_processed'])
@@ -205,12 +205,12 @@ redis.registerStreamTrigger("consumer", "stream",
     env.expect('WAIT', '1', '7000').equal(1)
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
     res = toDictionary(env.cmd('TFUNCTION', 'LIST', 'vvv'), 6)
     id_to_read_from = res[0]['stream_triggers'][0]['streams'][0]['id_to_read_from']
 
-    env.expect('TFCALL', 'lib', 'continue', '0').equal(id_to_read_from)
+    env.expect('TFCALL', 'lib.continue', '0').equal(id_to_read_from)
     runUntil(env, 1, lambda: len(toDictionary(slave_conn.execute_command('TFUNCTION', 'LIST', 'vvv'), 6)[0]['stream_triggers'][0]['streams']))
     env.assertEqual(id_to_read_from, toDictionary(slave_conn.execute_command('TFUNCTION', 'LIST', 'vvv'), 6)[0]['stream_triggers'][0]['streams'][0]['id_to_read_from'])
 
@@ -222,10 +222,10 @@ redis.registerStreamTrigger("consumer", "stream",
 
     # Turn slave to master
     slave_conn.execute_command('slaveof', 'no', 'one')
-    runUntil(env, 2, lambda: slave_conn.execute_command('TFCALL', 'lib', 'num_pending', '0'))
+    runUntil(env, 2, lambda: slave_conn.execute_command('TFCALL', 'lib.num_pending', '0'))
     def continue_function():
         try:
-            return slave_conn.execute_command('TFCALL', 'lib', 'continue', '0')
+            return slave_conn.execute_command('TFCALL', 'lib.continue', '0')
         except Exception as e:
             return str(e)
     runUntil(env, id1, continue_function)
@@ -261,28 +261,28 @@ redis.registerStreamTrigger("consumer", "stream",
     }
 );
     """
-    env.expect('TFCALL', 'lib', 'num_pending', '0').equal(0)
-    env.expect('TFCALL', 'lib', 'continue', '0').error().contains('No pending records')
+    env.expect('TFCALL', 'lib.num_pending', '0').equal(0)
+    env.expect('TFCALL', 'lib.continue', '0').error().contains('No pending records')
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
     env.expect('del', 'stream:1').equal(1)
 
-    env.expect('TFCALL', 'lib', 'continue', '0').equal('OK')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    env.expect('TFCALL', 'lib.continue', '0').equal('OK')
+    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
-    env.expect('TFCALL', 'lib', 'continue', '0').equal('OK')
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    env.expect('TFCALL', 'lib.continue', '0').equal('OK')
+    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
-    env.expect('TFCALL', 'lib', 'continue', '0').equal('OK')
-    runUntil(env, 0, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    env.expect('TFCALL', 'lib.continue', '0').equal('OK')
+    runUntil(env, 0, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
     res = env.cmd('TFUNCTION', 'LIST', 'vvv')
     env.assertEqual(0, len(toDictionary(res, 6)[0]['stream_triggers'][0]['streams']))
@@ -316,28 +316,28 @@ redis.registerStreamTrigger("consumer", "stream",
     }
 );
     """
-    env.expect('TFCALL', 'lib', 'num_pending', '0').equal(0)
-    env.expect('TFCALL', 'lib', 'continue', '0').error().contains('No pending records')
+    env.expect('TFCALL', 'lib.num_pending', '0').equal(0)
+    env.expect('TFCALL', 'lib.continue', '0').error().contains('No pending records')
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
     env.expect('flushall').equal(True)
 
-    env.expect('TFCALL', 'lib', 'continue', '0').equal('OK')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    env.expect('TFCALL', 'lib.continue', '0').equal('OK')
+    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
-    env.expect('TFCALL', 'lib', 'continue', '0').equal('OK')
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    env.expect('TFCALL', 'lib.continue', '0').equal('OK')
+    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
-    env.expect('TFCALL', 'lib', 'continue', '0').equal('OK')
-    runUntil(env, 0, lambda: env.cmd('TFCALL', 'lib', 'num_pending', '0'))
+    env.expect('TFCALL', 'lib.continue', '0').equal('OK')
+    runUntil(env, 0, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
 
     res = env.cmd('TFUNCTION', 'LIST', 'vvv')
     env.assertEqual(0, len(toDictionary(res, 6)[0]['stream_triggers'][0]['streams']))
@@ -375,37 +375,37 @@ redis.registerStreamTrigger("consumer", "stream",
     env.expect('TFUNCTION', 'LOAD', script % 'lib2').equal('OK')
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib1', 'num_pending', '0'))
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib2', 'num_pending', '0'))
+    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib1.num_pending', '0'))
+    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib2.num_pending', '0'))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib1', 'num_pending', '0'))
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib2', 'num_pending', '0'))
+    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib1.num_pending', '0'))
+    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib2.num_pending', '0'))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib1', 'num_pending', '0'))
-    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib2', 'num_pending', '0'))
+    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib1.num_pending', '0'))
+    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib2.num_pending', '0'))
 
-    env.expect('TFCALL', 'lib1', 'continue', '0').equal('OK')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib1', 'num_pending', '0'))
-    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib2', 'num_pending', '0'))
+    env.expect('TFCALL', 'lib1.continue', '0').equal('OK')
+    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib1.num_pending', '0'))
+    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib2.num_pending', '0'))
     runFor(3, lambda: env.cmd('XLEN', 'stream:1')) # make sure not trimming
 
-    env.expect('TFCALL', 'lib2', 'continue', '0').equal('OK')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib1', 'num_pending', '0'))
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib2', 'num_pending', '0'))
+    env.expect('TFCALL', 'lib2.continue', '0').equal('OK')
+    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib1.num_pending', '0'))
+    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib2.num_pending', '0'))
     runUntil(env, 2, lambda: env.cmd('XLEN', 'stream:1'))
 
-    env.expect('TFCALL', 'lib1', 'continue', '0').equal('OK')
-    env.expect('TFCALL', 'lib1', 'continue', '0').equal('OK')
-    runUntil(env, 0, lambda: env.cmd('TFCALL', 'lib1', 'num_pending', '0'))
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib2', 'num_pending', '0'))
+    env.expect('TFCALL', 'lib1.continue', '0').equal('OK')
+    env.expect('TFCALL', 'lib1.continue', '0').equal('OK')
+    runUntil(env, 0, lambda: env.cmd('TFCALL', 'lib1.num_pending', '0'))
+    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib2.num_pending', '0'))
     runFor(2, lambda: env.cmd('XLEN', 'stream:1')) # make sure not trimming
 
-    env.expect('TFCALL', 'lib2', 'continue', '0').equal('OK')
-    env.expect('TFCALL', 'lib2', 'continue', '0').equal('OK')
-    runUntil(env, 0, lambda: env.cmd('TFCALL', 'lib1', 'num_pending', '0'))
-    runUntil(env, 0, lambda: env.cmd('TFCALL', 'lib2', 'num_pending', '0'))
+    env.expect('TFCALL', 'lib2.continue', '0').equal('OK')
+    env.expect('TFCALL', 'lib2.continue', '0').equal('OK')
+    runUntil(env, 0, lambda: env.cmd('TFCALL', 'lib1.num_pending', '0'))
+    runUntil(env, 0, lambda: env.cmd('TFCALL', 'lib2.num_pending', '0'))
     runUntil(env, 0, lambda: env.cmd('XLEN', 'stream:1'))
 
 @gearsTest()
@@ -432,16 +432,16 @@ redis.registerStreamTrigger("consumer", "stream",
 );
     """
 
-    env.expect('TFCALL', 'lib', 'get_stream', '0').error().contains('No streams')
+    env.expect('TFCALL', 'lib.get_stream', '0').error().contains('No streams')
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
     env.cmd('xadd', 'stream:2', '*', 'foo', 'bar')
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
     env.cmd('xadd', 'stream:2', '*', 'foo', 'bar')
 
-    runUntil(env, 'stream:1', lambda: env.cmd('TFCALL', 'lib', 'get_stream', '0'), timeout=1)
-    runUntil(env, 'stream:2', lambda: env.cmd('TFCALL', 'lib', 'get_stream', '0'), timeout=1)
-    runUntil(env, 'stream:1', lambda: env.cmd('TFCALL', 'lib', 'get_stream', '0'), timeout=1)
-    runUntil(env, 'stream:2', lambda: env.cmd('TFCALL', 'lib', 'get_stream', '0'), timeout=1)
+    runUntil(env, 'stream:1', lambda: env.cmd('TFCALL', 'lib.get_stream', '0'), timeout=1)
+    runUntil(env, 'stream:2', lambda: env.cmd('TFCALL', 'lib.get_stream', '0'), timeout=1)
+    runUntil(env, 'stream:1', lambda: env.cmd('TFCALL', 'lib.get_stream', '0'), timeout=1)
+    runUntil(env, 'stream:2', lambda: env.cmd('TFCALL', 'lib.get_stream', '0'), timeout=1)
 
 @gearsTest()
 def testRDBSaveAndLoad(env):
@@ -517,15 +517,15 @@ redis.registerStreamTrigger("consumer", "stream",
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 'OK', lambda: env.cmd('TFCALLASYNC', 'lib', 'continue_process', '0'))
+    runUntil(env, 'OK', lambda: env.cmd('TFCALLASYNC', 'lib.continue_process', '0'))
     runUntil(env, 1, lambda: toDictionary(toDictionary(env.execute_command('TFUNCTION', 'LIST', 'vvv'), 4)[0]['stream_triggers'][0]['streams'][0], 1)['total_record_processed'])
 
     # Turn into a slave
     env.cmd('slaveof', '127.0.0.1', '3300')
-    runUntil(env, 'OK', lambda: env.cmd('TFCALLASYNC', 'lib', 'continue_process', '0'))
+    runUntil(env, 'OK', lambda: env.cmd('TFCALLASYNC', 'lib.continue_process', '0'))
     runUntil(env, 2, lambda: toDictionary(toDictionary(env.execute_command('TFUNCTION', 'LIST', 'vvv'), 4)[0]['stream_triggers'][0]['streams'][0], 1)['total_record_processed'])
 
-    runFor('no data to processes', lambda: env.cmd('TFCALLASYNC', 'lib', 'continue_process', '0'))
+    runFor('no data to processes', lambda: env.cmd('TFCALLASYNC', 'lib.continue_process', '0'))
     res = toDictionary(toDictionary(env.execute_command('TFUNCTION', 'LIST', 'vvv'), 4)[0]['stream_triggers'][0]['streams'][0], 1)['total_record_processed']
     env.assertEqual(2, res)
 

--- a/pytests/test_stream_reader.py
+++ b/pytests/test_stream_reader.py
@@ -21,11 +21,11 @@ redis.registerStreamTrigger("consumer", "stream", function(){
     num_events++;
 })
     """
-    env.expect('TFCALL', 'lib.num_events', '0').equal(0)
+    env.expectTfcall('lib', 'num_events').equal(0)
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    env.expect('TFCALL', 'lib.num_events', '0').equal(1)
+    env.expectTfcall('lib', 'num_events').equal(1)
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    env.expect('TFCALL', 'lib.num_events', '0').equal(2)
+    env.expectTfcall('lib', 'num_events').equal(2)
 
 @gearsTest(decodeResponses=False)
 def testBasicStreamReaderWithBinaryData(env):
@@ -49,9 +49,9 @@ redis.registerStreamTrigger("consumer", new Uint8Array([255]).buffer, function(c
     last_data_raw = data.record_raw;
 })
     """
-    env.expect('TFCALL', 'lib.stats', '0').equal([None, None, None, None])
+    env.expectTfcall('lib', 'stats').equal([None, None, None, None])
     env.cmd('xadd', b'\xff\xff', '*', b'\xaa', b'\xaa')
-    env.expect('TFCALL', 'lib.stats', '0').equal([None, b'\xff\xff', [[None, None]], [[b'\xaa', b'\xaa']]])
+    env.expectTfcall('lib', 'stats').equal([None, b'\xff\xff', [[None, None]], [[b'\xaa', b'\xaa']]])
 
 @gearsTest()
 def testAsyncStreamReader(env):
@@ -64,11 +64,11 @@ redis.registerStreamTrigger("consumer", "stream", async function(){
     num_events++;
 })
     """
-    env.expect('TFCALL', 'lib.num_events', '0').equal(0)
+    env.expectTfcall('lib', 'num_events').equal(0)
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib.num_events', '0'))
+    runUntil(env, 1, lambda: env.tfcall('lib', 'num_events'))
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib.num_events', '0'))
+    runUntil(env, 2, lambda: env.tfcall('lib', 'num_events'))
 
 @gearsTest()
 def testStreamTrim(env):
@@ -86,13 +86,13 @@ redis.registerStreamTrigger("consumer", "stream",
     }
 );
     """
-    env.expect('TFCALL', 'lib.num_events', '0').equal(0)
+    env.expectTfcall('lib', 'num_events').equal(0)
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
     env.expect('xlen', 'stream:1').equal(0)
-    env.expect('TFCALL', 'lib.num_events', '0').equal(1)
+    env.expectTfcall('lib', 'num_events').equal(1)
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
     env.expect('xlen', 'stream:1').equal(0)
-    env.expect('TFCALL', 'lib.num_events', '0').equal(2)
+    env.expectTfcall('lib', 'num_events').equal(2)
 
 @gearsTest()
 def testStreamProccessError(env):
@@ -134,37 +134,37 @@ redis.registerStreamTrigger("consumer", "stream",
     }
 );
     """
-    env.expect('TFCALL', 'lib.num_pending', '0').equal(0)
-    env.expect('TFCALL', 'lib.continue', '0').error().contains('No pending records')
+    env.expectTfcall('lib', 'num_pending').equal(0)
+    env.expectTfcall('lib', 'continue').error().contains('No pending records')
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    runUntil(env, 1, lambda: env.tfcall('lib', 'num_pending'))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    runUntil(env, 2, lambda: env.tfcall('lib', 'num_pending'))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    runUntil(env, 3, lambda: env.tfcall('lib', 'num_pending'))
 
     res = toDictionary(env.cmd('TFUNCTION', 'LIST', 'vvv'), 6)
     env.assertEqual(3, len(res[0]['stream_triggers'][0]['streams'][0]['pending_ids']))
 
     env.expect('TFCALL', 'lib.continue', '0').equal('OK')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    runUntil(env, 2, lambda: env.tfcall('lib', 'num_pending'))
 
     runUntil(env, 2, lambda: len(toDictionary(env.cmd('TFUNCTION', 'LIST', 'vvv'), 6)[0]['stream_triggers'][0]['streams'][0]['pending_ids']))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    runUntil(env, 3, lambda: env.tfcall('lib', 'num_pending'))
 
     res = toDictionary(env.cmd('TFUNCTION', 'LIST', 'vvv'), 6)
     env.assertEqual(3, len(res[0]['stream_triggers'][0]['streams'][0]['pending_ids']))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runFor(3, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    runFor(3, lambda: env.tfcall('lib', 'num_pending'))
 
     env.expect('TFCALL', 'lib.continue', '0').equal('OK')
-    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    runUntil(env, 3, lambda: env.tfcall('lib', 'num_pending'))
 
     res = toDictionary(env.cmd('TFUNCTION', 'LIST', 'vvv'), 6)
     env.assertEqual(2, res[0]['stream_triggers'][0]['streams'][0]['total_record_processed'])
@@ -205,12 +205,12 @@ redis.registerStreamTrigger("consumer", "stream",
     env.expect('WAIT', '1', '7000').equal(1)
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    runUntil(env, 1, lambda: env.tfcall('lib', 'num_pending'))
 
     res = toDictionary(env.cmd('TFUNCTION', 'LIST', 'vvv'), 6)
     id_to_read_from = res[0]['stream_triggers'][0]['streams'][0]['id_to_read_from']
 
-    env.expect('TFCALL', 'lib.continue', '0').equal(id_to_read_from)
+    env.expectTfcall('lib', 'continue').equal(id_to_read_from)
     runUntil(env, 1, lambda: len(toDictionary(slave_conn.execute_command('TFUNCTION', 'LIST', 'vvv'), 6)[0]['stream_triggers'][0]['streams']))
     env.assertEqual(id_to_read_from, toDictionary(slave_conn.execute_command('TFUNCTION', 'LIST', 'vvv'), 6)[0]['stream_triggers'][0]['streams'][0]['id_to_read_from'])
 
@@ -222,10 +222,10 @@ redis.registerStreamTrigger("consumer", "stream",
 
     # Turn slave to master
     slave_conn.execute_command('slaveof', 'no', 'one')
-    runUntil(env, 2, lambda: slave_conn.execute_command('TFCALL', 'lib.num_pending', '0'))
+    runUntil(env, 2, lambda: env.tfcall('lib', 'num_pending', c=slave_conn))
     def continue_function():
         try:
-            return slave_conn.execute_command('TFCALL', 'lib.continue', '0')
+            return env.tfcall('lib', 'continue', c=slave_conn)
         except Exception as e:
             return str(e)
     runUntil(env, id1, continue_function)
@@ -261,28 +261,28 @@ redis.registerStreamTrigger("consumer", "stream",
     }
 );
     """
-    env.expect('TFCALL', 'lib.num_pending', '0').equal(0)
-    env.expect('TFCALL', 'lib.continue', '0').error().contains('No pending records')
+    env.expectTfcall('lib', 'num_pending').equal(0)
+    env.expectTfcall('lib', 'continue').error().contains('No pending records')
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    runUntil(env, 1, lambda: env.tfcall('lib', 'num_pending'))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    runUntil(env, 2, lambda: env.tfcall('lib', 'num_pending'))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    runUntil(env, 3, lambda: env.tfcall('lib', 'num_pending'))
 
     env.expect('del', 'stream:1').equal(1)
 
-    env.expect('TFCALL', 'lib.continue', '0').equal('OK')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    env.expectTfcall('lib', 'continue').equal('OK')
+    runUntil(env, 2, lambda: env.tfcall('lib', 'num_pending'))
 
-    env.expect('TFCALL', 'lib.continue', '0').equal('OK')
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    env.expectTfcall('lib', 'continue').equal('OK')
+    runUntil(env, 1, lambda: env.tfcall('lib', 'num_pending'))
 
-    env.expect('TFCALL', 'lib.continue', '0').equal('OK')
-    runUntil(env, 0, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    env.expectTfcall('lib', 'continue').equal('OK')
+    runUntil(env, 0, lambda: env.tfcall('lib', 'num_pending'))
 
     res = env.cmd('TFUNCTION', 'LIST', 'vvv')
     env.assertEqual(0, len(toDictionary(res, 6)[0]['stream_triggers'][0]['streams']))
@@ -316,28 +316,28 @@ redis.registerStreamTrigger("consumer", "stream",
     }
 );
     """
-    env.expect('TFCALL', 'lib.num_pending', '0').equal(0)
-    env.expect('TFCALL', 'lib.continue', '0').error().contains('No pending records')
+    env.expectTfcall('lib', 'num_pending').equal(0)
+    env.expectTfcall('lib', 'continue').error().contains('No pending records')
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    runUntil(env, 1, lambda: env.tfcall('lib', 'num_pending'))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    runUntil(env, 2, lambda: env.tfcall('lib', 'num_pending'))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    runUntil(env, 3, lambda: env.tfcall('lib', 'num_pending'))
 
     env.expect('flushall').equal(True)
 
-    env.expect('TFCALL', 'lib.continue', '0').equal('OK')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    env.expectTfcall('lib', 'continue').equal('OK')
+    runUntil(env, 2, lambda: env.tfcall('lib', 'num_pending'))
 
-    env.expect('TFCALL', 'lib.continue', '0').equal('OK')
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    env.expectTfcall('lib', 'continue').equal('OK')
+    runUntil(env, 1, lambda: env.tfcall('lib', 'num_pending'))
 
-    env.expect('TFCALL', 'lib.continue', '0').equal('OK')
-    runUntil(env, 0, lambda: env.cmd('TFCALL', 'lib.num_pending', '0'))
+    env.expectTfcall('lib', 'continue').equal('OK')
+    runUntil(env, 0, lambda: env.tfcall('lib', 'num_pending'))
 
     res = env.cmd('TFUNCTION', 'LIST', 'vvv')
     env.assertEqual(0, len(toDictionary(res, 6)[0]['stream_triggers'][0]['streams']))
@@ -375,37 +375,37 @@ redis.registerStreamTrigger("consumer", "stream",
     env.expect('TFUNCTION', 'LOAD', script % 'lib2').equal('OK')
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib1.num_pending', '0'))
-    runUntil(env, 1, lambda: env.cmd('TFCALL', 'lib2.num_pending', '0'))
+    runUntil(env, 1, lambda: env.tfcall('lib1', 'num_pending'))
+    runUntil(env, 1, lambda: env.tfcall('lib2', 'num_pending'))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib1.num_pending', '0'))
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib2.num_pending', '0'))
+    runUntil(env, 2, lambda: env.tfcall('lib1', 'num_pending'))
+    runUntil(env, 2, lambda: env.tfcall('lib2', 'num_pending'))
 
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib1.num_pending', '0'))
-    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib2.num_pending', '0'))
+    runUntil(env, 3, lambda: env.tfcall('lib1', 'num_pending'))
+    runUntil(env, 3, lambda: env.tfcall('lib2', 'num_pending'))
 
-    env.expect('TFCALL', 'lib1.continue', '0').equal('OK')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib1.num_pending', '0'))
-    runUntil(env, 3, lambda: env.cmd('TFCALL', 'lib2.num_pending', '0'))
+    env.expectTfcall('lib1','continue').equal('OK')
+    runUntil(env, 2, lambda: env.tfcall('lib1', 'num_pending'))
+    runUntil(env, 3, lambda: env.tfcall('lib2', 'num_pending'))
     runFor(3, lambda: env.cmd('XLEN', 'stream:1')) # make sure not trimming
 
-    env.expect('TFCALL', 'lib2.continue', '0').equal('OK')
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib1.num_pending', '0'))
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib2.num_pending', '0'))
+    env.expectTfcall('lib2', 'continue').equal('OK')
+    runUntil(env, 2, lambda: env.tfcall('lib1', 'num_pending'))
+    runUntil(env, 2, lambda: env.tfcall('lib2', 'num_pending'))
     runUntil(env, 2, lambda: env.cmd('XLEN', 'stream:1'))
 
-    env.expect('TFCALL', 'lib1.continue', '0').equal('OK')
-    env.expect('TFCALL', 'lib1.continue', '0').equal('OK')
-    runUntil(env, 0, lambda: env.cmd('TFCALL', 'lib1.num_pending', '0'))
-    runUntil(env, 2, lambda: env.cmd('TFCALL', 'lib2.num_pending', '0'))
+    env.expectTfcall('lib1', 'continue').equal('OK')
+    env.expectTfcall('lib1', 'continue').equal('OK')
+    runUntil(env, 0, lambda: env.tfcall('lib1', 'num_pending'))
+    runUntil(env, 2, lambda: env.tfcall('lib2', 'num_pending'))
     runFor(2, lambda: env.cmd('XLEN', 'stream:1')) # make sure not trimming
 
-    env.expect('TFCALL', 'lib2.continue', '0').equal('OK')
-    env.expect('TFCALL', 'lib2.continue', '0').equal('OK')
-    runUntil(env, 0, lambda: env.cmd('TFCALL', 'lib1.num_pending', '0'))
-    runUntil(env, 0, lambda: env.cmd('TFCALL', 'lib2.num_pending', '0'))
+    env.expectTfcall('lib2', 'continue').equal('OK')
+    env.expectTfcall('lib2', 'continue').equal('OK')
+    runUntil(env, 0, lambda: env.tfcall('lib1', 'num_pending'))
+    runUntil(env, 0, lambda: env.tfcall('lib2', 'num_pending'))
     runUntil(env, 0, lambda: env.cmd('XLEN', 'stream:1'))
 
 @gearsTest()
@@ -432,16 +432,16 @@ redis.registerStreamTrigger("consumer", "stream",
 );
     """
 
-    env.expect('TFCALL', 'lib.get_stream', '0').error().contains('No streams')
+    env.expectTfcall('lib', 'get_stream').error().contains('No streams')
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
     env.cmd('xadd', 'stream:2', '*', 'foo', 'bar')
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
     env.cmd('xadd', 'stream:2', '*', 'foo', 'bar')
 
-    runUntil(env, 'stream:1', lambda: env.cmd('TFCALL', 'lib.get_stream', '0'), timeout=1)
-    runUntil(env, 'stream:2', lambda: env.cmd('TFCALL', 'lib.get_stream', '0'), timeout=1)
-    runUntil(env, 'stream:1', lambda: env.cmd('TFCALL', 'lib.get_stream', '0'), timeout=1)
-    runUntil(env, 'stream:2', lambda: env.cmd('TFCALL', 'lib.get_stream', '0'), timeout=1)
+    runUntil(env, 'stream:1', lambda: env.tfcall('lib', 'get_stream'), timeout=1)
+    runUntil(env, 'stream:2', lambda: env.tfcall('lib', 'get_stream'), timeout=1)
+    runUntil(env, 'stream:1', lambda: env.tfcall('lib', 'get_stream'), timeout=1)
+    runUntil(env, 'stream:2', lambda: env.tfcall('lib', 'get_stream'), timeout=1)
 
 @gearsTest()
 def testRDBSaveAndLoad(env):
@@ -517,15 +517,15 @@ redis.registerStreamTrigger("consumer", "stream",
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
     env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
-    runUntil(env, 'OK', lambda: env.cmd('TFCALLASYNC', 'lib.continue_process', '0'))
+    runUntil(env, 'OK', lambda: env.tfcallAsync('lib', 'continue_process'))
     runUntil(env, 1, lambda: toDictionary(toDictionary(env.execute_command('TFUNCTION', 'LIST', 'vvv'), 4)[0]['stream_triggers'][0]['streams'][0], 1)['total_record_processed'])
 
     # Turn into a slave
     env.cmd('slaveof', '127.0.0.1', '3300')
-    runUntil(env, 'OK', lambda: env.cmd('TFCALLASYNC', 'lib.continue_process', '0'))
+    runUntil(env, 'OK', lambda: env.tfcallAsync('lib', 'continue_process'))
     runUntil(env, 2, lambda: toDictionary(toDictionary(env.execute_command('TFUNCTION', 'LIST', 'vvv'), 4)[0]['stream_triggers'][0]['streams'][0], 1)['total_record_processed'])
 
-    runFor('no data to processes', lambda: env.cmd('TFCALLASYNC', 'lib.continue_process', '0'))
+    runFor('no data to processes', lambda: env.tfcallAsync('lib', 'continue_process'))
     res = toDictionary(toDictionary(env.execute_command('TFUNCTION', 'LIST', 'vvv'), 4)[0]['stream_triggers'][0]['streams'][0], 1)['total_record_processed']
     env.assertEqual(2, res)
 

--- a/pytests/test_verbose_error_reporting.py
+++ b/pytests/test_verbose_error_reporting.py
@@ -19,7 +19,7 @@ redis.registerFunction("test", function(client){
     return foo()
 })
     '''
-    env.expect('TFCALL', 'foo.test', 0).error().contains(':3:') # error on line 5
+    env.expectTfcall('foo', 'test').error().contains(':3:') # error on line 5
 
 @gearsTest(errorVerbosity=2)
 def testVerboseErrorOnAsyncFunctionRun(env):
@@ -28,7 +28,7 @@ redis.registerAsyncFunction("test", async function(client){
     return foo()
 })
     '''
-    env.expect('TFCALLASYNC', 'foo.test', 0).error().contains(':3:') # error on line 5
+    env.expectTfcallAsync('foo', 'test').error().contains(':3:') # error on line 5
 
 @gearsTest(errorVerbosity=2)
 def testVerboseErrorOnFunctionThatReturnsCoro(env):
@@ -39,7 +39,7 @@ redis.registerFunction("test", function(client){
     });
 })
     '''
-    env.expect('TFCALLASYNC', 'foo.test', 0).error().contains(':4:') # error on line 5
+    env.expectTfcallAsync('foo', 'test').error().contains(':4:') # error on line 5
 
 @gearsTest(errorVerbosity=2)
 def testVerboseErrorOnStreamProcessing(env):

--- a/pytests/test_verbose_error_reporting.py
+++ b/pytests/test_verbose_error_reporting.py
@@ -19,7 +19,7 @@ redis.registerFunction("test", function(client){
     return foo()
 })
     '''
-    env.expect('TFCALL', 'foo', 'test', 0).error().contains(':3:') # error on line 5
+    env.expect('TFCALL', 'foo.test', 0).error().contains(':3:') # error on line 5
 
 @gearsTest(errorVerbosity=2)
 def testVerboseErrorOnAsyncFunctionRun(env):
@@ -28,7 +28,7 @@ redis.registerAsyncFunction("test", async function(client){
     return foo()
 })
     '''
-    env.expect('TFCALLASYNC', 'foo', 'test', 0).error().contains(':3:') # error on line 5
+    env.expect('TFCALLASYNC', 'foo.test', 0).error().contains(':3:') # error on line 5
 
 @gearsTest(errorVerbosity=2)
 def testVerboseErrorOnFunctionThatReturnsCoro(env):
@@ -39,7 +39,7 @@ redis.registerFunction("test", function(client){
     });
 })
     '''
-    env.expect('TFCALLASYNC', 'foo', 'test', 0).error().contains(':4:') # error on line 5
+    env.expect('TFCALLASYNC', 'foo.test', 0).error().contains(':4:') # error on line 5
 
 @gearsTest(errorVerbosity=2)
 def testVerboseErrorOnStreamProcessing(env):

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -10,7 +10,7 @@ use redis_module::{
 use redisgears_plugin_api::redisgears_plugin_api::GearsApiError;
 
 use crate::compiled_library_api::CompiledLibraryAPI;
-use crate::{Deserialize, Serialize};
+use crate::{verify_name, Deserialize, Serialize};
 
 use crate::{
     get_backends_mut, get_libraries, GearsLibrary, GearsLibraryCtx, GearsLibraryMetaData,
@@ -47,6 +47,13 @@ fn library_extract_metadata(
 ) -> Result<GearsLibraryMetaData, RedisError> {
     let prologue = redisgears_plugin_api::redisgears_plugin_api::prologue::parse_prologue(code)
         .map_err(|e| RedisError::String(GearsApiError::from(e).get_msg().to_owned()))?;
+
+    verify_name(&prologue.library_name).map_err(|e| {
+        RedisError::String(format!(
+            "Unallowed library name '{}', {e}.",
+            prologue.library_name
+        ))
+    })?;
 
     Ok(GearsLibraryMetaData {
         engine: prologue.engine.to_owned(),

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -1013,7 +1013,7 @@ pub(crate) fn verify_name(name: &str) -> Result<(), String> {
         return Err(format!("Empty name is not allowed"));
     }
     name.chars().try_for_each(|c| {
-        if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' {
+        if c.is_ascii_alphanumeric() || c == '_' {
             return Ok(());
         }
         Err(format!("Unallowed char was given '{c}'"))

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -197,6 +197,9 @@ impl<'ctx, 'lib_ctx> GearsLoadLibraryCtx<'ctx, 'lib_ctx> {
         name: &str,
         func_ctx: GearsFunctionCtx,
     ) -> Result<(), GearsApiError> {
+        verify_name(name)
+            .map_err(|e| GearsApiError::new(format!("Unallowed function name '{name}', {e}.")))?;
+
         if self.gears_lib_ctx.functions.contains_key(name) {
             return Err(GearsApiError::new(format!(
                 "Function {} already exists",
@@ -244,6 +247,11 @@ impl<'ctx, 'lib_ctx> LoadLibraryCtxInterface for GearsLoadLibraryCtx<'ctx, 'lib_
     ) -> Result<(), GearsApiError> {
         // TODO move to <https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.try_insert>
         // once stabilised.
+
+        verify_name(name).map_err(|e| {
+            GearsApiError::new(format!("Unallowed cluster function name '{name}', {e}."))
+        })?;
+
         if self.gears_lib_ctx.remote_functions.contains_key(name) {
             return Err(GearsApiError::new(format!(
                 "Remote function {} already exists",
@@ -265,6 +273,10 @@ impl<'ctx, 'lib_ctx> LoadLibraryCtxInterface for GearsLoadLibraryCtx<'ctx, 'lib_
         trim: bool,
         description: Option<String>,
     ) -> Result<(), GearsApiError> {
+        verify_name(name).map_err(|e| {
+            GearsApiError::new(format!("Unallowed stream trigger name '{name}', {e}."))
+        })?;
+
         if self.gears_lib_ctx.stream_consumers.contains_key(name) {
             return Err(GearsApiError::new(
                 "Stream registration already exists".to_string(),
@@ -348,6 +360,10 @@ impl<'ctx, 'lib_ctx> LoadLibraryCtxInterface for GearsLoadLibraryCtx<'ctx, 'lib_
         keys_notifications_consumer_ctx: Box<dyn KeysNotificationsConsumerCtxInterface>,
         description: Option<String>,
     ) -> Result<(), GearsApiError> {
+        verify_name(name).map_err(|e| {
+            GearsApiError::new(format!("Unallowed key space trigger name '{name}', {e}."))
+        })?;
+
         if self
             .gears_lib_ctx
             .notifications_consumers
@@ -761,8 +777,15 @@ fn function_call_command(
     mut args: Skip<IntoIter<redis_module::RedisString>>,
     allow_block: bool,
 ) -> RedisResult {
-    let library_name = args.next_arg()?.try_as_str()?;
-    let function_name = args.next_arg()?.try_as_str()?;
+    let mut lib_func_name = args.next_arg()?.try_as_str()?.split(".");
+
+    let library_name = lib_func_name
+        .next()
+        .ok_or(RedisError::Str("Failed extracting library name"))?;
+    let function_name = lib_func_name
+        .next()
+        .ok_or(RedisError::Str("Failed extracting function name"))?;
+
     let num_keys = args.next_arg()?.try_as_str()?.parse::<usize>()?;
     let libraries = get_libraries();
 
@@ -985,6 +1008,18 @@ fn on_flush_event(ctx: &Context, flush_event: FlushSubevent) {
     }
 }
 
+pub(crate) fn verify_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err(format!("Empty name is not allowed"));
+    }
+    name.chars().try_for_each(|c| {
+        if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' {
+            return Ok(());
+        }
+        Err(format!("Unallowed char was given '{c}'"))
+    })
+}
+
 pub(crate) fn get_msg_verbose(err: &GearsApiError) -> &str {
     if ERROR_VERBOSITY.load(Ordering::Relaxed) == 1 {
         return err.get_msg();
@@ -996,11 +1031,11 @@ pub(crate) fn get_msg_verbose(err: &GearsApiError) -> &str {
     {
         name: "tfcall",
         flags: [MayReplicate, DenyScript, NoMandatoryKeys],
-        arity: -4,
+        arity: -3,
         key_spec: [
             {
                 flags: [ReadWrite, Access, Update],
-                begin_search: Index({ index : 3}),
+                begin_search: Index({ index : 2}),
                 find_keys: Keynum({ key_num_idx : 0, first_key : 1, key_step : 1 }),
             }
         ],
@@ -1015,11 +1050,11 @@ fn function_call(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     {
         name: "tfcallasync",
         flags: [MayReplicate, DenyScript, NoMandatoryKeys],
-        arity: -4,
+        arity: -3,
         key_spec: [
             {
                 flags: [ReadWrite, Access, Update],
-                begin_search: Index({ index : 3}),
+                begin_search: Index({ index : 2}),
                 find_keys: Keynum({ key_num_idx : 0, first_key : 1, key_step : 1 }),
             }
         ],

--- a/tests/benchmarks/rg_fcall_async.yml
+++ b/tests/benchmarks/rg_fcall_async.yml
@@ -10,4 +10,4 @@ dbconfig:
 clientconfig:
   benchmark_type: "read-only"
   tool: memtier_benchmark
-  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TFCALLASYNC lib foo 0'"
+  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TFCALLASYNC lib.foo 0'"

--- a/tests/benchmarks/rg_fcall_redis_cmd.yml
+++ b/tests/benchmarks/rg_fcall_redis_cmd.yml
@@ -10,4 +10,4 @@ dbconfig:
 clientconfig:
   benchmark_type: "read-only"
   tool: memtier_benchmark
-  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TFCALL lib foo 0'"
+  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TFCALL lib.foo 0'"

--- a/tests/benchmarks/rg_fcall_redis_cmd_async.yml
+++ b/tests/benchmarks/rg_fcall_redis_cmd_async.yml
@@ -10,4 +10,4 @@ dbconfig:
 clientconfig:
   benchmark_type: "read-only"
   tool: memtier_benchmark
-  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TFCALLASYNC lib foo 0'"
+  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TFCALLASYNC lib.foo 0'"

--- a/tests/benchmarks/rg_fcall_simple.yml
+++ b/tests/benchmarks/rg_fcall_simple.yml
@@ -10,4 +10,4 @@ dbconfig:
 clientconfig:
   benchmark_type: "read-only"
   tool: memtier_benchmark
-  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TFCALL lib foo 0'"
+  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TFCALL lib.foo 0'"

--- a/tests/benchmarks/rg_sync_and_async.yml
+++ b/tests/benchmarks/rg_sync_and_async.yml
@@ -12,4 +12,4 @@ dbconfig:
     - ["TFUNCTION","LOAD","#!js api_version=1.0 name=lib\n redis.registerAsyncFunction('test', function(client, expected_name){    client.call('type', expected_name);    return client.executeAsync(async function(async_client) {        async_client.block((client)=>{            client.call('type', expected_name);        });    });});"]
 clientconfig:
   tool: memtier_benchmark
-  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TFCALLASYNC lib test 0 abc'"
+  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TFCALLASYNC lib.test 0 abc'"


### PR DESCRIPTION
Fixes #920.

The PR combine the library and the function name to a single, `.` seperated argument instead of 2 distinct arguments. The main goal is to make the API closer to Redis Function while not giving up on the library name which we believe is important.

The PR also forces the set of allowed char for functions and library name to be `[a-zA-Z0-9_][a-zA-Z0-9_]?` just like Redis Function.