### PR TITLE
Force OOM on function load

### DIFF
--- a/pytests/test_basics.py
+++ b/pytests/test_basics.py
@@ -459,6 +459,20 @@ redis.registerStreamTrigger(
     env.expect('TFUNCTION', 'LOAD', code).equal('OK')
     env.expect('TFCALL', 'lib', 'test', '0').equal('OK')
 
+@gearsTest(v8MaxMemory=20 * 1024 * 1024)
+def testV8OOMOnFunctionLoad(env):
+    code = """#!js api_version=1.0 name=lib%d
+redis.registerFunction("test", function(client){
+    return "OK";
+});
+    """
+    try:
+        for i in range(100):
+            env.cmd('TFUNCTION', 'LOAD', code % i)
+        env.assertTrue(False, message='Except OOM on function load')
+    except Exception as e:
+        env.assertIn('JS engine reached OOM state', str(e))
+
 @gearsTest()
 def testLibraryConfiguration(env):
     code = """#!js api_version=1.0 name=lib

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -449,7 +449,7 @@ impl BackendCtxInterfaceInitialised for V8Backend {
         config: Option<&String>,
         compiled_library_api: Box<dyn CompiledLibraryInterface + Send + Sync>,
     ) -> Result<Box<dyn LibraryCtxInterface>, GearsApiError> {
-        if bypass_memory_limit() {
+        if calc_isolates_used_memory() >= max_memory_limit() {
             return Err(GearsApiError::new(
                 "JS engine reached OOM state and can not run any more code",
             ));


### PR DESCRIPTION
By calling `calc_isolates_used_memory` we will check the exact memory usage of all isolate instead of the estimated value used on `bypass_memory_limit`. Without it, one can create a lot of libraries and bypass the OOM value as long as each single library will not bypass the isolate OOM.