### PR TITLE
CP v2.0: Runnning benchmarks on pushes to master. Enabling nightly on 2.0 branch

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -1,6 +1,10 @@
 name: Run nightly CI benchmarks
 
 on:
+  push:
+    branches:
+      - master
+      - 2.0
 
   workflow_dispatch:
 
@@ -10,11 +14,16 @@ on:
 
 jobs:
   perf-ci:
+    strategy:
+      matrix:
+        ref: ['master','2.0']
     name: Trigger CI benchmarks
     runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ matrix.ref }}
     - name: Build release
       env:
         V8_VERSION: main


### PR DESCRIPTION
- CP of https://github.com/RedisGears/RedisGears/pull/956 
- Normally I wait for it to be merged but given I need v2.0 performance data I've went ahead and created this PR and triggered the benchmarks 