### PR TITLE
Added missing before_run and after_run calls so that timeout will work properly

### DIFF
--- a/pytests/test_basics.py
+++ b/pytests/test_basics.py
@@ -323,6 +323,21 @@ redis.registerAsyncFunction("test1", async function(client){
     env.expectTfcallAsync('lib', 'test1').error().contains('Execution was terminated due to OOM or timeout')
 
 @gearsTest()
+def testExecuteAsyncScriptTimeout(env):
+    """#!js api_version=1.0 name=lib
+redis.registerAsyncFunction("test1", function(client){
+    return client.executeAsync(async (c) =>{
+        c.block(function(){
+            while (true);
+        });
+    });
+    
+});
+    """
+    env.expect('config', 'set', 'redisgears_2.lock-redis-timeout', '100').equal('OK')
+    env.expectTfcallAsync('lib', 'test1').error().contains('Execution was terminated due to OOM or timeout')
+
+@gearsTest()
 def testTimeoutErrorNotCatchable(env):
     """#!js api_version=1.0 name=lib
 redis.registerAsyncFunction("test1", async function(client){

--- a/redisgears_v8_plugin/src/v8_native_functions.rs
+++ b/redisgears_v8_plugin/src/v8_native_functions.rs
@@ -618,9 +618,11 @@ pub(crate) fn get_redis_client<'isolate_scope, 'isolate>(
                         &ctx_scope,
                         Arc::new(bg_redis_client),
                     );
+                    new_script_ctx_ref.before_run();
                     let res = f
                         .take_local(&isolate_scope)
                         .call(&ctx_scope, Some(&[&background_client.to_value()]));
+                    new_script_ctx_ref.after_run();
 
                     let resolver = resolver.take_local(&isolate_scope).as_resolver();
                     match res {


### PR DESCRIPTION
The code were missing a call to `before_run` and `after_run` which causes RedisGears to miss the fact that the isolate runs JS code. This cause it not to monitor the code for timeout.