### PR TITLE
Allow lazy loading of V8 engine and threads.

### DIFF
--- a/pytests/common.py
+++ b/pytests/common.py
@@ -109,7 +109,7 @@ def verifyClusterInitialized(env):
             allConnected = True
             for n in nodes:
                 status = n[17]
-                if status != 'connected':
+                if status != 'connected' and status != 'uninitialized':
                     allConnected = False
             if not allConnected:
                 time.sleep(0.1)

--- a/redisgears_core/src/config.rs
+++ b/redisgears_core/src/config.rs
@@ -26,7 +26,7 @@ lazy_static! {
 
     /// Configuration value indicates the number of execution threads for
     /// background tasks.
-    pub(crate) static ref EXECUTION_THREADS: RedisGILGuard<i64> = RedisGILGuard::default();
+    pub(crate) static ref EXECUTION_THREADS: AtomicI64 = AtomicI64::default();
 
     /// Configuration value indicates the timeout for remote tasks that runs on a remote shard.
     pub(crate) static ref REMOTE_TASK_DEFAULT_TIMEOUT: AtomicI64 = AtomicI64::default();

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -101,8 +101,7 @@ pub(crate) fn function_load_internal(
 ) -> Result<(), String> {
     let meta_data = library_extract_metadata(code, config, user).map_err(|e| e.to_string())?;
     let backend_name = meta_data.engine.as_str();
-    let backend = get_backend(ctx, backend_name)
-        .ok_or_else(|| format!("Unknown backend {}", backend_name))?;
+    let backend = get_backend(ctx, backend_name).map_err(|e| e.to_string())?;
     let compile_lib_ctx = CompiledLibraryAPI::new();
     let compile_lib_internals = compile_lib_ctx.take_internals();
     let lib_ctx = backend.compile_library(

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -10,11 +10,10 @@ use redis_module::{
 use redisgears_plugin_api::redisgears_plugin_api::GearsApiError;
 
 use crate::compiled_library_api::CompiledLibraryAPI;
-use crate::{verify_name, Deserialize, Serialize};
+use crate::{get_backend, verify_name, Deserialize, Serialize};
 
 use crate::{
-    get_backends_mut, get_libraries, GearsLibrary, GearsLibraryCtx, GearsLibraryMetaData,
-    GearsLoadLibraryCtx,
+    get_libraries, GearsLibrary, GearsLibraryCtx, GearsLibraryMetaData, GearsLoadLibraryCtx,
 };
 
 use mr::libmr::{
@@ -102,11 +101,8 @@ pub(crate) fn function_load_internal(
 ) -> Result<(), String> {
     let meta_data = library_extract_metadata(code, config, user).map_err(|e| e.to_string())?;
     let backend_name = meta_data.engine.as_str();
-    let backend = get_backends_mut().get_mut(backend_name);
-    if backend.is_none() {
-        return Err(format!("Unknown backend {}", backend_name));
-    }
-    let backend = backend.unwrap();
+    let backend = get_backend(ctx, backend_name)
+        .ok_or_else(|| format!("Unknown backend {}", backend_name))?;
     let compile_lib_ctx = CompiledLibraryAPI::new();
     let compile_lib_internals = compile_lib_ctx.take_internals();
     let lib_ctx = backend.compile_library(

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -387,7 +387,7 @@ impl V8Backend {
             1,
             Some(flags),
         )
-        .map_err(|e| GearsApiError::new(e))
+        .map_err(GearsApiError::new)
     }
 
     fn spawn_background_maintenance_thread(&self) -> Result<(), GearsApiError> {

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -390,7 +390,7 @@ impl V8Backend {
         .map_err(|e| GearsApiError::new(e))
     }
 
-    fn spone_background_maintenance_thread(&self) -> Result<(), GearsApiError> {
+    fn spawn_background_maintenance_thread(&self) -> Result<(), GearsApiError> {
         let script_ctxs = Arc::clone(&self.script_ctx_vec);
         std::thread::Builder::new()
             .name("v8maintenance".to_string())
@@ -429,7 +429,7 @@ impl BackendCtxInterfaceUninitialised for V8Backend {
             GLOBAL.script_ctx_vec = Some(Arc::clone(&self.script_ctx_vec));
         }
         self.initialize_v8_engine(&flags)?;
-        self.spone_background_maintenance_thread()?;
+        self.spawn_background_maintenance_thread()?;
 
         Ok(self)
     }


### PR DESCRIPTION
The PR allow to postpone the opening of new threads up until the time we really need them. In addition, the PR postpone the loading of the V8 plugin up until the time we really need it to run JS code.

Those changes reduce Gears footprints if its not used and reduce the risk of damaging existing servers that do not use RedisGears (but do load it).