### PR TITLE
Fixes according to recent librm changes

### DIFF
--- a/pytests/common.py
+++ b/pytests/common.py
@@ -109,7 +109,7 @@ def verifyClusterInitialized(env):
             allConnected = True
             for n in nodes:
                 status = n[17]
-                if status != 'connected':
+                if status != 'connected' and status != 'uninitialized':
                     allConnected = False
             if not allConnected:
                 time.sleep(0.1)


### PR DESCRIPTION
Recent changes of LibMR is lazy initialisation of threads and connections. So we can not wait for the connections to the other shards to be `connected`. Instead we can wait for it to be either `connected` or `uninitialised` (Which means that we got the topology and we will connect when needed).