### PR TITLE
Add Support for Handling Fatal Errors in Async Functions

### DIFF
--- a/pytests/common.py
+++ b/pytests/common.py
@@ -7,6 +7,7 @@ import json
 import asyncio
 from threading import Thread
 from redis.asyncio import Redis as AIORedis
+from redis import Redis
 
 def toDictionary(res, max_recursion=1000):
     if  max_recursion == 0:
@@ -165,6 +166,11 @@ def extendEnvWithGearsFunctionality(env):
     
     def noBlockingTfcallAsync(lib, func, keys=[], args=[]):
         return env.noBlockingCmd('TFCALLASYNC', '%s.%s' % (lib, func), str(len(keys)), *(keys + args))
+    
+    def getResp3Connection():
+        port = int(env.cmd('config', 'get', 'port')[1])
+        # test resp3
+        return Redis('localhost', port, protocol=3, decode_responses=True)
 
     
     env.expectTfcall = expectTfcall
@@ -174,6 +180,7 @@ def extendEnvWithGearsFunctionality(env):
     env.noBlockingCmd = noBlockingCmd
     env.noBlockingTfcall = noBlockingTfcall
     env.noBlockingTfcallAsync = noBlockingTfcallAsync
+    env.getResp3Connection = getResp3Connection
 
 def gearsTest(skipTest=False,
               skipOnCluster=False,

--- a/pytests/test_basics.py
+++ b/pytests/test_basics.py
@@ -340,7 +340,7 @@ redis.registerAsyncFunction("test1", async function(client){
     future = env.noBlockingTfcallAsync('lib', 'test1')
     env.expect('RPUSH', 'l', '1').equal(1)
     def run_v8_gc():
-        env.cmd('tfunction', 'debug', 'js', 'request_v8_gc_fore_debugging')
+        env.cmd('tfunction', 'debug', 'js', 'request_v8_gc_for_debugging')
         res = env.cmd('info', 'clients')['blocked_clients']
         return res
     runUntil(env, 0, run_v8_gc)

--- a/pytests/test_basics.py
+++ b/pytests/test_basics.py
@@ -338,11 +338,12 @@ redis.registerAsyncFunction("test1", async function(client){
     env.expect('tfunction', 'debug', 'js', 'avoid_global_allow_list').equal('OK')
     env.expect('tfunction', 'LOAD', script).equal('OK')
     future = env.noBlockingTfcallAsync('lib', 'test1')
-    env.expect('RPUSH', 'l', '1').equal(1)
     def run_v8_gc():
         env.cmd('tfunction', 'debug', 'js', 'request_v8_gc_for_debugging')
         res = env.cmd('info', 'clients')['blocked_clients']
         return res
+    runUntil(env, 1, run_v8_gc)
+    env.expect('RPUSH', 'l', '1').equal(1)
     runUntil(env, 0, run_v8_gc)
     future.expectError('Promise was dropped without been resolved')
     

--- a/pytests/test_basics.py
+++ b/pytests/test_basics.py
@@ -322,6 +322,32 @@ redis.registerAsyncFunction("test1", async function(client){
     env.expect('config', 'set', 'redisgears_2.lock-redis-timeout', '100').equal('OK')
     env.expectTfcallAsync('lib', 'test1').error().contains('Execution was terminated due to OOM or timeout')
 
+@gearsTest(enableGearsDebugCommands=True, gearsConfig={"v8-flags": "'--expose_gc'"})
+def testAsyncScriptTimeout2(env):
+    script = """#!js api_version=1.0 name=lib
+redis.registerAsyncFunction("test1", async function(client){
+    await client.block(function(c){
+        return c.callAsync('blpop', 'l', '0');
+    });
+    client.block(function(){
+        while (true);
+    });
+});
+    """
+    env.expect('config', 'set', 'redisgears_2.lock-redis-timeout', '100').equal('OK')
+    env.expect('tfunction', 'debug', 'js', 'avoid_global_allow_list').equal('OK')
+    env.expect('tfunction', 'LOAD', script).equal('OK')
+    future = env.noBlockingTfcallAsync('lib', 'test1')
+    env.expect('RPUSH', 'l', '1').equal(1)
+    def run_v8_gc():
+        env.cmd('tfunction', 'debug', 'js', 'request_v8_gc_fore_debugging')
+        res = env.cmd('info', 'clients')['blocked_clients']
+        return res
+    runUntil(env, 0, run_v8_gc)
+    future.expectError('Promise was dropped without been resolved')
+    
+    
+
 @gearsTest()
 def testExecuteAsyncScriptTimeout(env):
     """#!js api_version=1.0 name=lib
@@ -584,10 +610,7 @@ redis.registerFunction("debug_protocol", function(client, arg){
 });
     """
     env.expect('TFUNCTION', 'DEBUG', 'allow_unsafe_redis_commands').equal("OK")
-    port = int(env.cmd('config', 'get', 'port')[1])
-
-    # test resp3
-    conn = Redis('localhost', port, protocol=3, decode_responses=True)
+    conn = env.getResp3Connection()
     
     env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['string'], c=conn), 'Hello World')
     env.assertEqual(env.tfcall('lib', 'debug_protocol', [], ['integer'], c=conn), 12345)
@@ -623,10 +646,7 @@ redis.registerFunction("test", function(){
     return "test";
 });
     """
-    port = int(env.cmd('config', 'get', 'port')[1])
-
-    # test resp3
-    conn = Redis('localhost', port, protocol=3, decode_responses=True)
+    conn = env.getResp3Connection()
     
     env.assertEqual(conn.execute_command('TFUNCTION', 'LIST'), [\
         {\

--- a/pytests/test_stream_reader.py
+++ b/pytests/test_stream_reader.py
@@ -466,6 +466,20 @@ redis.registerStreamTrigger("consumer", "stream", async function(client, data){
     env.assertEqual(id_to_read_from1, id_to_read_from2)
 
 @gearsTest()
+def testSteamReaderPromiseFromSyncFunction(env):
+    """#!js api_version=1.0 name=lib
+
+redis.registerStreamTrigger("consumer", "stream", function(client, data){
+    return client.callAsync('blpop', 'l', '0');
+})
+    """
+    env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
+    conn = env.getResp3Connection()
+    env.assertEqual(0, conn.execute_command('TFUNCTION', 'LIST', 'vvv')[0]['stream_triggers'][0]['streams'][0]['total_record_processed'])
+    env.expect('lpush', 'l', '1').equal(1)
+    runUntil(env, 1, lambda: conn.execute_command('TFUNCTION', 'LIST', 'vvv')[0]['stream_triggers'][0]['streams'][0]['total_record_processed'])
+
+@gearsTest()
 def testCallingRedisCommandOnStreamConsumer(env):
     """#!js api_version=1.0 name=lib
 

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -1141,7 +1141,7 @@ fn function_debug_command(
         }
         _ => (),
     }
-    let backend = get_backends_mut().get_mut(backend_name).map_or(
+    let backend = get_backend(ctx, backend_name).map_or(
         Err(RedisError::String(format!(
             "Backend '{}' does not exists or not yet loaded",
             backend_name

--- a/redisgears_v8_plugin/Cargo.toml
+++ b/redisgears_v8_plugin/Cargo.toml
@@ -15,6 +15,7 @@ redisgears-macros-internals = { path = "../redisgears_macros_internals/" }
 serde_json = "1"
 serde = "1"
 lazy_static = "1"
+bitflags = "2"
 
 [build-dependencies]
 

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -668,7 +668,7 @@ impl BackendCtxInterfaceInitialised for V8Backend {
                 self.isolates_gc();
                 Ok(RedisValue::SimpleString("OK".to_string()))
             }
-            "request_v8_gc_fore_debugging" => {
+            "request_v8_gc_for_debugging" => {
                 let l = self.script_ctx_vec.lock().unwrap();
                 l.iter().filter_map(|v| v.upgrade()).for_each(|v| {
                     let isolate_scope = v.isolate.enter();

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -4,6 +4,7 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
+use bitflags::bitflags;
 use redis_module::redisvalue::RedisValueKey;
 use redis_module::RedisValue;
 use redisgears_macros_internals::get_allow_deny_lists;
@@ -14,6 +15,7 @@ use redisgears_plugin_api::redisgears_plugin_api::{
     backend_ctx::CompiledLibraryInterface, backend_ctx::LibraryFatalFailurePolicy,
     load_library_ctx::LibraryCtxInterface, GearsApiError,
 };
+use v8_rs::v8::isolate_scope::GarbageCollectionJobType;
 use v8_rs::v8::v8_version;
 
 use crate::v8_native_functions::{initialize_globals_for_version, ApiVersionSupported};
@@ -112,10 +114,19 @@ fn deny_list() -> &'static HashSet<String> {
 
 type ScriptCtxVec = Arc<Mutex<Vec<Weak<V8ScriptCtx>>>>;
 
+bitflags! {
+    #[derive(Clone, Copy, Debug)]
+    pub struct GlobalOptions : u32 {
+        /// If enable, avoid filtering globals by the globals allow list.
+        const AVOID_GLOBALS_ALLOW_LIST = 0b00000001;
+    }
+}
+
 struct Globals {
     backend_ctx: Option<BackendCtx>,
     bypassed_memory_limit: Option<AtomicBool>,
     script_ctx_vec: Option<ScriptCtxVec>,
+    global_options: GlobalOptions,
 }
 
 unsafe impl GlobalAlloc for Globals {
@@ -139,6 +150,7 @@ static mut GLOBAL: Globals = Globals {
     backend_ctx: None,
     bypassed_memory_limit: None,
     script_ctx_vec: None,
+    global_options: GlobalOptions::empty(),
 };
 
 /// Log a generic info message which are not related to
@@ -242,6 +254,16 @@ pub(crate) fn initial_memory_limit() -> usize {
     0usize
 }
 
+/// Set the given globals option.
+pub(crate) fn set_global_option(global_option: GlobalOptions) {
+    unsafe { &mut GLOBAL }.global_options |= global_option;
+}
+
+/// Get the given globals option.
+pub(crate) fn get_global_option() -> GlobalOptions {
+    unsafe { &GLOBAL }.global_options
+}
+
 /// Return the delta by which we should increase
 /// an isolate memory limit, as long as the max
 /// memory did not yet reached.
@@ -307,7 +329,7 @@ fn scan_for_isolates_timeout(script_ctx_vec: &ScriptCtxVec) {
                 if script_ctx.is_gil_locked() && !script_ctx.is_lock_timedout() {
                     // gil is current locked. we should check for timeout.
                     // todo: call Redis back to reply to pings and some other commands.
-                    let gil_lock_duration = script_ctx.git_lock_duration_ms();
+                    let gil_lock_duration = script_ctx.gil_lock_duration_ms();
                     let gil_lock_configured_timeout = gil_lock_timeout();
                     if gil_lock_duration > gil_lock_configured_timeout {
                         script_ctx.set_lock_timedout();
@@ -468,23 +490,25 @@ impl BackendCtxInterfaceInitialised for V8Backend {
                 let ctx_scope = ctx.enter(&isolate_scope);
 
                 let globals = ctx_scope.get_globals();
-                let propeties = globals.get_own_property_names(&ctx_scope);
-                propeties.iter(&ctx_scope).try_for_each(|v| {
-                    let s = v.to_utf8().ok_or(GearsApiError::new("Failed converting global property name to string"))?;
-                    if !allow_list().contains(s.as_str()) {
-                        if !deny_list().contains(s.as_str()) {
-                            compiled_library_api.log_warning(&format!(
-                                "Found global '{}' which is not on the allowed list nor on the deny list.",
-                                s.as_str()
-                            ));
+                if !(get_global_option().contains(GlobalOptions::AVOID_GLOBALS_ALLOW_LIST)) {
+                    let propeties = globals.get_own_property_names(&ctx_scope);
+                    propeties.iter(&ctx_scope).try_for_each(|v| {
+                        let s = v.to_utf8().ok_or(GearsApiError::new("Failed converting global property name to string"))?;
+                        if !allow_list().contains(s.as_str()) {
+                            if !deny_list().contains(s.as_str()) {
+                                compiled_library_api.log_warning(&format!(
+                                    "Found global '{}' which is not on the allowed list nor on the deny list.",
+                                    s.as_str()
+                                ));
+                            }
+                            // property does not exists on the allow list. lets drop it.
+                            if !globals.delete(&ctx_scope, &v) {
+                                return Err(GearsApiError::new(format!("Failed deleting global '{}' which is not on the allowed list, can not load the library.", s.as_str())));
+                            }
                         }
-                        // property does not exists on the allow list. lets drop it.
-                        if !globals.delete(&ctx_scope, &v) {
-                            return Err(GearsApiError::new(format!("Failed deleting global '{}' which is not on the allowed list, can not load the library.", s.as_str())));
-                        }
-                    }
-                    Ok(())
-                })?;
+                        Ok(())
+                    })?;
+                }
 
                 let v8code_str = isolate_scope.new_string(code);
 
@@ -642,6 +666,18 @@ impl BackendCtxInterfaceInitialised for V8Backend {
             }
             "isolates_gc" => {
                 self.isolates_gc();
+                Ok(RedisValue::SimpleString("OK".to_string()))
+            }
+            "request_v8_gc_fore_debugging" => {
+                let l = self.script_ctx_vec.lock().unwrap();
+                l.iter().filter_map(|v| v.upgrade()).for_each(|v| {
+                    let isolate_scope = v.isolate.enter();
+                    isolate_scope.request_gc_for_testing(GarbageCollectionJobType::Full);
+                });
+                Ok(RedisValue::SimpleString("OK".to_string()))
+            }
+            "avoid_global_allow_list" => {
+                set_global_option(GlobalOptions::AVOID_GLOBALS_ALLOW_LIST);
                 Ok(RedisValue::SimpleString("OK".to_string()))
             }
             "isolates_stats" => {

--- a/redisgears_v8_plugin/src/v8_function_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_function_ctx.rs
@@ -15,31 +15,19 @@ use redisgears_plugin_api::redisgears_plugin_api::{
 
 use v8_rs::v8::v8_array::V8LocalArray;
 use v8_rs::v8::{
-    isolate_scope::V8IsolateScope, v8_context_scope::V8ContextScope, v8_promise::V8PromiseState,
-    v8_value::V8LocalValue, v8_value::V8PersistValue,
+    isolate_scope::V8IsolateScope, v8_context_scope::V8ContextScope, v8_value::V8LocalValue,
+    v8_value::V8PersistValue,
 };
 
 use crate::v8_native_functions::{get_backgrounnd_client, RedisClient};
-use crate::v8_script_ctx::V8ScriptCtx;
-use crate::{get_error_from_object, get_exception_msg, v8_backend::bypass_memory_limit};
+use crate::v8_script_ctx::{GilStatus, V8ScriptCtx};
+use crate::{get_exception_msg, v8_backend::bypass_memory_limit};
 
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use std::str;
-
-use v8_derive::new_native_function;
-
-struct BackgroundClientHolder {
-    c: Option<Box<dyn ReplyCtxInterface>>,
-}
-
-impl BackgroundClientHolder {
-    fn unblock(&mut self) {
-        self.c = None;
-    }
-}
 
 pub struct V8InternalFunction {
     persisted_client: V8PersistValue,
@@ -208,61 +196,35 @@ impl V8InternalFunction {
                 .as_ref()
                 .map(|v| v.iter().collect::<Vec<&V8LocalValue>>());
 
-            self.script_ctx.before_run();
-            let res = self
-                .persisted_function
-                .as_local(&isolate_scope)
-                .call(&ctx_scope, args_ref.as_deref());
-            self.script_ctx.after_run();
-            res
+            self.script_ctx.call(
+                &self.persisted_function.as_local(&isolate_scope),
+                &ctx_scope,
+                args_ref.as_deref(),
+                GilStatus::Unlock,
+            )
         };
 
         match res {
             Some(r) => {
                 if r.is_promise() {
-                    let res = r.as_promise();
-                    if res.state() == V8PromiseState::Fulfilled
-                        || res.state() == V8PromiseState::Rejected
-                    {
-                        let r = res.get_result();
-                        if res.state() == V8PromiseState::Fulfilled {
-                            send_reply(&isolate_scope, &ctx_scope, bg_client.as_ref(), r);
-                        } else {
-                            bg_client.reply_with_error(get_error_from_object(&r, &ctx_scope));
-                        }
-                    } else {
-                        let bg_execution_ctx = BackgroundClientHolder { c: Some(bg_client) };
-                        let execution_ctx_resolve = Arc::new(RefCell::new(bg_execution_ctx));
-                        let execution_ctx_reject = Arc::clone(&execution_ctx_resolve);
-                        let resolve = ctx_scope.new_native_function(new_native_function!(
-                            move |isolate, context, rep: V8LocalValue| {
-                                let mut execution_ctx = execution_ctx_resolve.borrow_mut();
-                                send_reply(
-                                    isolate,
-                                    context,
-                                    execution_ctx.c.as_ref().unwrap().as_ref(),
-                                    rep,
-                                );
-                                execution_ctx.unblock();
-                                Ok::<_, String>(None)
-                            }
-                        ));
-                        let reject = ctx_scope.new_native_function(new_native_function!(
-                            move |_isolate_scope, ctx_scope, reply: V8LocalValue| {
-                                let mut execution_ctx = execution_ctx_reject.borrow_mut();
-                                // see if we can extract trace
-                                execution_ctx
-                                    .c
-                                    .as_ref()
-                                    .unwrap()
-                                    .reply_with_error(get_error_from_object(&reply, ctx_scope));
-                                execution_ctx.unblock();
-                                Ok::<_, String>(None)
-                            }
-                        ));
-                        res.then(&ctx_scope, &resolve, &reject);
-                        return FunctionCallResult::Hold;
-                    }
+                    return self
+                        .script_ctx
+                        .handle_promise(&isolate_scope, &ctx_scope, &r.as_promise(), move |res| {
+                            res.map_or_else(
+                                |err| {
+                                    bg_client.reply_with_error(err);
+                                },
+                                |v| {
+                                    send_reply(
+                                        v.isolate_scope,
+                                        v.ctx_scope,
+                                        bg_client.as_ref(),
+                                        v.res,
+                                    );
+                                },
+                            )
+                        })
+                        .map_or(FunctionCallResult::Hold, |_| FunctionCallResult::Done);
                 } else {
                     send_reply(&isolate_scope, &ctx_scope, bg_client.as_ref(), r);
                 }
@@ -314,69 +276,70 @@ impl V8InternalFunction {
 
             let _block_guard = ctx_scope.set_private_data(0, &true); // indicate we are blocked
 
-            self.script_ctx.before_run();
-            self.script_ctx.after_lock_gil();
-            let res = self
-                .persisted_function
-                .as_local(&isolate_scope)
-                .call(&ctx_scope, args_ref.as_deref());
-            self.script_ctx.before_release_gil();
-            self.script_ctx.after_run();
-
-            res
+            self.script_ctx.call(
+                &self.persisted_function.as_local(&isolate_scope),
+                &ctx_scope,
+                args_ref.as_deref(),
+                GilStatus::Lock,
+            )
         };
 
         match res {
             Some(r) => {
                 if r.is_promise() {
-                    let res = r.as_promise();
-                    if res.state() == V8PromiseState::Fulfilled
-                        || res.state() == V8PromiseState::Rejected
-                    {
-                        let r = res.get_result();
-                        if res.state() == V8PromiseState::Fulfilled {
-                            send_reply(&isolate_scope, &ctx_scope, run_ctx.as_client(), r);
-                        } else {
-                            run_ctx.reply_with_error(get_error_from_object(&r, &ctx_scope));
-                        }
-                    } else {
-                        let bc = match run_ctx.get_background_client() {
-                            Ok(bc) => bc,
-                            Err(e) => {
-                                run_ctx.reply_with_error(GearsApiError::new(format!(
-                                    "Can not block client for background execution, {}.",
-                                    e.get_msg()
-                                )));
-                                return FunctionCallResult::Done;
-                            }
-                        };
-                        let bg_execution_ctx = BackgroundClientHolder { c: Some(bc) };
-                        let execution_ctx_resolve = Arc::new(RefCell::new(bg_execution_ctx));
-                        let execution_ctx_reject = Arc::clone(&execution_ctx_resolve);
-                        let resolve = ctx_scope.new_native_function(new_native_function!(
-                            move |isolate_scope, ctx_scope, reply: V8LocalValue| {
-                                let mut execution_ctx = execution_ctx_resolve.borrow_mut();
-                                let client = execution_ctx.c.as_ref().unwrap();
-                                send_reply(isolate_scope, ctx_scope, client.as_ref(), reply);
-                                execution_ctx.unblock();
-                                Ok::<_, String>(None)
-                            }
-                        ));
-                        let reject = ctx_scope.new_native_function(new_native_function!(
-                            move |_isolate_scope, ctx_scope, reply: V8LocalValue| {
-                                let mut execution_ctx = execution_ctx_reject.borrow_mut();
-                                execution_ctx
-                                    .c
-                                    .as_ref()
-                                    .unwrap()
-                                    .reply_with_error(get_error_from_object(&reply, ctx_scope));
-                                execution_ctx.unblock();
-                                Ok::<_, String>(None)
-                            }
-                        ));
-                        res.then(&ctx_scope, &resolve, &reject);
-                        return FunctionCallResult::Hold;
-                    }
+                    let promise = r.as_promise();
+                    return self
+                        .script_ctx
+                        .promise_rejected_or_fulfilled(
+                            &isolate_scope,
+                            &ctx_scope,
+                            &promise,
+                            move |res| {
+                                res.map_or_else(
+                                    |e| run_ctx.reply_with_error(e),
+                                    |v| {
+                                        send_reply(
+                                            v.isolate_scope,
+                                            v.ctx_scope,
+                                            run_ctx.as_client(),
+                                            v.res,
+                                        )
+                                    },
+                                );
+                                FunctionCallResult::Done
+                            },
+                        )
+                        .unwrap_or_else(|| {
+                            run_ctx.get_background_client().map_or_else(
+                                |e| {
+                                    run_ctx.reply_with_error(GearsApiError::new(format!(
+                                        "Can not block client for background execution, {}.",
+                                        e.get_msg()
+                                    )));
+                                    FunctionCallResult::Done
+                                },
+                                |bc| {
+                                    self.script_ctx.promise_rejected_or_fulfilled_async(
+                                        &ctx_scope,
+                                        &promise,
+                                        move |res| {
+                                            res.map_or_else(
+                                                |e| bc.reply_with_error(e),
+                                                |v| {
+                                                    send_reply(
+                                                        v.isolate_scope,
+                                                        v.ctx_scope,
+                                                        bc.as_ref(),
+                                                        v.res,
+                                                    )
+                                                },
+                                            );
+                                        },
+                                    );
+                                    FunctionCallResult::Hold
+                                },
+                            )
+                        });
                 } else {
                     send_reply(&isolate_scope, &ctx_scope, run_ctx.as_client(), r);
                 }

--- a/redisgears_v8_plugin/src/v8_function_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_function_ctx.rs
@@ -200,7 +200,7 @@ impl V8InternalFunction {
                 &self.persisted_function.as_local(&isolate_scope),
                 &ctx_scope,
                 args_ref.as_deref(),
-                GilStatus::Unlock,
+                GilStatus::Unlocked,
             )
         };
 
@@ -280,7 +280,7 @@ impl V8InternalFunction {
                 &self.persisted_function.as_local(&isolate_scope),
                 &ctx_scope,
                 args_ref.as_deref(),
-                GilStatus::Lock,
+                GilStatus::Locked,
             )
         };
 

--- a/redisgears_v8_plugin/src/v8_native_functions.rs
+++ b/redisgears_v8_plugin/src/v8_native_functions.rs
@@ -18,7 +18,7 @@ use v8_rs::v8::v8_array::V8LocalArray;
 use v8_rs::v8::{
     isolate_scope::V8IsolateScope, v8_array_buffer::V8LocalArrayBuffer,
     v8_context_scope::V8ContextScope, v8_native_function_template::V8LocalNativeFunctionArgsIter,
-    v8_object::V8LocalObject, v8_promise::V8PromiseState, v8_utf8::V8LocalUtf8,
+    v8_object::V8LocalObject, v8_utf8::V8LocalUtf8,
     v8_value::V8LocalValue, v8_version,
 };
 
@@ -29,7 +29,7 @@ use crate::v8_redisai::{get_redisai_api, get_redisai_client};
 use crate::v8_backend::log_warning;
 use crate::v8_function_ctx::V8Function;
 use crate::v8_notifications_ctx::V8NotificationsCtx;
-use crate::v8_script_ctx::V8ScriptCtx;
+use crate::v8_script_ctx::{V8ScriptCtx, GilStatus};
 use crate::v8_stream_ctx::V8StreamCtx;
 use crate::{
     get_exception_msg, get_exception_v8_value, get_function_flags_from_strings,
@@ -301,11 +301,7 @@ pub(crate) fn get_backgrounnd_client<'isolate_scope, 'isolate>(
 
             let _block_guard = ctx_scope.set_private_data(0, &true); // indicate we are blocked
 
-            script_ctx_ref.after_lock_gil();
-            let res = f.call(ctx_scope, Some(&[&c.to_value()]));
-            script_ctx_ref.before_release_gil();
-            r_client.borrow_mut().make_invalid();
-            Ok(res)
+            Ok(script_ctx_ref.call(&f, ctx_scope, Some(&[&c.to_value()]), GilStatus::Lock))
         }),
     );
 
@@ -358,16 +354,16 @@ pub(crate) fn get_backgrounnd_client<'isolate_scope, 'isolate>(
                                 let v8_str = isolate_scope.new_string(s);
                                 let v8_obj = ctx_scope.new_object_from_json(&v8_str);
                                 if v8_obj.is_none() {
-                                    resolver.reject(&ctx_scope, &isolate_scope.new_string("Failed deserializing remote function result").to_value());
+                                    script_ctx.reject(&resolver, &ctx_scope, &isolate_scope.new_string("Failed deserializing remote function result").to_value());
                                     return;
                                 }
                                 v8_obj.unwrap()
                             }
                         };
-                        resolver.resolve(&ctx_scope, &v)
+                        script_ctx.resolve(&resolver, &ctx_scope, &v);
                     },
                     Err(e) => {
-                        resolver.reject(&ctx_scope, &isolate_scope.new_string(e.get_msg()).to_value());
+                        script_ctx.reject(&resolver, &ctx_scope, &isolate_scope.new_string(e.get_msg()).to_value());
                     }
                 }
             }));
@@ -437,7 +433,7 @@ pub(crate) fn get_backgrounnd_client<'isolate_scope, 'isolate>(
                 let results_array = isolate_scope.new_array(&results.iter().collect::<Vec<&V8LocalValue>>()).to_value();
                 let errors_array = isolate_scope.new_array(&errors.iter().collect::<Vec<&V8LocalValue>>()).to_value();
 
-                resolver.resolve(&ctx_scope, &isolate_scope.new_array(&[&results_array, &errors_array]).to_value());
+                script_ctx.resolve(&resolver, &ctx_scope, &isolate_scope.new_array(&[&results_array, &errors_array]).to_value());
             }));
         }));
         Ok(Some(promise.to_value()))
@@ -569,8 +565,8 @@ fn add_call_function(
                             decode_response,
                         );
                         match res {
-                            Ok(res) => resolver.resolve(&ctx_scope, &res),
-                            Err(e) => resolver.reject(&ctx_scope, &isolate_scope.new_string(&e).to_value())
+                            Ok(res) => script_ctx_ref.resolve(&resolver, &ctx_scope, &res),
+                            Err(e) => script_ctx_ref.reject(&resolver, &ctx_scope, &isolate_scope.new_string(&e).to_value())
                         }
                         
                     };
@@ -734,16 +730,12 @@ pub(crate) fn get_redis_client<'isolate_scope, 'isolate>(
                         &ctx_scope,
                         Arc::new(bg_redis_client),
                     );
-                    new_script_ctx_ref.before_run();
-                    let res = f
-                        .take_local(&isolate_scope)
-                        .call(&ctx_scope, Some(&[&background_client.to_value()]));
-                    new_script_ctx_ref.after_run();
+                    let res = new_script_ctx_ref.call(&f.take_local(&isolate_scope), &ctx_scope, Some(&[&background_client.to_value()]), GilStatus::Unlock);
 
                     let resolver = resolver.take_local(&isolate_scope).as_resolver();
                     match res {
                         Some(r) => {
-                            resolver.resolve(&ctx_scope, &r);
+                            new_script_ctx_ref.resolve(&resolver, &ctx_scope, &r);
                         }
                         None => {
                             let error_utf8 = get_exception_v8_value(
@@ -751,7 +743,7 @@ pub(crate) fn get_redis_client<'isolate_scope, 'isolate>(
                                 &isolate_scope,
                                 trycatch,
                             );
-                            resolver.reject(&ctx_scope, &error_utf8);
+                            new_script_ctx_ref.reject(&resolver, &ctx_scope, &error_utf8);
                         }
                     }
                 }));
@@ -1365,70 +1357,26 @@ pub(crate) fn initialize_globals_1_0(
                 }
                 let args_refs = args.iter().collect::<Vec<&V8LocalValue>>();
 
-                script_ctx.before_run();
-                let res = persisted_function
-                    .as_local(&isolate_scope)
-                    .call(
-                        &ctx_scope,
-                        Some(&args_refs),
-                    );
-                script_ctx.after_run();
+                let res = script_ctx.call(&persisted_function.as_local(&isolate_scope), &ctx_scope, Some(&args_refs), GilStatus::Unlock);
+
                 match res {
                     Some(r) => {
                         if r.is_promise() {
-                            let res = r.as_promise();
-                            if res.state() == V8PromiseState::Fulfilled
-                                || res.state() == V8PromiseState::Rejected
-                            {
-                                let r = res.get_result();
-                                if res.state() == V8PromiseState::Fulfilled {
-                                    let r = js_value_to_remote_function_data(&ctx_scope, r);
-                                    if let Some(v) = r {
-                                        on_done(Ok(v));
-                                    } else {
-                                        let error_utf8 = trycatch.get_exception().to_utf8().unwrap();
-                                        on_done(Err(GearsApiError::new(format!("Failed serializing result, {}.", error_utf8.as_str()))));
-                                    }
-                                } else {
-                                    let r = r.to_utf8().unwrap();
-                                    on_done(Err(GearsApiError::new(r.as_str().to_string())));
-                                }
-                            } else {
-                                // Notice, we are allowed to do this trick because we are protected by the isolate GIL
-                                let done_resolve = Arc::new(RefCellWrapper{ref_cell: RefCell::new(Some(on_done))});
-                                let done_reject = Arc::clone(&done_resolve);
-                                let resolve =
-                                    ctx_scope.new_native_function(new_native_function!(move |isolate_scope, ctx_scope, arg: V8LocalValue| {
-                                        {
-                                            if done_resolve.ref_cell.borrow().is_none() {
-                                                return Ok::<_, String>(None)
-                                            }
-                                        }
-                                        let on_done = done_resolve.ref_cell.borrow_mut().take().unwrap();
-                                        let trycatch = isolate_scope.new_try_catch();
-                                        let r = js_value_to_remote_function_data(ctx_scope, arg);
+                            script_ctx.handle_promise(&isolate_scope, &ctx_scope, &r.as_promise(), move |res| {
+                                match res {
+                                    Ok(v) => {
+                                        let trycatch = v.isolate_scope.new_try_catch();
+                                        let r = js_value_to_remote_function_data(v.ctx_scope, v.res);
                                         if let Some(v) = r {
                                             on_done(Ok(v));
                                         } else {
                                             let error_utf8 = trycatch.get_exception().to_utf8().unwrap();
                                             on_done(Err(GearsApiError::new(format!("Failed serializing result, {}.", error_utf8.as_str()))));
                                         }
-                                        Ok(None)
-                                    }));
-                                let reject =
-                                    ctx_scope.new_native_function(new_native_function!(move |_isolate_scope, _ctx_scope, utf8_str: V8LocalUtf8| {
-                                        {
-                                            if done_reject.ref_cell.borrow().is_none() {
-                                                return Ok::<_, String>(None);
-                                            }
-                                        }
-                                        let on_done = done_reject.ref_cell.borrow_mut().take().unwrap();
-
-                                        on_done(Err(GearsApiError::new(utf8_str.as_str().to_string())));
-                                        Ok(None)
-                                    }));
-                                res.then(&ctx_scope, &resolve, &reject);
-                            }
+                                    }
+                                    Err(e) => on_done(Err(e)),
+                                }
+                            });
                         } else {
                             let r = js_value_to_remote_function_data(&ctx_scope, r);
                             if let Some(v) = r {
@@ -1559,7 +1507,7 @@ pub(crate) fn initialize_globals_1_0(
                                     .borrow_mut()
                                     .take_local(&isolate_scope)
                                     .as_resolver();
-                                resolver.resolve(&ctx_scope, &res);
+                                new_script_ctx_ref_resolve.resolve(&resolver, &ctx_scope, &res);
                             }));
                         Ok(None)
                     }
@@ -1602,7 +1550,7 @@ pub(crate) fn initialize_globals_1_0(
                                     .borrow_mut()
                                     .take_local(&isolate_scope)
                                     .as_resolver();
-                                resolver.reject(&ctx_scope, &res);
+                                new_script_ctx_ref_reject.reject(&resolver, &ctx_scope, &res);
                             }));
                         Ok(None)
                     }

--- a/redisgears_v8_plugin/src/v8_native_functions.rs
+++ b/redisgears_v8_plugin/src/v8_native_functions.rs
@@ -301,7 +301,7 @@ pub(crate) fn get_backgrounnd_client<'isolate_scope, 'isolate>(
 
             let _block_guard = ctx_scope.set_private_data(0, &true); // indicate we are blocked
 
-            Ok(script_ctx_ref.call(&f, ctx_scope, Some(&[&c.to_value()]), GilStatus::Lock))
+            Ok(script_ctx_ref.call(&f, ctx_scope, Some(&[&c.to_value()]), GilStatus::Locked))
         }),
     );
 
@@ -730,7 +730,7 @@ pub(crate) fn get_redis_client<'isolate_scope, 'isolate>(
                         &ctx_scope,
                         Arc::new(bg_redis_client),
                     );
-                    let res = new_script_ctx_ref.call(&f.take_local(&isolate_scope), &ctx_scope, Some(&[&background_client.to_value()]), GilStatus::Unlock);
+                    let res = new_script_ctx_ref.call(&f.take_local(&isolate_scope), &ctx_scope, Some(&[&background_client.to_value()]), GilStatus::Unlocked);
 
                     let resolver = resolver.take_local(&isolate_scope).as_resolver();
                     match res {
@@ -1357,7 +1357,7 @@ pub(crate) fn initialize_globals_1_0(
                 }
                 let args_refs = args.iter().collect::<Vec<&V8LocalValue>>();
 
-                let res = script_ctx.call(&persisted_function.as_local(&isolate_scope), &ctx_scope, Some(&args_refs), GilStatus::Unlock);
+                let res = script_ctx.call(&persisted_function.as_local(&isolate_scope), &ctx_scope, Some(&args_refs), GilStatus::Unlocked);
 
                 match res {
                     Some(r) => {

--- a/redisgears_v8_plugin/src/v8_notifications_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_notifications_ctx.rs
@@ -52,7 +52,7 @@ impl V8NotificationsCtxInternal {
                 &self.persisted_function.as_local(&isolate_scope),
                 &ctx_scope,
                 Some(&[&r_client.to_value(), &notification_data]),
-                GilStatus::Lock,
+                GilStatus::Locked,
             );
 
             redis_client.borrow_mut().make_invalid();
@@ -111,7 +111,7 @@ impl V8NotificationsCtxInternal {
                 &self.persisted_function.as_local(&isolate_scope),
                 &ctx_scope,
                 Some(&[&r_client.to_value(), &notification_data]),
-                GilStatus::Unlock,
+                GilStatus::Unlocked,
             );
 
             match res {
@@ -237,7 +237,7 @@ impl KeysNotificationsConsumerCtxInterface for V8NotificationsCtx {
                     &on_trigger_fired,
                     &ctx_scope,
                     Some(&[&r_client.to_value(), &val]),
-                    GilStatus::Lock,
+                    GilStatus::Locked,
                 );
 
                 redis_client.borrow_mut().make_invalid();

--- a/redisgears_v8_plugin/src/v8_redisai.rs
+++ b/redisgears_v8_plugin/src/v8_redisai.rs
@@ -216,10 +216,10 @@ pub(crate) fn get_redisai_client<'isolate, 'isolate_scope>(
                             Ok(res) => {
                                 let values = res.into_iter().map(|v| get_js_tensor_from_tensor(&script_ctx_ref, &isolate_scope, &ctx_scope, v).to_value()).collect::<Vec<V8LocalValue>>();
                                 let res_js = isolate_scope.new_array(&values.iter().collect::<Vec<&V8LocalValue>>()).to_value();
-                                resolver.resolve(&ctx_scope, &res_js);
+                                script_ctx_ref.resolve(&resolver, &ctx_scope, &res_js);
                             }
                             Err(e) => {
-                                resolver.reject(&ctx_scope, &isolate_scope.new_string(e.get_msg()).to_value());
+                                script_ctx_ref.reject(&resolver, &ctx_scope, &isolate_scope.new_string(e.get_msg()).to_value());
                             }
                         }
 
@@ -299,10 +299,10 @@ pub(crate) fn get_redisai_client<'isolate, 'isolate_scope>(
                             Ok(res) => {
                                 let values = res.into_iter().map(|v| get_js_tensor_from_tensor(&script_ctx_ref, &isolate_scope, &ctx_scope, v).to_value()).collect::<Vec<V8LocalValue>>();
                                 let res_js = isolate_scope.new_array(&values.iter().collect::<Vec<&V8LocalValue>>()).to_value();
-                                resolver.resolve(&ctx_scope, &res_js);
+                                script_ctx_ref.resolve(&resolver, &ctx_scope, &res_js);
                             }
                             Err(e) => {
-                                resolver.reject(&ctx_scope, &isolate_scope.new_string(e.get_msg()).to_value());
+                                script_ctx_ref.reject(&resolver, &ctx_scope, &isolate_scope.new_string(e.get_msg()).to_value());
                             }
                         }
 

--- a/redisgears_v8_plugin/src/v8_script_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_script_ctx.rs
@@ -9,6 +9,13 @@ use redisgears_plugin_api::redisgears_plugin_api::{
     load_library_ctx::LoadLibraryCtxInterface, GearsApiError,
 };
 
+use v8_derive::new_native_function;
+use v8_rs::v8::isolate_scope::V8IsolateScope;
+use v8_rs::v8::v8_context_scope::V8ContextScope;
+use v8_rs::v8::v8_promise::V8LocalPromise;
+use v8_rs::v8::v8_resolver::V8LocalResolver;
+use v8_rs::v8::v8_script::V8LocalScript;
+use v8_rs::v8::v8_value::V8LocalValue;
 use v8_rs::v8::{
     isolate::V8Isolate, v8_context::V8Context, v8_object_template::V8PersistedObjectTemplate,
     v8_promise::V8PromiseState, v8_script::V8PersistedScript,
@@ -21,7 +28,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use crate::get_exception_msg;
+use crate::{get_error_from_object, get_exception_msg};
 
 pub(crate) enum GilState {
     Lock,
@@ -77,6 +84,20 @@ impl GilStateCtx {
     }
 }
 
+pub(crate) enum GilStatus {
+    Lock,
+    Unlock,
+}
+
+impl GilStatus {
+    pub(crate) fn is_locked(&self) -> bool {
+        match self {
+            GilStatus::Lock => true,
+            GilStatus::Unlock => true,
+        }
+    }
+}
+
 pub(crate) struct V8ScriptCtx {
     pub(crate) name: String,
     pub(crate) script: V8PersistedScript,
@@ -86,6 +107,12 @@ pub(crate) struct V8ScriptCtx {
     pub(crate) compiled_library_api: Box<dyn CompiledLibraryInterface + Send + Sync>,
     pub(crate) is_running: AtomicBool,
     pub(crate) lock_state: RefCellWrapper<GilStateCtx>,
+}
+
+pub(crate) struct OnDoneCtx<'isolate_scope, 'isolate, 'ctx_scope> {
+    pub(crate) isolate_scope: &'isolate_scope V8IsolateScope<'isolate>,
+    pub(crate) ctx_scope: &'ctx_scope V8ContextScope<'isolate_scope, 'isolate>,
+    pub(crate) res: V8LocalValue<'isolate_scope, 'isolate>,
 }
 
 impl V8ScriptCtx {
@@ -111,12 +138,12 @@ impl V8ScriptCtx {
         }
     }
 
-    pub(crate) fn before_run(&self) {
-        self.is_running.store(true, Ordering::Relaxed);
+    pub(crate) fn before_run(&self) -> bool {
+        self.is_running.swap(true, Ordering::Relaxed)
     }
 
-    pub(crate) fn after_run(&self) {
-        self.is_running.store(false, Ordering::Relaxed);
+    pub(crate) fn after_run(&self, val: bool) {
+        self.is_running.store(val, Ordering::Relaxed);
     }
 
     pub(crate) fn after_lock_gil(&self) {
@@ -131,7 +158,7 @@ impl V8ScriptCtx {
         self.lock_state.ref_cell.borrow().is_locked()
     }
 
-    pub(crate) fn git_lock_duration_ms(&self) -> u128 {
+    pub(crate) fn gil_lock_duration_ms(&self) -> u128 {
         self.lock_state.ref_cell.borrow().git_lock_duration_ms()
     }
 
@@ -141,6 +168,213 @@ impl V8ScriptCtx {
 
     pub(crate) fn is_lock_timedout(&self) -> bool {
         self.lock_state.ref_cell.borrow().is_lock_timedout()
+    }
+
+    /// The function calls the specified V8 function with the provided arguments.
+    /// It performs the necessary operations before and after invoking the function,
+    /// such as setting a variable to indicate that JavaScript code is currently running
+    /// or recording the time at which the GIL (Global Interpreter Lock) is locked for timeout support.
+    pub(crate) fn call<'isolate_scope, 'isolate>(
+        &self,
+        func: &V8LocalValue<'isolate_scope, 'isolate>,
+        ctx_scope: &V8ContextScope<'isolate_scope, 'isolate>,
+        args: Option<&[&V8LocalValue<'isolate_scope, 'isolate>]>,
+        gil_statuc: GilStatus,
+    ) -> Option<V8LocalValue<'isolate_scope, 'isolate>> {
+        let old_val = self.before_run();
+        if gil_statuc.is_locked() {
+            self.after_lock_gil();
+        }
+        let res = func.call(&ctx_scope, args);
+        if gil_statuc.is_locked() {
+            self.before_release_gil();
+        }
+        self.after_run(old_val);
+        res
+    }
+
+    /// The function calls the specified V8 script.
+    /// It performs the necessary operations before and after invoking the function,
+    /// such as setting a variable to indicate that JavaScript code is currently running
+    /// or recording the time at which the GIL (Global Interpreter Lock) is locked for timeout support.
+    pub(crate) fn run<'isolate_scope, 'isolate>(
+        &self,
+        script: &V8LocalScript<'isolate_scope, 'isolate>,
+        ctx_scope: &V8ContextScope<'isolate_scope, 'isolate>,
+        gil_statuc: GilStatus,
+    ) -> Option<V8LocalValue<'isolate_scope, 'isolate>> {
+        let old_val = self.before_run();
+        if gil_statuc.is_locked() {
+            self.after_lock_gil();
+        }
+        let res = script.run(&ctx_scope);
+        if gil_statuc.is_locked() {
+            self.before_release_gil();
+        }
+        self.after_run(old_val);
+        res
+    }
+
+    /// Resolve the given promise object with the given value.
+    /// It performs the necessary operations before and after invoking the function,
+    /// such as setting a variable to indicate that JavaScript code is currently running.
+    pub(crate) fn resolve(
+        &self,
+        resolver: &V8LocalResolver,
+        ctx_scope: &V8ContextScope,
+        val: &V8LocalValue,
+    ) {
+        let old_val = self.before_run();
+        resolver.resolve(ctx_scope, val);
+        self.after_run(old_val);
+    }
+
+    /// Reject the given promise object with the given value.
+    /// It performs the necessary operations before and after invoking the function,
+    /// such as setting a variable to indicate that JavaScript code is currently running.
+    pub(crate) fn reject(
+        &self,
+        resolver: &V8LocalResolver,
+        ctx_scope: &V8ContextScope,
+        val: &V8LocalValue,
+    ) {
+        let old_val = self.before_run();
+        resolver.reject(ctx_scope, val);
+        self.after_run(old_val);
+    }
+
+    /// Runs the given closure if the given promise obejct was already resolved or rejected.
+    fn run_on_done_promise<
+        'isolate_scope,
+        'isolate,
+        'ctx_scope,
+        T,
+        Done: FnOnce(Result<OnDoneCtx, GearsApiError>) -> T,
+    >(
+        &self,
+        isolate_scope: &'isolate_scope V8IsolateScope<'isolate>,
+        ctx_scope: &'ctx_scope V8ContextScope<'isolate_scope, 'isolate>,
+        promise: &V8LocalPromise<'isolate_scope, 'isolate>,
+        on_done: Done,
+    ) -> T {
+        let res = promise.get_result();
+        if promise.state() == V8PromiseState::Fulfilled {
+            return on_done(Ok(OnDoneCtx {
+                isolate_scope,
+                ctx_scope,
+                res,
+            }));
+        } else {
+            let error = get_error_from_object(&res, &ctx_scope);
+            return on_done(Err(error));
+        }
+    }
+
+    /// Return [`true`] if the given promise was already resolved or rejected, otherwise false.
+    fn is_reject_or_fulfilled(&self, promise: &V8LocalPromise) -> bool {
+        promise.state() == V8PromiseState::Fulfilled || promise.state() == V8PromiseState::Rejected
+    }
+
+    /// The function receives a promise and a closure as parameters,
+    /// and invokes the closure if the promise has already been resolved or rejected.
+    /// In such cases, the function returns Some(T),
+    /// where T represents the return value of the closure.
+    /// If the promise has neither been resolved nor rejected yet,
+    /// the function returns None.
+    pub(crate) fn promise_rejected_or_fulfilled<
+        'isolate_scope,
+        'isolate,
+        'ctx_scope,
+        T,
+        Done: FnOnce(Result<OnDoneCtx, GearsApiError>) -> T,
+    >(
+        &self,
+        isolate_scope: &'isolate_scope V8IsolateScope<'isolate>,
+        ctx_scope: &'ctx_scope V8ContextScope<'isolate_scope, 'isolate>,
+        promise: &V8LocalPromise<'isolate_scope, 'isolate>,
+        on_done: Done,
+    ) -> Option<T> {
+        if self.is_reject_or_fulfilled(promise) {
+            return Some(self.run_on_done_promise(isolate_scope, ctx_scope, promise, on_done));
+        }
+        None
+    }
+
+    /// The function receives a promise and a closure as arguments,
+    /// and assigns the closure as the resolve/reject callback of the promise,
+    /// assuming that the promise has not been resolved or rejected yet.
+    /// If the promise was already resolved or reject, the callback will be called
+    /// on the next V8 minor task cicle.
+    pub(crate) fn promise_rejected_or_fulfilled_async<
+        'isolate_scope,
+        'isolate,
+        'ctx_scope,
+        T,
+        Done: FnOnce(Result<OnDoneCtx, GearsApiError>) -> T,
+    >(
+        &self,
+        ctx_scope: &'ctx_scope V8ContextScope<'isolate_scope, 'isolate>,
+        promise: &V8LocalPromise<'isolate_scope, 'isolate>,
+        on_done: Done,
+    ) {
+        let on_done_resolve = Arc::new(RefCell::new(Some(on_done)));
+        let on_done_reject = Arc::clone(&on_done_resolve);
+        let on_done_dropped = Arc::clone(&on_done_resolve);
+        let resolve = ctx_scope.new_native_function(new_native_function!(
+            move |isolate_scope, ctx_scope, res: V8LocalValue| {
+                let mut on_done = on_done_resolve.borrow_mut();
+                on_done.take().map(|v| {
+                    v(Ok(OnDoneCtx {
+                        isolate_scope,
+                        ctx_scope,
+                        res,
+                    }));
+                });
+                Ok::<_, String>(None)
+            }
+        ));
+        let reject = ctx_scope.new_native_function(new_native_function!(
+            move |_isolate_scope, ctx_scope, res: V8LocalValue| {
+                let mut on_done = on_done_reject.borrow_mut();
+                on_done.take().map(|v| {
+                    v(Err(get_error_from_object(&res, ctx_scope)));
+                });
+                Ok::<_, String>(None)
+            }
+        ));
+        promise.then(&ctx_scope, &resolve, &reject);
+        promise.to_value().on_dropped(move || {
+            let mut on_done = on_done_dropped.borrow_mut();
+            on_done.take().map(|v| {
+                v(Err(GearsApiError::new("Promise was dropped without been resolved. Usually happened because of timeout or OOM.")));
+            });
+        });
+    }
+
+    /// The function accepts a promise object and a closure,
+    /// and invokes the closure when the promise is resolved.
+    /// This invocation occurs immediately if the promise is
+    /// already resolved or when it becomes resolved.
+    /// The closure receives a [`Result<V8LocalValue, GearsApiError>`] parameter,
+    /// which indicates whether the promise was successfully resolved or rejected.
+    pub(crate) fn handle_promise<
+        'isolate_scope,
+        'isolate,
+        'ctx_scope,
+        T,
+        Done: FnOnce(Result<OnDoneCtx, GearsApiError>) -> T,
+    >(
+        &self,
+        isolate_scope: &'isolate_scope V8IsolateScope<'isolate>,
+        ctx_scope: &'ctx_scope V8ContextScope<'isolate_scope, 'isolate>,
+        promise: &V8LocalPromise<'isolate_scope, 'isolate>,
+        on_done: Done,
+    ) -> Option<T> {
+        if self.is_reject_or_fulfilled(promise) {
+            return Some(self.run_on_done_promise(isolate_scope, ctx_scope, promise, on_done));
+        }
+        self.promise_rejected_or_fulfilled_async(ctx_scope, promise, on_done);
+        None
     }
 }
 
@@ -162,11 +396,7 @@ impl LibraryCtxInterface for V8LibraryCtx {
         // set private content
         let _load_library_guard = self.script_ctx.ctx.set_private_data(0, &load_library_ctx);
 
-        self.script_ctx.before_run();
-        self.script_ctx.after_lock_gil();
-        let res = script.run(&ctx_scope);
-        self.script_ctx.before_release_gil();
-        self.script_ctx.after_run();
+        let res = self.script_ctx.run(&script, &ctx_scope, GilStatus::Lock);
 
         let res =
             res.ok_or_else(|| get_exception_msg(&self.script_ctx.isolate, trycatch, &ctx_scope))?;

--- a/redisgears_v8_plugin/src/v8_stream_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_stream_ctx.rs
@@ -143,7 +143,7 @@ impl V8StreamCtxInternals {
             &self.persisted_function.as_local(&isolate_scope),
             &ctx_scope,
             Some(&[&r_client.to_value(), &stream_data.to_value()]),
-            GilStatus::Lock,
+            GilStatus::Locked,
         );
 
         redis_client.borrow_mut().make_invalid();
@@ -281,7 +281,7 @@ impl V8StreamCtxInternals {
                 &self.persisted_function.as_local(&isolate_scope),
                 &ctx_scope,
                 Some(&[&r_client.to_value(), &stream_data.to_value()]),
-                GilStatus::Unlock,
+                GilStatus::Unlocked,
             );
 
             match res {

--- a/redisgears_v8_plugin/src/v8_stream_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_stream_ctx.rs
@@ -5,7 +5,7 @@
  */
 
 use redisgears_plugin_api::redisgears_plugin_api::GearsApiError;
-use v8_rs::v8::{v8_promise::V8PromiseState, v8_value::V8LocalValue, v8_value::V8PersistValue};
+use v8_rs::v8::{v8_value::V8LocalValue, v8_value::V8PersistValue};
 
 use redisgears_plugin_api::redisgears_plugin_api::stream_ctx::{
     StreamCtxInterface, StreamProcessCtxInterface, StreamRecordAck, StreamRecordInterface,
@@ -15,20 +15,14 @@ use redisgears_plugin_api::redisgears_plugin_api::run_function_ctx::BackgroundRu
 
 use crate::v8_backend::bypass_memory_limit;
 use crate::v8_native_functions::{get_backgrounnd_client, get_redis_client, RedisClient};
-use crate::v8_script_ctx::V8ScriptCtx;
+use crate::v8_script_ctx::{GilStatus, V8ScriptCtx};
 
 use std::cell::RefCell;
 use std::sync::Arc;
 
 use std::str;
 
-use v8_derive::new_native_function;
-
-use crate::{get_error_from_object, get_exception_msg};
-
-struct V8StreamAckCtx {
-    ack: Option<Box<dyn FnOnce(StreamRecordAck) + Send>>,
-}
+use crate::get_exception_msg;
 
 struct V8StreamCtxInternals {
     persisted_function: V8PersistValue,
@@ -63,6 +57,7 @@ impl V8StreamCtxInternals {
         stream_name: &[u8],
         record: Box<dyn StreamRecordInterface>,
         run_ctx: &dyn StreamProcessCtxInterface,
+        ack_callback: Box<dyn FnOnce(StreamRecordAck) + Send>,
     ) -> Option<StreamRecordAck> {
         let isolate_scope = self.script_ctx.isolate.enter();
         let ctx_scope = self.script_ctx.ctx.enter(&isolate_scope);
@@ -144,21 +139,50 @@ impl V8StreamCtxInternals {
 
         let _block_guard = ctx_scope.set_private_data(0, &true); // indicate we are blocked
 
-        self.script_ctx.before_run();
-        self.script_ctx.after_lock_gil();
-        let res = self.persisted_function.as_local(&isolate_scope).call(
+        let res = self.script_ctx.call(
+            &self.persisted_function.as_local(&isolate_scope),
             &ctx_scope,
             Some(&[&r_client.to_value(), &stream_data.to_value()]),
+            GilStatus::Lock,
         );
-        self.script_ctx.before_release_gil();
-        self.script_ctx.after_run();
 
         redis_client.borrow_mut().make_invalid();
 
         Some(match res {
-            Some(_) => StreamRecordAck::Ack,
+            Some(res) => {
+                if res.is_promise() {
+                    let promise = res.as_promise();
+                    return self
+                        .script_ctx
+                        .promise_rejected_or_fulfilled(
+                            &isolate_scope,
+                            &ctx_scope,
+                            &promise,
+                            move |res| {
+                                Some(res.map_or_else(
+                                    |e| StreamRecordAck::Nack(e),
+                                    |_| StreamRecordAck::Ack,
+                                ))
+                            },
+                        )
+                        .unwrap_or_else(|| {
+                            self.script_ctx.promise_rejected_or_fulfilled_async(
+                                &ctx_scope,
+                                &promise,
+                                move |res| {
+                                    ack_callback(res.map_or_else(
+                                        |e| StreamRecordAck::Nack(e),
+                                        |_| StreamRecordAck::Ack,
+                                    ));
+                                },
+                            );
+                            None
+                        });
+                } else {
+                    StreamRecordAck::Ack
+                }
+            }
             None => {
-                // todo: handle promise
                 let error_msg = get_exception_msg(&self.script_ctx.isolate, trycatch, &ctx_scope);
                 StreamRecordAck::Nack(error_msg)
             }
@@ -172,9 +196,6 @@ impl V8StreamCtxInternals {
         redis_client: Box<dyn BackgroundRunFunctionCtxInterface>,
         ack_callback: Box<dyn FnOnce(StreamRecordAck) + Send>,
     ) {
-        let ack_callback = Arc::new(RefCell::new(V8StreamAckCtx {
-            ack: Some(ack_callback),
-        }));
         let res = {
             let isolate_scope = self.script_ctx.isolate.enter();
             let ctx_scope = self.script_ctx.ctx.enter(&isolate_scope);
@@ -256,54 +277,35 @@ impl V8StreamCtxInternals {
                 Arc::new(redis_client),
             );
 
-            self.script_ctx.before_run();
-            let res = self.persisted_function.as_local(&isolate_scope).call(
+            let res = self.script_ctx.call(
+                &self.persisted_function.as_local(&isolate_scope),
                 &ctx_scope,
                 Some(&[&r_client.to_value(), &stream_data.to_value()]),
+                GilStatus::Unlock,
             );
-            self.script_ctx.after_run();
 
             match res {
                 Some(res) => {
                     if res.is_promise() {
-                        let res = res.as_promise();
-                        if res.state() == V8PromiseState::Rejected {
-                            let res = res.get_result();
-                            let error = get_error_from_object(&res, &ctx_scope);
-                            Some(StreamRecordAck::Nack(error))
-                        } else if res.state() == V8PromiseState::Fulfilled {
-                            Some(StreamRecordAck::Ack)
-                        } else {
-                            let ack_callback_resolve = Arc::clone(&ack_callback);
-                            let ack_callback_reject = Arc::clone(&ack_callback);
-                            let resolve =
-                                ctx_scope.new_native_function(move |_args, isolate, _context| {
-                                    let _unlocker = isolate.new_unlocker();
-                                    if let Some(ack) = ack_callback_resolve.borrow_mut().ack.take()
-                                    {
-                                        ack(StreamRecordAck::Ack);
-                                    }
-                                    None
-                                });
-                            let reject = ctx_scope.new_native_function(new_native_function!(
-                                move |isolate, ctx_scope, res: V8LocalValue| {
-                                    let error = get_error_from_object(&res, ctx_scope);
-                                    let _unlocker = isolate.new_unlocker();
-                                    if let Some(ack) = ack_callback_reject.borrow_mut().ack.take() {
-                                        ack(StreamRecordAck::Nack(error));
-                                    }
-                                    Ok::<_, String>(None)
-                                }
-                            ));
-                            res.then(&ctx_scope, &resolve, &reject);
-                            None
-                        }
+                        self.script_ctx.handle_promise(
+                            &isolate_scope,
+                            &ctx_scope,
+                            &res.as_promise(),
+                            move |res| {
+                                let _unlocker =
+                                    res.as_ref().map(|v| v.isolate_scope.new_unlocker());
+                                ack_callback(res.map_or_else(
+                                    |e| StreamRecordAck::Nack(e),
+                                    |_| StreamRecordAck::Ack,
+                                ));
+                            },
+                        );
+                        return;
                     } else {
                         Some(StreamRecordAck::Ack)
                     }
                 }
                 None => {
-                    // todo: hanlde promise
                     let error_msg =
                         get_exception_msg(&self.script_ctx.isolate, trycatch, &ctx_scope);
                     Some(StreamRecordAck::Nack(error_msg))
@@ -312,9 +314,7 @@ impl V8StreamCtxInternals {
         };
 
         if let Some(r) = res {
-            if let Some(ack) = ack_callback.borrow_mut().ack.take() {
-                ack(r);
-            }
+            ack_callback(r);
         }
     }
 }
@@ -350,7 +350,7 @@ impl StreamCtxInterface for V8StreamCtx {
             None
         } else {
             self.internals
-                .process_record_internal_sync(stream_name, record, run_ctx)
+                .process_record_internal_sync(stream_name, record, run_ctx, ack_callback)
         }
     }
 }


### PR DESCRIPTION
The pull request (PR) introduces support for handling fatal errors in async functions. One of the primary challenges with async functions and fatal errors is that the callback set on the async function's future object will not be invoked if the async function encounters a fatal error, such as a timeout or an out-of-memory (OOM) condition. In such cases, the only way to resolve the promise is by registering a callback that will be triggered when the promise object is garbage collected. This is when an error can be returned to the user.

The PR also includes a comprehensive rearrangement of the JavaScript (JS) code invocation and promise handling. This is achieved through three key code refactoring steps:

1. Any invocation of JS code is performed using the `script_ctx` object, which utilizes the `call` and `run` functions. The `call` function is used for invoking JS functions, while `run` is used for running scripts. These functions handle the necessary tasks before and after executing JS code to ensure the proper functioning of timeout and OOM mechanisms.

2. Resolving or rejecting promises also goes through the `script_ctx` object, utilizing the `resolve` and `reject` functions. These functions handle the required tasks before and after executing JS code since resolving or rejecting a promise may involve the execution of JS code.

3. Setting promise handlers is achieved through a set of functions on the `script_ctx` object. These functions handle the checking of whether the promise has already been resolved or rejected. If so, the `on_done` closure is immediately called. Otherwise, the `on_done` closure is set as the resolver or rejecter for the promise object.

The third point primarily focuses on code organization and maintainability, reducing a significant amount of code duplication in promise handling.

The pull request (PR) also introduces two new debug commands:

1. `request_v8_gc_for_debugging`: This command forcibly triggers a JavaScript garbage collection (GC) for debugging purposes. It is intended to assist with debugging and analyzing memory-related issues.

2. `avoid_global_allow_list`: By using this command, the allow list for registering a function is bypassed. This is particularly useful when `--expose_gc` is used, which adds the `gc` global object that is not included in our allow list. Although the `gc` object is not allowed in our normal operations, it is necessary for debugging and testing purposes.

These new debug commands enhance the debugging capabilities and provide more flexibility for testing scenarios, allowing for better analysis and resolution of issues.