### PR TITLE
Avoid --fail-fast on benchmarks. Include tags triggering

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -2,10 +2,18 @@ name: Run nightly CI benchmarks
 
 on:
   push:
-    branches:
-      - master
-      - 2.0
-
+      paths-ignore:
+          - '.circleci/**'
+          - 'docs/**'
+          - '*.md'
+      branches:
+          - main
+          - master
+          - '[2-9].[0-9].[0-9]'
+          - '[2-9].[0-9]'
+      tags:
+          - 'v[2-9].[0-9].[0-9]-rc[0-9]+'
+          - 'v[2-9].[0-9].[0-9]-m[0-9]+'
   workflow_dispatch:
 
   schedule:
@@ -56,7 +64,6 @@ jobs:
           --upload_results_s3 \
           --triggering_env circleci \
           --continue-on-module-check-error \
-          --fail_fast \
           --push_results_redistimeseries \
           --redistimeseries_host ${{ secrets.PERFORMANCE_RTS_HOST }} \
           --redistimeseries_port ${{ secrets.PERFORMANCE_RTS_PORT }} \

--- a/.github/workflows/trigger-benchmark.yml
+++ b/.github/workflows/trigger-benchmark.yml
@@ -54,7 +54,6 @@ jobs:
           --continue-on-module-check-error \
           --upload_results_s3 \
           --triggering_env circleci \
-          --fail_fast \
           --push_results_redistimeseries \
           --redistimeseries_host ${{ secrets.PERFORMANCE_RTS_HOST }} \
           --redistimeseries_port ${{ secrets.PERFORMANCE_RTS_PORT }} \


### PR DESCRIPTION
With `--fail-fast` mode we stop all benchmarks at the first error. Given the benchmark suite of RedisGears is quite simple I suggest we remove this and let the benchmark tool to try to trigger other benchmarks even in the case of some failure. In that manner we'll at least have partial performance data and logs to analyze what happened and confirm if it's test related or env/tool related.