### PR TITLE
Added execution mode parameter run `run` function.

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -181,7 +181,7 @@ Trying to run more than one function in the same execution will fail with an err
 
 **Python API**
 ```python
-class GearsBuilder.run(arg=None, convertToStr=True, collect=True)
+class GearsBuilder.run(arg=None, convertToStr=True, collect=True, mode='async')
 ```
 
 _Arguments_
@@ -192,6 +192,9 @@ _Arguments_
     * A Python generator for the [PythonReader](readers.md#pythonreader) reader
 * _convertToStr_: when `True` adds a [map](operations.md#map) operation to the flow's end that converts records to strings
 * _collect_: when `True` adds a [collect](operations.md#collect) operation to flow's end
+* _mode_: the execution mode of the function. Can be one of (notice that unlike register, `sync` is not supported on `run`):
+    * **'async'**: execution will be asynchronous across the entire cluster
+    * **'async_local'**: execution will be asynchronous and restricted to the handling shard
 
 **Examples**
 ```python

--- a/plugins/jvmplugin/gears_runtime/pom.xml
+++ b/plugins/jvmplugin/gears_runtime/pom.xml
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.13.0</version>
+			<version>2.15.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.13.0</version>
+			<version>2.15.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.2.1</version>
+			<version>2.15.2</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/pytest/test_basics.py
+++ b/pytest/test_basics.py
@@ -863,3 +863,7 @@ def testKeysReaderCommandsOptionWithAsyncExecution(env):
     env.expect('RG.PYEXECUTE', "GearsBuilder().foreach(lambda x: override_reply('-no allowed')).register(commands=['set'])").equal('OK')
     env.expect('set', 'x', '1').error().equal('no allowed')
     env.expect('RG.PYEXECUTE', "GearsBuilder('ShardsIDReader').map(lambda x: execute('ping')).run()").equal([['PONG'], []])
+
+@gearsTest()
+def testExecutionModeOnRun(env):
+    env.expect('RG.PYEXECUTE', "GearsBuilder('ShardsIDReader').count().run(mode='async_local')").equal([['1'], []])

--- a/src/execution_plan.c
+++ b/src/execution_plan.c
@@ -3135,7 +3135,7 @@ void FlatExecutionPlan_Register(SessionRegistrationCtx *srctx){
 }
 
 ExecutionPlan* FlatExecutionPlan_Run(FlatExecutionPlan* fep, ExecutionMode mode, void* arg, RedisGears_OnExecutionDoneCallback callback, void* privateData, WorkerData* worker, char** err, RunFlags runFlags){
-    if(Cluster_IsClusterMode()){
+    if(mode == ExecutionModeAsync && Cluster_IsClusterMode()){
         // on cluster mode, we must make sure we can distribute the execution to all shards.
         if(!FlatExecutionPlan_SerializeInternal(fep, NULL, err)){
             return NULL;


### PR DESCRIPTION
The PR add `mode` parameter to run function that can be one of the following:
* **'async'**: execution will be asynchronous across the entire cluster
* **'async_local'**: execution will be asynchronous and restricted to the handling shard

In addition, the PR updates the jackson dependency on jvm plugin to 2.15.2.