### PR TITLE
Respect avoid replication traffic indication.

### DIFF
--- a/pytests/test_basics.py
+++ b/pytests/test_basics.py
@@ -976,3 +976,22 @@ redis.registerFunction("n_notifications", ()=>{return n_notifications;}, {flags:
     env.expect('replicaof', 'localhost', '1111').equal('OK')
     env.cmd('get', 'x') # should trigger key miss notification but we should not count it because we are a replica
     env.expectTfcall('lib', 'n_notifications').equal(1)
+
+@gearsTest()
+def testAvoidReplicationTrafficOnAsyncFunction(env):
+    """#!js api_version=1.0 name=lib
+var n_notifications = 0;
+redis.registerAsyncFunction("test",
+    async (client) => {
+        while (true) {
+            client.block((c)=>{
+                c.call('incr', 'x');
+            });
+        }
+    }
+);
+    """
+    future = env.noBlockingTfcallAsync('lib', 'test')
+    runUntil(env, True, lambda: int(env.cmd('get', 'x')) > 2)
+    env.expect('CLIENT', 'PAUSE', '1000', 'all').equal('OK')
+    future.expectError('Can not lock redis for write')

--- a/pytests/test_stream_reader.py
+++ b/pytests/test_stream_reader.py
@@ -544,3 +544,38 @@ redis.registerStreamTrigger("consumer", "stream",
     env.assertEqual(2, res)
 
     env.cmd('slaveof', 'no', 'one')
+
+@gearsTest()
+def testStreamReaderOnAvoidReplicationTraffic(env):
+    """#!js api_version=1.0 name=lib
+var promise = null;
+
+// we need a key space trigger to register on key miss event
+// and continue the run
+redis.registerKeySpaceTrigger("consumer", "",
+    function(){
+        if (promise == null || promise == 1) {
+            return "no data to processes";
+        }
+        promise("continue");
+        promise = 1;
+        return "OK";
+    }
+);
+
+redis.registerStreamTrigger("consumer", "stream",
+    async function(client) {
+        if (promise == null) {
+            await new Promise((resume, reject) => {
+                promise = resume;
+            });
+        }
+    }
+)
+    """
+    env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
+    env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
+    env.expect('CLIENT', 'PAUSE', '2000', 'write').equal('OK')
+    env.cmd('get', 'x')
+    conn = env.getResp3Connection()
+    runUntil(env, 2, lambda: conn.execute_command('TFUNCTION', 'LIST', 'vvv')[0]['stream_triggers'][0]['streams'][0]['total_record_processed'], timeout=5)

--- a/redisgears_core/src/background_run_ctx.rs
+++ b/redisgears_core/src/background_run_ctx.rs
@@ -159,7 +159,7 @@ impl BackgroundRunFunctionCtxInterface for BackgroundRunCtx {
         let detached_ctx_guard = redis_module::MODULE_CONTEXT.lock();
         if !verify_ok_on_replica(&detached_ctx_guard, self.call_options.flags) {
             return Err(GearsApiError::new(
-                "Can not lock redis for write on replica".to_string(),
+                "Can not lock redis for write on replica or when avoid replication traffic is requested".to_string(),
             ));
         }
         if !verify_oom(&detached_ctx_guard, self.call_options.flags) {

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -505,6 +505,7 @@ struct GlobalCtx {
     allow_unsafe_redis_commands: bool,
     db_policy: DbPolicy,
     future_handlers: HashMap<String, Vec<Weak<RedisGILGuard<FutureHandlerContext>>>>,
+    avoid_replication_traffic: bool,
 }
 
 static mut GLOBALS: Option<GlobalCtx> = None;
@@ -922,8 +923,11 @@ fn js_init(ctx: &Context, _args: &[RedisString]) -> Status {
         stream_ctx: StreamReaderCtx::new(
             Box::new(|ctx, key, id, include_id| {
                 // read data from the stream
-                if !is_master(ctx) {
-                    return Err("Can not read data on replica".to_string());
+                if !is_master(ctx) || ctx.avoid_replication_traffic() {
+                    return Err(
+                        "Can not read data on replica or if avoid replication traffic is enabled"
+                            .to_string(),
+                    );
                 }
                 let stream_name = ctx.create_string(key);
                 let key = ctx.open_key(&stream_name);
@@ -969,6 +973,7 @@ fn js_init(ctx: &Context, _args: &[RedisString]) -> Status {
         allow_unsafe_redis_commands: false,
         db_policy: get_db_policy(ctx),
         future_handlers: HashMap::new(),
+        avoid_replication_traffic: false,
     };
 
     unsafe { GLOBALS = Some(global_ctx) };
@@ -1000,8 +1005,10 @@ pub(crate) fn is_master(ctx: &Context) -> bool {
 /// Returns `true` if the function with the specified flags is allowed
 /// to run on replicas in case the current instance is a replica.
 pub(crate) fn verify_ok_on_replica(ctx: &Context, flags: FunctionFlags) -> bool {
-    // master which is not readonly, ok to run || we can run function with no writes on replica.
-    (ctx.get_flags().contains(ContextFlags::MASTER) && !get_globals().db_policy.is_readonly())
+    // master which is not readonly and avoid replication traffic was not requested, ok to run || we can run function with no writes anyhow.
+    (ctx.get_flags().contains(ContextFlags::MASTER)
+        && !get_globals().db_policy.is_readonly()
+        && !ctx.avoid_replication_traffic())
         || flags.contains(FunctionFlags::NO_WRITES)
 }
 
@@ -1034,7 +1041,7 @@ fn function_call_command(
 
     if !verify_ok_on_replica(ctx, function.flags) {
         return Err(RedisError::Str(
-            "Err can not run a function that might perform writes on a replica",
+            "Err can not run a function that might perform writes on a replica or when avoid replication traffic is requested",
         ));
     }
 
@@ -1226,8 +1233,8 @@ fn scan_key_space_for_streams(ctx: &Context) {
 }
 
 #[role_changed_event_handler]
-fn on_role_changed(ctx: &Context, role_changed: ServerRole) {
-    if let ServerRole::Primary = role_changed {
+fn on_role_changed(ctx: &Context, _role_changed: ServerRole) {
+    if is_master(ctx) {
         ctx.log_notice("Role changed to primary, initializing key scan to search for streams.");
         scan_key_space_for_streams(ctx);
     } else {
@@ -1303,7 +1310,7 @@ fn on_config_change(ctx: &Context, values: &[&str]) {
 /// Will be called by Redis to execute some repeated tasks.
 /// Currently we will clean future handlers that has been finised.
 #[cron_event_handler]
-fn cron_event_handler(_ctx: &Context, _hz: u64) {
+fn cron_event_handler(ctx: &Context, _hz: u64) {
     let globals = get_globals_mut();
     globals.future_handlers = globals
         .future_handlers
@@ -1322,6 +1329,15 @@ fn cron_event_handler(_ctx: &Context, _hz: u64) {
             Some((k, res))
         })
         .collect();
+
+    if globals.avoid_replication_traffic && !ctx.avoid_replication_traffic() {
+        // avoid replication traffic was turned off, lets reinitiate stream processing.
+        if is_master(ctx) {
+            ctx.log_notice("Avoid replication traffic was disabled, initializing key scan to search for streams.");
+            scan_key_space_for_streams(ctx);
+        }
+    }
+    globals.avoid_replication_traffic = ctx.avoid_replication_traffic();
 }
 
 pub(crate) fn verify_name(name: &str) -> Result<(), String> {


### PR DESCRIPTION
Fixes #988.

The PR adds support for avoid replication traffic. If Redis requests to avoid replication traffic we should do the following:

1. Not allow locking Redis for Writes from within a async function
2. Stop processing stream record.

Notice that we do not stop processing key space notifications, this can be a violation of the atomic contruct. The key space notification should stop because the clients should be paused in this situations.