### PR TITLE
Fix wrong mutable borrow on refcell.

### DIFF
--- a/redisgears_v8_plugin/src/v8_script_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_script_ctx.rs
@@ -305,7 +305,7 @@ impl V8ScriptCtx {
     }
 
     /// Return [`true`] if the given promise was already resolved or rejected, otherwise false.
-    fn is_reject_or_fulfilled(&self, promise: &V8LocalPromise) -> bool {
+    pub(crate) fn is_reject_or_fulfilled(&self, promise: &V8LocalPromise) -> bool {
         promise.state() == V8PromiseState::Fulfilled || promise.state() == V8PromiseState::Rejected
     }
 


### PR DESCRIPTION
Fix crash on wrong mutable borrow on refcell: https://app.circleci.com/pipelines/github/RedisGears/RedisGears/4479/workflows/cdeb1ff7-6918-47cd-81ab-02661be041f5/jobs/12005

```
2124:M 18 Jul 2023 12:06:51.465 # <redisgears_2> Application panicked, panicked at 'already borrowed: BorrowMutError', redisgears_core/src/keys_notifications.rs:118:48
```

The crash happened because the stats data of the key space notification are protected by the Redis GIL. So each time, before updating the stats, we must make sure the Redis GIL is held. This was violated on the ack callback in case we call it from a background promise resolving, the caller in this case did not lock the GIL before calling the ack callback.

This PR fixes the violation but in general this is very fragile and should be fixed and a more robust way that will prevent such mistakes in the future. Open an issue to remove all usages of `refcell` and use `RedisGILGuard` instead which better guard object protected by GIL and does not allow to touch them without providing a `RedisLockIndicator`