### PR TITLE
Fix crash on benchmark when running with V8 main branch.

### DIFF
--- a/.github/workflows/branch_merge-benchmark.yml
+++ b/.github/workflows/branch_merge-benchmark.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build release
-      run: cargo build --release --verbose
+      run: cargo build --release -vv
 
     - name: Install terraform
       env:

--- a/.github/workflows/nightly-benchmark-v8-plugin-main.yml
+++ b/.github/workflows/nightly-benchmark-v8-plugin-main.yml
@@ -23,7 +23,7 @@ jobs:
       env:
         V8_VERSION: main
         V8_UPDATE_HEADERS: "yes"
-      run: cargo build --release --verbose
+      run: cargo build --release -vv
 
     - name: Install terraform
       env:

--- a/.github/workflows/trigger-benchmark.yml
+++ b/.github/workflows/trigger-benchmark.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build release
-      run: cargo build --release --verbose
+      run: cargo build --release -vv
 
     - name: Install terraform
       env:

--- a/dockerbuilds/build_and_test.incl
+++ b/dockerbuilds/build_and_test.incl
@@ -14,13 +14,13 @@ RUN sh install_rust.sh -y --default-toolchain={{ MSRV }}
 {% else %}
 RUN sh install_rust.sh -y
 {% endif %}
-RUN bash -l -c "$HOME/.cargo/bin/cargo build --verbose"
-RUN bash -l -c "$HOME/.cargo/bin/cargo build --release --verbose"
+RUN bash -l -c "$HOME/.cargo/bin/cargo build -vv"
+RUN bash -l -c "$HOME/.cargo/bin/cargo build --release -vv"
 
-RUN bash -l -c "$HOME/.cargo/bin/cargo test --verbose"
+RUN bash -l -c "$HOME/.cargo/bin/cargo test -vv"
 
 WORKDIR /build/pytests
-RUN ./run_tests.sh
+RUN ./run_tests.sh -t test_errors:testJSStackOverflow -s
 
 WORKDIR /build
 RUN bash -l -c "target/release/packer"

--- a/dockerbuilds/build_and_test.incl
+++ b/dockerbuilds/build_and_test.incl
@@ -20,7 +20,7 @@ RUN bash -l -c "$HOME/.cargo/bin/cargo build --release -vv"
 RUN bash -l -c "$HOME/.cargo/bin/cargo test -vv"
 
 WORKDIR /build/pytests
-RUN ./run_tests.sh -t test_errors:testJSStackOverflow -s
+RUN ./run_tests.sh
 
 WORKDIR /build
 RUN bash -l -c "target/release/packer"

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -913,10 +913,7 @@ fn js_init(ctx: &Context, _args: &[RedisString]) -> Status {
             return Status::Err;
         }
     };
-    let v8_flags: String = V8_FLAGS.lock(ctx).to_owned();
-    let on_load_res = v8_backend.on_load(&LoadingCtx {
-        get_v8_flags: Box::new(move || v8_flags.to_owned()),
-    });
+    let on_load_res = v8_backend.on_load(&LoadingCtx::new(V8_FLAGS.lock(ctx).to_owned()));
     if let Err(e) = on_load_res {
         log::error!("{e}");
         return Status::Err;

--- a/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
@@ -48,20 +48,7 @@ pub struct BackendCtx {
     pub get_v8_library_initial_memory: Box<dyn Fn() -> usize + 'static>,
     pub get_v8_library_initial_memory_limit: Box<dyn Fn() -> usize + 'static>,
     pub get_v8_library_memory_delta: Box<dyn Fn() -> usize + 'static>,
-}
-
-pub struct LoadingCtx {
-    v8_flags: String,
-}
-
-impl LoadingCtx {
-    pub fn new(v8_flags: String) -> LoadingCtx {
-        LoadingCtx { v8_flags }
-    }
-
-    pub fn get_v8_flags(&self) -> &str {
-        &self.v8_flags
-    }
+    pub get_v8_flags: Box<dyn Fn() -> String + 'static>,
 }
 
 /// The trait which is only implemented for a successfully initialised
@@ -88,12 +75,11 @@ pub trait BackendCtxInterfaceUninitialised {
     /// on loading phase. The backend should only perform the minimal
     /// needed operation and should avoid any resources allocation
     /// like thread or network.
-    fn on_load(&self, on_load_ctx: &LoadingCtx) -> Result<(), GearsApiError>;
+    fn on_load(&self, backend_ctx: BackendCtx) -> Result<(), GearsApiError>;
 
     /// Initialises the backend with the information passed and returns
     /// a successfully initialised instance.
     fn initialize(
         self: Box<Self>,
-        backend_ctx_info: BackendCtx,
     ) -> Result<Box<dyn BackendCtxInterfaceInitialised>, GearsApiError>;
 }

--- a/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
@@ -51,7 +51,17 @@ pub struct BackendCtx {
 }
 
 pub struct LoadingCtx {
-    pub get_v8_flags: Box<dyn Fn() -> String>,
+    v8_flags: String,
+}
+
+impl LoadingCtx {
+    pub fn new(v8_flags: String) -> LoadingCtx {
+        LoadingCtx { v8_flags }
+    }
+
+    pub fn get_v8_flags(&self) -> &str {
+        &self.v8_flags
+    }
 }
 
 /// The trait which is only implemented for a successfully initialised

--- a/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
@@ -48,6 +48,9 @@ pub struct BackendCtx {
     pub get_v8_library_initial_memory: Box<dyn Fn() -> usize + 'static>,
     pub get_v8_library_initial_memory_limit: Box<dyn Fn() -> usize + 'static>,
     pub get_v8_library_memory_delta: Box<dyn Fn() -> usize + 'static>,
+}
+
+pub struct LoadingCtx {
     pub get_v8_flags: Box<dyn Fn() -> String>,
 }
 
@@ -69,6 +72,13 @@ pub trait BackendCtxInterfaceInitialised {
 pub trait BackendCtxInterfaceUninitialised {
     /// Returns the name of the backend.
     fn get_name(&self) -> &'static str;
+
+    /// This callback will be called on loading phase to allow
+    /// the backend to perform minimal operation that must be done
+    /// on loading phase. The backend should only perform the minimal
+    /// needed operation and should avoid any resources allocation
+    /// like thread or network.
+    fn on_load(&self, on_load_ctx: &LoadingCtx) -> Result<(), GearsApiError>;
 
     /// Initialises the backend with the information passed and returns
     /// a successfully initialised instance.

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -8,9 +8,7 @@ use bitflags::bitflags;
 use redis_module::redisvalue::RedisValueKey;
 use redis_module::RedisValue;
 use redisgears_macros_internals::get_allow_deny_lists;
-use redisgears_plugin_api::redisgears_plugin_api::backend_ctx::{
-    BackendCtxInterfaceInitialised, LoadingCtx,
-};
+use redisgears_plugin_api::redisgears_plugin_api::backend_ctx::BackendCtxInterfaceInitialised;
 use redisgears_plugin_api::redisgears_plugin_api::prologue::ApiVersion;
 use redisgears_plugin_api::redisgears_plugin_api::{
     backend_ctx::BackendCtx, backend_ctx::BackendCtxInterfaceUninitialised,
@@ -266,6 +264,14 @@ pub(crate) fn get_global_option() -> GlobalOptions {
     unsafe { &GLOBAL }.global_options
 }
 
+/// Get the given globals option.
+pub(crate) fn get_v8_flags() -> String {
+    unsafe { &GLOBAL }
+        .backend_ctx
+        .as_ref()
+        .map_or_else(|| "".to_owned(), |v| (v.get_v8_flags)())
+}
+
 /// Return the delta by which we should increase
 /// an isolate memory limit, as long as the max
 /// memory did not yet reached.
@@ -435,20 +441,7 @@ impl BackendCtxInterfaceUninitialised for V8Backend {
         "js"
     }
 
-    fn on_load(&self, on_load_ctx: &LoadingCtx) -> Result<(), GearsApiError> {
-        let flags = on_load_ctx.get_v8_flags();
-        let flags = if flags.starts_with("'") && flags.len() > 1 {
-            &flags[1..flags.len() - 1]
-        } else {
-            &flags
-        };
-        v8_init_platform(1, Some(flags)).map_err(GearsApiError::new)
-    }
-
-    fn initialize(
-        self: Box<Self>,
-        backend_ctx: BackendCtx,
-    ) -> Result<Box<dyn BackendCtxInterfaceInitialised>, GearsApiError> {
+    fn on_load(&self, backend_ctx: BackendCtx) -> Result<(), GearsApiError> {
         unsafe {
             GLOBAL.backend_ctx = Some(backend_ctx);
             GLOBAL.bypassed_memory_limit = Some(AtomicBool::new(false));
@@ -471,6 +464,19 @@ impl BackendCtxInterfaceUninitialised for V8Backend {
             }
         }));
 
+        let flags = get_v8_flags();
+        let flags = if flags.starts_with("'") && flags.len() > 1 {
+            &flags[1..flags.len() - 1]
+        } else {
+            &flags
+        };
+
+        v8_init_platform(1, Some(flags)).map_err(GearsApiError::new)
+    }
+
+    fn initialize(
+        self: Box<Self>,
+    ) -> Result<Box<dyn BackendCtxInterfaceInitialised>, GearsApiError> {
         self.initialize_v8_engine()?;
         self.spawn_background_maintenance_thread()?;
 

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -436,7 +436,7 @@ impl BackendCtxInterfaceUninitialised for V8Backend {
     }
 
     fn on_load(&self, on_load_ctx: &LoadingCtx) -> Result<(), GearsApiError> {
-        let flags = (on_load_ctx.get_v8_flags)();
+        let flags = on_load_ctx.get_v8_flags();
         let flags = if flags.starts_with("'") && flags.len() > 1 {
             &flags[1..flags.len() - 1]
         } else {


### PR DESCRIPTION
The crash started to happened since we merge this PR: https://github.com/RedisGears/RedisGears/pull/973

The purpose of the PR was to initialise the V8 backend lazy only when needed. A side effect was that the V8 might have been initialises on some other thread which are not the main thread. Unfortunately, the V8 platform must be initialised on the main thread (for some reason that I yet been able to understand) and this causes the crash.

The fix is to perform minimal initialisation steps on load time and leave the heavy V8 initialisation processes for the first time its been used. To achieve this, the PR adds a new `on_load` backend interface to `V8Backend` that will be called on loading time and allow the V8 backend to only initialise the platforms.

Depends on: https://github.com/RedisGears/v8-rs/pull/45