### PR TITLE
Fix #1000, trim stream on post execution job.

### DIFF
--- a/pytests/test_stream_reader.py
+++ b/pytests/test_stream_reader.py
@@ -94,6 +94,28 @@ redis.registerStreamTrigger("consumer", "stream",
     env.expect('xlen', 'stream:1').equal(0)
     env.expectTfcall('lib', 'num_events').equal(2)
 
+@gearsTest(withReplicas=True)
+def testSyncStreamTrimWithReplica(env):
+    """#!js api_version=1.0 name=lib
+redis.registerStreamTrigger("consumer", "stream", 
+    function(){
+        return;
+    },
+    {
+        isStreamTrimmed: true
+    }
+);
+    """
+    slave_conn = env.getSlaveConnection()
+    env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
+    env.expect('xlen', 'stream:1').equal(0)
+    env.expect('WAIT', '1', '1000').equal(1)
+    env.assertEqual(slave_conn.execute_command('xlen', 'stream:1'), 0)
+    env.cmd('xadd', 'stream:1', '*', 'foo', 'bar')
+    env.expect('xlen', 'stream:1').equal(0)
+    env.expect('WAIT', '1', '1000').equal(1)
+    env.assertEqual(slave_conn.execute_command('xlen', 'stream:1'), 0)
+
 @gearsTest()
 def testStreamProccessError(env):
     """#!js api_version=1.0 name=lib

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -954,10 +954,10 @@ fn js_init(ctx: &Context, _args: &[RedisString]) -> Status {
                     ctx.log_warning("Attempt to trim data on replica was denied.");
                     return;
                 }
+                let stream_name = ctx.create_string(key_name);
                 // We need to run inside a post execution job to make sure the trim
                 // will happened last and will be replicated to the replica last.
                 ctx.add_post_notification_job(move |ctx| {
-                    let stream_name = ctx.create_string(key_name);
                     let key = ctx.open_key_writable(&stream_name);
                     let res = key.trim_stream_by_id(id, false);
                     if let Err(e) = res {
@@ -970,7 +970,7 @@ fn js_init(ctx: &Context, _args: &[RedisString]) -> Status {
                             ctx.ctx,
                             "xtrim",
                             &[
-                                key_name,
+                                stream_name.as_slice(),
                                 "MINID".as_bytes(),
                                 format!("{}-{}", id.ms, id.seq).as_bytes(),
                             ],


### PR DESCRIPTION
Fix #1000.

Trim the stream should be done on post execution job so we will make sure the trimming happeneds last. otherwise, we might perform the trimming on the key notification itself and this is not allow (we can not perform any write operation inside a key space notification callback, doing so can cause issues like replication reordering).