### PR TITLE
Fix #1005, avoid trigger key space notification inside function that trigger stream processing

### DIFF
--- a/pytests/test_notifications_consumers.py
+++ b/pytests/test_notifications_consumers.py
@@ -88,6 +88,22 @@ redis.registerFunction("simple_set", function(client){
     env.expectTfcallAsync('lib', 'n_notifications').equal(1)
 
 @gearsTest()
+def testNotificationsAreNotFiredFromWithinFunction2(env):
+    """#!js api_version=1.0 name=lib
+var n_notifications = 0;
+redis.registerKeySpaceTrigger("consumer", "", function(client, data) {
+    redis.log('inside key space trigger');
+    client.call('xadd', 's', '*', 'foo', 'bar');
+    client.call('set', 'x', '1'); // make sure this is not getting into infinit loop.
+});
+
+redis.registerStreamTrigger("stream", "", function(){
+    return 1
+});
+    """
+    env.expect('SET', 'X', '1').equal(True)
+
+@gearsTest()
 def testNotificationsAreNotFiredFromWithinAsyncFunction(env):
     """#!js api_version=1.0 name=lib
 var n_notifications = 0;

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -546,16 +546,21 @@ struct GlobalCtx {
 
 static mut GLOBALS: Option<GlobalCtx> = None;
 
-pub(crate) struct NotificationBlocker;
+pub(crate) struct NotificationBlocker {
+    old_val: bool,
+}
 
 pub(crate) fn get_notification_blocker() -> NotificationBlocker {
+    let res = NotificationBlocker {
+        old_val: get_globals_mut().avoid_key_space_notifications,
+    };
     get_globals_mut().avoid_key_space_notifications = true;
-    NotificationBlocker
+    res
 }
 
 impl Drop for NotificationBlocker {
     fn drop(&mut self) {
-        get_globals_mut().avoid_key_space_notifications = false;
+        get_globals_mut().avoid_key_space_notifications = self.old_val;
     }
 }
 


### PR DESCRIPTION
Fix #1005.

If a function trigger a stream processing by writing into a stream, when the stream processing code were done it would have reset the `NotificationBlocker` and so it would trigger notifications inside the function code.
To avoid that, the notification blocker will reset the value to the previous value that was set before.