### PR TITLE
Run stream trigger on post notificaiton job.

### DIFF
--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -1407,10 +1407,14 @@ fn on_stream_touched(ctx: &Context, _event_type: NotifyEvent, event: &str, key: 
     }
 }
 
-fn generic_notification(_ctx: &Context, _event_type: NotifyEvent, event: &str, key: &[u8]) {
+fn generic_notification(ctx: &Context, _event_type: NotifyEvent, event: &str, key: &[u8]) {
     if event == "del" {
-        let stream_ctx = &mut get_globals_mut().stream_ctx;
-        stream_ctx.on_stream_deleted(event, key);
+        let event = event.to_owned();
+        let key = key.to_vec();
+        ctx.add_post_notification_job(move |_ctx| {
+            let stream_ctx = &mut get_globals_mut().stream_ctx;
+            stream_ctx.on_stream_deleted(&event, &key);
+        });
     }
 }
 

--- a/redisgears_core/src/stream_reader.rs
+++ b/redisgears_core/src/stream_reader.rs
@@ -596,14 +596,18 @@ where
             .into_iter()
             .map(|res| {
                 if let Some((consumer_weak, record, consumer_info)) = res {
-                    send_new_data(
-                        ctx,
-                        Arc::clone(&tracked_stream),
-                        consumer_weak,
-                        record,
-                        consumer_info,
-                        Arc::clone(&self.stream_reader),
-                    );
+                    let stream_reader = Arc::clone(&self.stream_reader);
+                    let tracked_stream = Arc::clone(&tracked_stream);
+                    ctx.add_post_notification_job(move |ctx| {
+                        send_new_data(
+                            ctx,
+                            Arc::clone(&tracked_stream),
+                            consumer_weak,
+                            record,
+                            consumer_info,
+                            stream_reader,
+                        );
+                    });
                 }
             })
             .collect::<Vec<()>>();

--- a/redisgears_core/src/stream_reader.rs
+++ b/redisgears_core/src/stream_reader.rs
@@ -601,7 +601,7 @@ where
                     ctx.add_post_notification_job(move |ctx| {
                         send_new_data(
                             ctx,
-                            Arc::clone(&tracked_stream),
+                            tracked_stream,
                             consumer_weak,
                             record,
                             consumer_info,


### PR DESCRIPTION
Currently Stream trigger is invoke as part of the stream key space notification. One of Redis restrictions is that a module should not perform any write operation inside a key space notification callback. The PR moves the stream trigger invocation into a post notifications job so we will not violate the restriction. Without this fix we are getting a reordering of the replication order (the `xadd` command are replicated last).