### PR TITLE
Apply loading timeout on AOF and Replication stream.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,4 +20,4 @@ jobs:
             os_version: 22.04
             os_family: ubuntu
             dockerfile: dockerbuilds/dockerfile.debian.tmpl
-            msrv: 1.65.0
+            msrv: 1.67.0

--- a/docs/build_instructions.md
+++ b/docs/build_instructions.md
@@ -75,7 +75,7 @@ export PATH=/home/meir/.cargo/bin:$PATH
 ```
 
 #### MSRV (Minimally Supported Rust Version)
-Currently the edition 2021 of Rust language is used and the MSRV is `1.65`.
+Currently the edition 2021 of Rust language is used and the MSRV is `1.67`.
 
 ## Build_Release
 

--- a/docs/docs/Configuration.md
+++ b/docs/docs/Configuration.md
@@ -178,7 +178,7 @@ No
 The `lock-redis-timeout` configuration option controls the maximum amount of time (in MS) a library can lock Redis. Exceeding this limit is considered a fatal error and will be handled based on the [library-fatal-failure-policy](#library-fatal-failure-policy) configuration value. This
 configuration only affects library loading at runtime with `TFUNCTION LOAD`.
 The timeout for loading a library from RDB is set separately via
-[rdb-lock-redis-timeout](#rdb-lock-redis-timeout).
+[loading-lock-redis-timeout](#loading-lock-redis-timeout).
 
 
 _Expected Value_
@@ -204,11 +204,11 @@ Yes
 ### Side effects
 
 When setting `lock-redis-timeout`, if the new value is higher than the
-`rdb-lock-redis-timeout`, the `rdb-lock-redis-timeout` is also updated to
+`loading-lock-redis-timeout`, the `loading-lock-redis-timeout` is also updated to
 this value.
 
 
-## rdb-lock-redis-timeout
+## loading-lock-redis-timeout
 
 This timeout configuration is used for setting the upper time limit
 (in milliseconds) for the library loading from RDB.

--- a/docs/docs/Configuration.md
+++ b/docs/docs/Configuration.md
@@ -178,7 +178,7 @@ No
 The `lock-redis-timeout` configuration option controls the maximum amount of time (in MS) a library can lock Redis. Exceeding this limit is considered a fatal error and will be handled based on the [library-fatal-failure-policy](#library-fatal-failure-policy) configuration value. This
 configuration only affects library loading at runtime with `TFUNCTION LOAD`.
 The timeout for loading a library from RDB is set separately via
-[loading-lock-redis-timeout](#loading-lock-redis-timeout).
+[db-loading-lock-redis-timeout](#db-loading-lock-redis-timeout).
 
 
 _Expected Value_
@@ -204,11 +204,11 @@ Yes
 ### Side effects
 
 When setting `lock-redis-timeout`, if the new value is higher than the
-`loading-lock-redis-timeout`, the `loading-lock-redis-timeout` is also updated to
+`db-loading-lock-redis-timeout`, the `db-loading-lock-redis-timeout` is also updated to
 this value.
 
 
-## loading-lock-redis-timeout
+## db-loading-lock-redis-timeout
 
 This timeout configuration is used for setting the upper time limit
 (in milliseconds) for the library loading from RDB.

--- a/pytests/test_basics.py
+++ b/pytests/test_basics.py
@@ -587,10 +587,10 @@ while (true) {
     env.expectTfcall('lib', 'test1').equal("GOODJOB")
 
     # Now dump to RDB and load from there. This case makes sure the
-    # loading-lock-redis-timeout is used, by setting it to a minimal
+    # db-loading-lock-redis-timeout is used, by setting it to a minimal
     # possible value.
     env.expect('CONFIG', 'SET', f'{MODULE_NAME}.lock-redis-timeout', MINIMAL_TIMEOUT_MS).equal("OK")
-    env.expect('CONFIG', 'SET', f'{MODULE_NAME}.loading-lock-redis-timeout', MINIMAL_TIMEOUT_MS).equal("OK")
+    env.expect('CONFIG', 'SET', f'{MODULE_NAME}.db-loading-lock-redis-timeout', MINIMAL_TIMEOUT_MS).equal("OK")
     env.expect('debug', 'reload').equal("Error trying to load the RDB dump, check server logs.")
 
 @gearsTest(withReplicas=True)
@@ -631,13 +631,13 @@ while (true) {
 def testRdbTimeoutCantBeLessThanLoadTimeout(env):
     MINIMAL_TIMEOUT_MS = 100
 
-    env.expect('CONFIG', 'SET', f'{MODULE_NAME}.loading-lock-redis-timeout', MINIMAL_TIMEOUT_MS).contains("value can't be less than lock-redis-timeout")
+    env.expect('CONFIG', 'SET', f'{MODULE_NAME}.db-loading-lock-redis-timeout', MINIMAL_TIMEOUT_MS).contains("value can't be less than lock-redis-timeout")
     # 500 is the default for the lock-redis-timeout.
-    env.expect('CONFIG', 'SET', f'{MODULE_NAME}.loading-lock-redis-timeout', 501).equal("OK")
+    env.expect('CONFIG', 'SET', f'{MODULE_NAME}.db-loading-lock-redis-timeout', 501).equal("OK")
     # Test that changing the lock-redis-timeout also increases the
     # rdb one, if it would be lower.
     env.expect('CONFIG', 'SET', f'{MODULE_NAME}.lock-redis-timeout', 502).equal("OK")
-    env.expect('CONFIG', 'GET', f'{MODULE_NAME}.loading-lock-redis-timeout').apply(lambda v: int(v[1])).equal(502)
+    env.expect('CONFIG', 'GET', f'{MODULE_NAME}.db-loading-lock-redis-timeout').apply(lambda v: int(v[1])).equal(502)
 
 @gearsTest(enableGearsDebugCommands=True)
 def testCallTypeParsing(env):

--- a/redisgears_core/src/config.rs
+++ b/redisgears_core/src/config.rs
@@ -74,7 +74,7 @@ impl redis_module::ConfigurationValue<i64> for LoadLockTimeout {
         val: i64,
     ) -> Result<(), redis_module::RedisError> {
         self.store(val, std::sync::atomic::Ordering::SeqCst);
-        // The db loading lock redis timeout shouldn't be less than the
+        // db-loading-lock-redis-timeout shouldn't be less than the
         // lock-redis-timeout value, as it wouldn't make sense then.
         // Hence we are updating it here too as well.
         let current_db_loading_timeout =
@@ -105,7 +105,7 @@ lazy_static! {
     pub(crate) static ref LOCK_REDIS_TIMEOUT: LoadLockTimeout = LoadLockTimeout::default();
 
     /// Configuration value indicates the timeout for locking Redis when
-    /// loading from persistency (either AOF or RDB).
+    /// loading from persistency (either AOF, RDB or replication stream).
     pub(crate) static ref DB_LOADING_LOCK_REDIS_TIMEOUT: RdbLockTimeout = RdbLockTimeout::default();
 
     /// Configuration value indicates the gears box url.

--- a/redisgears_core/src/config.rs
+++ b/redisgears_core/src/config.rs
@@ -55,7 +55,7 @@ impl redis_module::ConfigurationValue<i64> for RdbLockTimeout {
     ) -> Result<(), redis_module::RedisError> {
         if val < LOCK_REDIS_TIMEOUT.load(std::sync::atomic::Ordering::Relaxed) {
             return Err(redis_module::RedisError::Str(
-                "The loading-lock-redis-timeout value can't be less than lock-redis-timeout value.",
+                "The db-loading-lock-redis-timeout value can't be less than lock-redis-timeout value.",
             ));
         }
         self.store(val, std::sync::atomic::Ordering::SeqCst);
@@ -77,8 +77,8 @@ impl redis_module::ConfigurationValue<i64> for LoadLockTimeout {
         // The RDB lock redis timeout value shouldn't be less than the
         // lock-redis-timeout value, as it wouldn't make sense then.
         // Hence we are updating it here too as well.
-        let current_rdb = LOADING_LOCK_REDIS_TIMEOUT.load(std::sync::atomic::Ordering::Relaxed);
-        LOADING_LOCK_REDIS_TIMEOUT.store(
+        let current_rdb = DB_LOADING_LOCK_REDIS_TIMEOUT.load(std::sync::atomic::Ordering::Relaxed);
+        DB_LOADING_LOCK_REDIS_TIMEOUT.store(
             std::cmp::max(val, current_rdb),
             std::sync::atomic::Ordering::SeqCst,
         );
@@ -100,12 +100,12 @@ lazy_static! {
     pub(crate) static ref REMOTE_TASK_DEFAULT_TIMEOUT: AtomicI64 = AtomicI64::default();
 
     /// Configuration value indicates the timeout for locking Redis (except
-    /// for the loading from RDB. For that, see the [`LOADING_LOCK_REDIS_TIMEOUT`]).
+    /// for the loading from RDB. For that, see the [`DB_LOADING_LOCK_REDIS_TIMEOUT`]).
     pub(crate) static ref LOCK_REDIS_TIMEOUT: LoadLockTimeout = LoadLockTimeout::default();
 
     /// Configuration value indicates the timeout for locking Redis when
     /// loading from RDB.
-    pub(crate) static ref LOADING_LOCK_REDIS_TIMEOUT: RdbLockTimeout = RdbLockTimeout::default();
+    pub(crate) static ref DB_LOADING_LOCK_REDIS_TIMEOUT: RdbLockTimeout = RdbLockTimeout::default();
 
     /// Configuration value indicates the gears box url.
     pub(crate) static ref GEARS_BOX_ADDRESS: RedisGILGuard<String> = RedisGILGuard::default();

--- a/redisgears_core/src/config.rs
+++ b/redisgears_core/src/config.rs
@@ -55,7 +55,7 @@ impl redis_module::ConfigurationValue<i64> for RdbLockTimeout {
     ) -> Result<(), redis_module::RedisError> {
         if val < LOCK_REDIS_TIMEOUT.load(std::sync::atomic::Ordering::Relaxed) {
             return Err(redis_module::RedisError::Str(
-                "The rdb-lock-redis-timeout value can't be less than lock-redis-timeout value.",
+                "The loading-lock-redis-timeout value can't be less than lock-redis-timeout value.",
             ));
         }
         self.store(val, std::sync::atomic::Ordering::SeqCst);
@@ -77,8 +77,8 @@ impl redis_module::ConfigurationValue<i64> for LoadLockTimeout {
         // The RDB lock redis timeout value shouldn't be less than the
         // lock-redis-timeout value, as it wouldn't make sense then.
         // Hence we are updating it here too as well.
-        let current_rdb = RDB_LOCK_REDIS_TIMEOUT.load(std::sync::atomic::Ordering::Relaxed);
-        RDB_LOCK_REDIS_TIMEOUT.store(
+        let current_rdb = LOADING_LOCK_REDIS_TIMEOUT.load(std::sync::atomic::Ordering::Relaxed);
+        LOADING_LOCK_REDIS_TIMEOUT.store(
             std::cmp::max(val, current_rdb),
             std::sync::atomic::Ordering::SeqCst,
         );
@@ -100,12 +100,12 @@ lazy_static! {
     pub(crate) static ref REMOTE_TASK_DEFAULT_TIMEOUT: AtomicI64 = AtomicI64::default();
 
     /// Configuration value indicates the timeout for locking Redis (except
-    /// for the loading from RDB. For that, see the [`RDB_LOCK_REDIS_TIMEOUT`]).
+    /// for the loading from RDB. For that, see the [`LOADING_LOCK_REDIS_TIMEOUT`]).
     pub(crate) static ref LOCK_REDIS_TIMEOUT: LoadLockTimeout = LoadLockTimeout::default();
 
     /// Configuration value indicates the timeout for locking Redis when
     /// loading from RDB.
-    pub(crate) static ref RDB_LOCK_REDIS_TIMEOUT: RdbLockTimeout = RdbLockTimeout::default();
+    pub(crate) static ref LOADING_LOCK_REDIS_TIMEOUT: RdbLockTimeout = RdbLockTimeout::default();
 
     /// Configuration value indicates the gears box url.
     pub(crate) static ref GEARS_BOX_ADDRESS: RedisGILGuard<String> = RedisGILGuard::default();

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -331,10 +331,10 @@ pub(crate) fn function_load_command(
     Ok(RedisValue::NoReply)
 }
 
-pub(crate) fn function_load_on_replica(
-    ctx: &Context,
-    args: Skip<IntoIter<redis_module::RedisString>>,
-) -> RedisResult {
+/// Verify that it is OK to perform an internal command.
+/// Internal command should only run if it came from replication stream
+/// or from AOF loading. In other words, the command did not came directly from a user.
+fn verify_internal_command(ctx: &Context) -> Result<(), RedisError> {
     let flags = ctx.get_flags();
     let globals = get_globals();
     if !flags.contains(ContextFlags::LOADING)
@@ -345,9 +345,17 @@ pub(crate) fn function_load_on_replica(
         // Another special option is if the instance is pseudo slave (replica of) which is treated as if the command was replicated from primary.
         // If none of those cases holds we will return an error.
         return Err(RedisError::Str(
-            "Internal command should only be sent from primary of loaded from AOF",
+            "Internal command should only be sent from primary or loaded from AOF",
         ));
     }
+    Ok(())
+}
+
+pub(crate) fn function_load_on_replica(
+    ctx: &Context,
+    args: Skip<IntoIter<redis_module::RedisString>>,
+) -> RedisResult {
+    verify_internal_command(ctx)?;
 
     let args = get_args_values(args)?;
     if args.user.is_none() {

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -25,8 +25,8 @@ use redisgears_plugin_api::redisgears_plugin_api::run_function_ctx::PromiseReply
 use serde::{Deserialize, Serialize};
 
 use config::{
-    FatalFailurePolicyConfiguration, ENABLE_DEBUG_COMMAND, ERROR_VERBOSITY, EXECUTION_THREADS,
-    FATAL_FAILURE_POLICY, LOADING_LOCK_REDIS_TIMEOUT, LOCK_REDIS_TIMEOUT, V8_FLAGS,
+    FatalFailurePolicyConfiguration, DB_LOADING_LOCK_REDIS_TIMEOUT, ENABLE_DEBUG_COMMAND,
+    ERROR_VERBOSITY, EXECUTION_THREADS, FATAL_FAILURE_POLICY, LOCK_REDIS_TIMEOUT, V8_FLAGS,
     V8_LIBRARY_INITIAL_MEMORY_LIMIT, V8_LIBRARY_INITIAL_MEMORY_USAGE,
     V8_LIBRARY_MEMORY_USAGE_DELTA, V8_MAX_MEMORY, V8_PLUGIN_PATH,
 };
@@ -952,7 +952,7 @@ fn js_init(ctx: &Context, _args: &[RedisString]) -> Status {
         }),
         get_lock_timeout: Box::new(|| LOCK_REDIS_TIMEOUT.load(Ordering::Relaxed) as u128),
         get_rdb_lock_timeout: Box::new(|| {
-            LOADING_LOCK_REDIS_TIMEOUT.load(Ordering::Relaxed) as u128
+            DB_LOADING_LOCK_REDIS_TIMEOUT.load(Ordering::Relaxed) as u128
         }),
         get_v8_maxmemory: Box::new(|| V8_MAX_MEMORY.load(Ordering::Relaxed) as usize),
         get_v8_library_initial_memory: Box::new(|| {
@@ -1749,7 +1749,7 @@ mod gears_module {
                 ["execution-threads", &*EXECUTION_THREADS ,1, 1, 32, ConfigurationFlags::IMMUTABLE, None],
                 ["remote-task-default-timeout", &*REMOTE_TASK_DEFAULT_TIMEOUT , 500, 1, i64::MAX, ConfigurationFlags::DEFAULT, None],
                 ["lock-redis-timeout", &*LOCK_REDIS_TIMEOUT , 500, 100, 1000000000, ConfigurationFlags::DEFAULT, None],
-                ["loading-lock-redis-timeout", &*LOADING_LOCK_REDIS_TIMEOUT , 30000, 100, 1000000000, ConfigurationFlags::DEFAULT, None],
+                ["db-loading-lock-redis-timeout", &*DB_LOADING_LOCK_REDIS_TIMEOUT , 30000, 100, 1000000000, ConfigurationFlags::DEFAULT, None],
 
                 [
                     "v8-maxmemory",

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 
 use config::{
     FatalFailurePolicyConfiguration, ENABLE_DEBUG_COMMAND, ERROR_VERBOSITY, EXECUTION_THREADS,
-    FATAL_FAILURE_POLICY, LOCK_REDIS_TIMEOUT, RDB_LOCK_REDIS_TIMEOUT, V8_FLAGS,
+    FATAL_FAILURE_POLICY, LOADING_LOCK_REDIS_TIMEOUT, LOCK_REDIS_TIMEOUT, V8_FLAGS,
     V8_LIBRARY_INITIAL_MEMORY_LIMIT, V8_LIBRARY_INITIAL_MEMORY_USAGE,
     V8_LIBRARY_MEMORY_USAGE_DELTA, V8_MAX_MEMORY, V8_PLUGIN_PATH,
 };
@@ -951,7 +951,9 @@ fn js_init(ctx: &Context, _args: &[RedisString]) -> Status {
             FatalFailurePolicyConfiguration::Kill => LibraryFatalFailurePolicy::Kill,
         }),
         get_lock_timeout: Box::new(|| LOCK_REDIS_TIMEOUT.load(Ordering::Relaxed) as u128),
-        get_rdb_lock_timeout: Box::new(|| RDB_LOCK_REDIS_TIMEOUT.load(Ordering::Relaxed) as u128),
+        get_rdb_lock_timeout: Box::new(|| {
+            LOADING_LOCK_REDIS_TIMEOUT.load(Ordering::Relaxed) as u128
+        }),
         get_v8_maxmemory: Box::new(|| V8_MAX_MEMORY.load(Ordering::Relaxed) as usize),
         get_v8_library_initial_memory: Box::new(|| {
             V8_LIBRARY_INITIAL_MEMORY_USAGE.load(Ordering::Relaxed) as usize
@@ -1747,7 +1749,7 @@ mod gears_module {
                 ["execution-threads", &*EXECUTION_THREADS ,1, 1, 32, ConfigurationFlags::IMMUTABLE, None],
                 ["remote-task-default-timeout", &*REMOTE_TASK_DEFAULT_TIMEOUT , 500, 1, i64::MAX, ConfigurationFlags::DEFAULT, None],
                 ["lock-redis-timeout", &*LOCK_REDIS_TIMEOUT , 500, 100, 1000000000, ConfigurationFlags::DEFAULT, None],
-                ["rdb-lock-redis-timeout", &*RDB_LOCK_REDIS_TIMEOUT , 30000, 100, 1000000000, ConfigurationFlags::DEFAULT, None],
+                ["loading-lock-redis-timeout", &*LOADING_LOCK_REDIS_TIMEOUT , 30000, 100, 1000000000, ConfigurationFlags::DEFAULT, None],
 
                 [
                     "v8-maxmemory",


### PR DESCRIPTION
The loading timeout introduce on https://github.com/RedisGears/RedisGears/pull/999 should also be applied when loading data from AOF and when replica gets the replication stream from its primary. To handle those cases, set the loading timeout to apply also on `_rg_internals.function load` command (which is the command that is written to AOF and sent on the replication stream).

In addition, the PR rename `rdb-lock-redis-timeout` to `db-loading-lock-redis-timeout` so it will match also to AOF and not only RDB.

In addition, the PR makes sure that `_rg_internals.function load` is only invoked on replica or during loading time.