### PR TITLE
Fixes title

### DIFF
--- a/docs/docs/_index.md
+++ b/docs/docs/_index.md
@@ -11,8 +11,6 @@ bannerChildren: true
 [![discord](https://img.shields.io/discord/697882427875393627?style=flat-square)](https://discord.gg/xTbqgTB)
 [![Github](https://img.shields.io/static/v1?label=&message=repository&color=5961FF&logo=github)](https://github.com/RedisGears/RedisGears/)
 
-# Triggers and functions
-
 The triggers and functions feature of Redis Stack allows running JavaScript functions inside Redis. These functions can be executed on-demand, by an event-driven trigger, or by a stream processing trigger.
 
 > You can try out the triggers and functions preview with a [free Redis Cloud account](https://redis.com/try-free/). The preview is available in the fixed subscription plan for the Google Cloud Asia Pacific (Tokyo) and AWS Asia Pacific (Singapore) regions.


### PR DESCRIPTION
If we render the markdown on redis.io, then the title would appear twice because it's pulled in from the meta data header. So I am removing this title here.