### PR TITLE
Move the post notification job creation into `on_stream_touched`.

### DIFF
--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -1404,8 +1404,12 @@ fn function_debug_command(
 
 fn on_stream_touched(ctx: &Context, _event_type: NotifyEvent, event: &str, key: &[u8]) {
     if is_master(ctx) {
-        let stream_ctx = &mut get_globals_mut().stream_ctx;
-        stream_ctx.on_stream_touched(ctx, event, key);
+        let key = key.to_vec();
+        let event = event.to_owned();
+        ctx.add_post_notification_job(move |ctx| {
+            let stream_ctx = &mut get_globals_mut().stream_ctx;
+            stream_ctx.on_stream_touched(ctx, &event, &key);
+        });
     }
 }
 

--- a/redisgears_core/src/stream_reader.rs
+++ b/redisgears_core/src/stream_reader.rs
@@ -598,16 +598,14 @@ where
                 if let Some((consumer_weak, record, consumer_info)) = res {
                     let stream_reader = Arc::clone(&self.stream_reader);
                     let tracked_stream = Arc::clone(&tracked_stream);
-                    ctx.add_post_notification_job(move |ctx| {
-                        send_new_data(
-                            ctx,
-                            tracked_stream,
-                            consumer_weak,
-                            record,
-                            consumer_info,
-                            stream_reader,
-                        );
-                    });
+                    send_new_data(
+                        ctx,
+                        tracked_stream,
+                        consumer_weak,
+                        record,
+                        consumer_info,
+                        stream_reader,
+                    );
                 }
             })
             .collect::<Vec<()>>();


### PR DESCRIPTION
Today the post notification job is created after the stream data was read. This is wrong because it means that we will read the data on the notification itself. Moving the post notification job into `on_stream_touched` will make sure the entire logic is happening inside the post notification job.