### PR TITLE
Fix `_rg_internals.update_stream_last_read_id` command definition.

### DIFF
--- a/pytests/test_errors.py
+++ b/pytests/test_errors.py
@@ -574,3 +574,8 @@ def testWasmIsNotExposeByDefault(env):
 WebAssembly.Global
     '''
     env.expect('TFUNCTION', 'LOAD', code).error().contains('WebAssembly is not defined')
+
+@gearsTest()
+def testInternalCommandOnRegularClient(env):
+    env.expect('_rg_internals.update_stream_last_read_id', 'foo', 'bar', 'aa', 'stream', '1', '2').error().contains('should only be sent from primary or loaded from AOF')
+    env.expect('_rg_internals.function', 'load', 'test').error().contains('should only be sent from primary or loaded from AOF')

--- a/pytests/test_errors.py
+++ b/pytests/test_errors.py
@@ -577,5 +577,5 @@ WebAssembly.Global
 
 @gearsTest()
 def testInternalCommandOnRegularClient(env):
-    env.expect('_rg_internals.update_stream_last_read_id', 'foo', 'bar', 'aa', 'stream', '1', '2').error().contains('should only be sent from primary or loaded from AOF')
+    env.expect('_rg_internals.update_stream_last_read_id', 'foo', 'bar', 'stream', '1', '2').error().contains('should only be sent from primary or loaded from AOF')
     env.expect('_rg_internals.function', 'load', 'test').error().contains('should only be sent from primary or loaded from AOF')

--- a/pytests/test_stream_reader.py
+++ b/pytests/test_stream_reader.py
@@ -678,7 +678,7 @@ redis.registerFunction("test2",
 def testupdateStreamLastReadIdInternalCommand(env):
     # make sure we get a legacy key spec (first_key, last_key, steps)
     res = env.cmd('COMMAND', 'INFO', '_rg_internals.update_stream_last_read_id')['_rg_internals.update_stream_last_read_id']
-    env.assertEqual(res['arity'], 7)
-    env.assertEqual(res['first_key_pos'], 4)
-    env.assertEqual(res['last_key_pos'], 4)
+    env.assertEqual(res['arity'], 6)
+    env.assertEqual(res['first_key_pos'], 3)
+    env.assertEqual(res['last_key_pos'], 3)
     env.assertEqual(res['step_count'], 1)

--- a/pytests/test_stream_reader.py
+++ b/pytests/test_stream_reader.py
@@ -674,3 +674,11 @@ redis.registerFunction("test2",
     env.expectTfcall('lib', 'test2').equal('OK')
     env.expect('exists', 'stream:1').equal(False)
 
+@gearsTest()
+def testupdateStreamLastReadIdInternalCommand(env):
+    # make sure we get a legacy key spec (first_key, last_key, steps)
+    res = env.cmd('COMMAND', 'INFO', '_rg_internals.update_stream_last_read_id')['_rg_internals.update_stream_last_read_id']
+    env.assertEqual(res['arity'], 7)
+    env.assertEqual(res['first_key_pos'], 4)
+    env.assertEqual(res['last_key_pos'], 4)
+    env.assertEqual(res['step_count'], 1)

--- a/ramp.yml
+++ b/ramp.yml
@@ -26,7 +26,6 @@ capabilities:
     - flash
 exclude_commands:
     - _RG_INTERNALS.FUNCTION
-    - _RG_INTERNALS.UPDATE_STREAM_LAST_READ_ID
     - redisgears_2.REFRESHCLUSTER
     - redisgears_2.INFOCLUSTER
     - redisgears_2.NETWORKTEST
@@ -39,7 +38,6 @@ exclude_commands:
     - TFCALL
     - tfcallasync
     - TFCALLASYNC
-    - _rg_internals.update_stream_last_read_id
     - _rg_internals.function
 dependencies:
     gears_v8:

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -1703,7 +1703,7 @@ fn function_command(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
 #[command(
     {
         name: "_rg_internals.update_stream_last_read_id",
-        flags: [ReadOnly, DenyScript, NoMandatoryKeys],
+        flags: [MayReplicate, DenyScript],
         arity: 6,
         key_spec: [
             {

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -1704,11 +1704,11 @@ fn function_command(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     {
         name: "_rg_internals.update_stream_last_read_id",
         flags: [ReadOnly, DenyScript, NoMandatoryKeys],
-        arity: 7,
+        arity: 6,
         key_spec: [
             {
                 flags: [ReadWrite, Access, Update],
-                begin_search: Index({ index : 4}),
+                begin_search: Index({ index : 3}),
                 find_keys: Range({ last_key: 0, steps: 1, limit: 0 }),
             }
         ],

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -1597,6 +1597,26 @@ pub(crate) fn get_msg_verbose(err: &GearsApiError) -> &str {
     err.get_msg_verbose()
 }
 
+/// Verify that it is OK to perform an internal command.
+/// Internal command should only run if it came from replication stream
+/// or from AOF loading. In other words, the command did not came directly from a user.
+fn verify_internal_command(ctx: &Context) -> Result<(), RedisError> {
+    let flags = ctx.get_flags();
+    let globals = get_globals();
+    if !flags.contains(ContextFlags::LOADING)
+        && !(flags.contains(ContextFlags::REPLICATED) || globals.db_policy.is_pseudo_slave())
+    {
+        // Internal commands should either be loaded from AOF ([`ContextFlags::LOADING`])
+        // or sent over the replication stream([`ContextFlags::REPLICATED`]).
+        // Another special option is if the instance is pseudo slave (replica of) which is treated as if the command was replicated from primary.
+        // If none of those cases holds we will return an error.
+        return Err(RedisError::Str(
+            "Internal command should only be sent from primary or loaded from AOF",
+        ));
+    }
+    Ok(())
+}
+
 #[command(
     {
         name: "tfcall",
@@ -1644,6 +1664,7 @@ fn function_call_async(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     }
 )]
 fn function_command_on_replica(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    verify_internal_command(ctx)?;
     let mut args = args.into_iter().skip(1);
     let sub_command = args.next_arg()?.try_as_str()?.to_lowercase();
     match sub_command.as_ref() {
@@ -1683,11 +1704,18 @@ fn function_command(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     {
         name: "_rg_internals.update_stream_last_read_id",
         flags: [ReadOnly, DenyScript, NoMandatoryKeys],
-        arity: 6,
-        key_spec: [],
+        arity: 7,
+        key_spec: [
+            {
+                flags: [ReadWrite, Access, Update],
+                begin_search: Index({ index : 4}),
+                find_keys: Range({ last_key: 0, steps: 1, limit: 0 }),
+            }
+        ],
     }
 )]
 fn update_stream_last_read_id(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    verify_internal_command(ctx)?;
     let mut args = args.into_iter().skip(1);
     let library_name = args.next_arg()?.try_as_str()?;
     let stream_consumer = args.next_arg()?.try_as_str()?;


### PR DESCRIPTION
The PR fixes `_rg_internals.update_stream_last_read_id` command definition with respect to key spec. Though the command is internal, it is send to replica (and replica of) and it is required that the command definition will be done correctly.

In addition, the PR makes sure that all internal command will only run if came from primary. Tests was added to verify it.

Last, the PR removes `_rg_internals.update_stream_last_read_id` from the `exclude_commands` command section of ramp.yml. We need this command to not be excluded so that if it is sent on replica of, it will arrive successfully to the destination.