### PR TITLE
Restrict the serde-derive version.

### DIFF
--- a/redisgears_core/Cargo.toml
+++ b/redisgears_core/Cargo.toml
@@ -17,13 +17,17 @@ libloading = "0.7"
 redisgears_plugin_api = { path="../redisgears_plugin_api/" }
 threadpool = "1"
 reqwest = { version = "0.11", features = ["json", "blocking"] }
-serde_json = "1"
-serde = { version = "1", features = ["derive"] }
-serde_derive = "1"
 sha256 = "1"
 lazy_static = "1"
 log = "0.4"
 byte-unit = "4"
+serde_json = "1"
+# DO NOT CHANGE to avoid security issues. This exact version
+# specification is required for the second level dependencies
+# to use exactly this version too, so that the dependencies of
+# this project will not be able to compromise it.
+serde = { version = "1.0.171", features = ["derive"] }
+serde_derive = "1.0.171"
 
 [build-dependencies]
 regex = "1"

--- a/redisgears_plugin_api/Cargo.toml
+++ b/redisgears_plugin_api/Cargo.toml
@@ -8,8 +8,12 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 
 [dependencies]
 redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
-serde = { version = "1", features = ["derive"] }
-serde_derive = "1"
 bitflags = "1"
+# DO NOT CHANGE to avoid security issues. This exact version
+# specification is required for the second level dependencies
+# to use exactly this version too, so that the dependencies of
+# this project will not be able to compromise it.
+serde = { version = "1.0.171", features = ["derive"] }
+serde_derive = "=1.0.171"
 
 [build-dependencies]


### PR DESCRIPTION
This should help to avoid the security implications caused by the project becoming a BLOB instead of a source code compiling along with other crates.

This version lock is precisely on `1.0.171`, which doesn't have the binary yet.