### PR TITLE
Add JavaScript debugging

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,4 +20,4 @@ jobs:
             os_version: 22.04
             os_family: ubuntu
             dockerfile: dockerbuilds/dockerfile.debian.tmpl
-            msrv: 1.67.0
+            msrv: 1.70.0

--- a/examples/js_package/index.js
+++ b/examples/js_package/index.js
@@ -23,12 +23,12 @@ redis.registerKeySpaceTrigger(
   'bar', // trigger name
   'keys:*', //key prefix
   function(client, data) {
-    console.log("Got this key data updated: " + data);
+    console.log("Got this key data updated1: " + data);
   }, //callback
   {
     description: 'description',
     onTriggerFired: function(client, data) {
-        console.log("Got this key data updated: " + data);
+        console.log("Got this key data updated2: " + data);
     }
   } //optional arguments
 )

--- a/examples/js_package/index.js
+++ b/examples/js_package/index.js
@@ -10,7 +10,7 @@ redis.registerFunction("foo", () => {
 
 redis.registerAsyncFunction(
   'asyncfoo', //Function name
-  function(client, args) {
+  async function(async_client, args) {
       console.log("Hello from async")
   }, //callback
   {

--- a/examples/js_package/package.json
+++ b/examples/js_package/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "deploy": "gears-api index.js",
+    "deploy_for_debug": "gears-api --debug index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {

--- a/pytests/common.py
+++ b/pytests/common.py
@@ -89,7 +89,7 @@ def getShardInfo(conn, log_file):
         functions = conn.execute_command('tfunction', 'list', 'vvv')
     except Exception as e:
         functions = 'Failed getting shard info, shards probably crashed.'
-    
+
     return {
         'info': info,
         'log': log,
@@ -130,10 +130,10 @@ class AsyncResponse:
             if self.future.exception():
                 raise self.future.exception()
             return self.future.result()
-        
+
     def equal(self, val):
         self.env.assertEqual(self.readResponse(), val)
-    
+
     def expectError(self, msg=''):
         try:
             res = self.readResponse()
@@ -149,14 +149,14 @@ def extendEnvWithGearsFunctionality(env):
 
     def expectTfcall(lib, func, keys=[], args=[]):
         return env.expect('TFCALL', '%s.%s' % (lib, func), str(len(keys)), *(keys + args))
-    
+
     def tfcall(lib, func, keys=[], args=[], c=None):
         c = c if c else env
         return c.execute_command('TFCALL', '%s.%s' % (lib, func), str(len(keys)), *(keys + args))
 
     def expectTfcallAsync(lib, func, keys=[], args=[]):
         return env.expect('TFCALLASYNC', '%s.%s' % (lib, func), str(len(keys)), *(keys + args))
-    
+
     def tfcallAsync(lib, func, keys=[], args=[], c=None):
         c = c if c else env
         return c.execute_command('TFCALLASYNC', '%s.%s' % (lib, func), str(len(keys)), *(keys + args))
@@ -165,19 +165,19 @@ def extendEnvWithGearsFunctionality(env):
         con = env.getConnection().connection_pool.get_connection("_")
         async_con = AIORedis(host = con.host, port = con.port, db = con.db, password = con.password, decode_responses=decodeResponses)
         return AsyncResponse(env, asyncio.run_coroutine_threadsafe(async_con.execute_command(*args), event_loop))
-    
+
     def noBlockingTfcall(lib, func, keys=[], args=[]):
         return env.noBlockingCmd('TFCALL', '%s.%s' % (lib, func), str(len(keys)), *(keys + args))
-    
+
     def noBlockingTfcallAsync(lib, func, keys=[], args=[]):
         return env.noBlockingCmd('TFCALLASYNC', '%s.%s' % (lib, func), str(len(keys)), *(keys + args))
-    
+
     def getResp3Connection():
         port = int(env.cmd('config', 'get', 'port')[1])
         # test resp3
         return Redis('localhost', port, protocol=3, decode_responses=True)
 
-    
+
     env.expectTfcall = expectTfcall
     env.tfcall = tfcall
     env.expectTfcallAsync = expectTfcallAsync
@@ -201,6 +201,7 @@ def gearsTest(skipTest=False,
               shardsCount=2,
               errorVerbosity=1,
               v8MaxMemory=None,
+              debugServerAddress=None,
               useAof=False,
               gearsConfig={},
               envArgs={}):
@@ -244,6 +245,8 @@ def gearsTest(skipTest=False,
                 module_args += ["enable-debug-command", "yes"]
             if v8MaxMemory:
                 module_args += ["v8-maxmemory", str(v8MaxMemory)]
+            if debugServerAddress:
+                module_args += ["v8-debug-server-address", str(debugServerAddress)]
             for k, v in gearsConfig.items():
                 module_args += [k, v]
             module_args += ["error-verbosity", str(errorVerbosity)]

--- a/pytests/test_debugging.py
+++ b/pytests/test_debugging.py
@@ -1,5 +1,5 @@
 from redis import ResponseError
-from common import gearsTest, shardsConnections
+from common import gearsTest, shardsConnections, toDictionary
 from common import Env
 from websockets.sync.client import connect
 import json
@@ -343,6 +343,11 @@ def testDeployConnectStartDisconnect(env: Env):
 
     # Check that Redis still operates fine.
     env.expect('PING').equal(True)
+    # After debugging the library should be deleted automatically from
+    # the database, as the only purpose it was uploaded for was to have
+    # a debugging session.
+    env.assertEqual(len(toDictionary(env.cmd('TFUNCTION', 'list', 'library', 'lib', 'v'))), 0)
+
 
 @gearsTest(debugServerAddress="127.0.0.1:9005")
 def testSetBreakpointAndHitIt(env: Env):

--- a/pytests/test_debugging.py
+++ b/pytests/test_debugging.py
@@ -1,0 +1,20 @@
+from common import gearsTest
+from common import toDictionary
+from common import runUntil
+from redis import Redis
+from websockets.client import ClientConnection
+import time
+
+MODULE_NAME = "redisgears_2"
+
+@gearsTest()
+def testDeployConnectStartDisconnect(env):
+    script = '''#!js api_version=1.0 name=foo
+redis.registerFunction("test", function(client) {
+    return 1
+})
+    '''
+
+    env.expect('TFUNCTION', 'DELETE', 'foo')
+    env.expect('TFUNCTION', 'LOAD', 'debug', script).equal('OK')
+    client = ClientConnection("ws://127.0.0.1:9005")

--- a/pytests/test_debugging.py
+++ b/pytests/test_debugging.py
@@ -1,20 +1,311 @@
 from common import gearsTest
-from common import toDictionary
-from common import runUntil
-from redis import Redis
-from websockets.client import ClientConnection
-import time
+from common import Env
+from websockets.sync.client import connect
+import json
 
-MODULE_NAME = "redisgears_2"
+# This adds logging. Uncomment to see the websocket logging.
+# import logging
+# logger = logging.getLogger('websockets')
+# logger.setLevel(logging.DEBUG)
+# logger.addHandler(logging.StreamHandler())
+
+# This script is used everywhere within the test.
+SCRIPT = '''#!js name=gears_example api_version=1.0
+var redis = redis;
+
+var numberOfCalls = 0;
+
+redis.registerFunction("foo", () => {
+    return ++numberOfCalls;
+});
+
+redis.registerAsyncFunction(
+  'asyncfoo', //Function name
+  function(client, args) {
+      console.log("Hello from async");
+  }, //callback
+  {
+    description: 'description',
+    flags: [redis.functionFlags.NO_WRITES, redis.functionFlags.ALLOW_OOM]
+  } //optional arguments
+);
+
+redis.registerKeySpaceTrigger(
+  'bar', // trigger name
+  'keys:*', //key prefix
+  function(client, data) {
+    console.log("Got this key data updated1: " + data);
+  }, //callback
+  {
+    description: 'description',
+    onTriggerFired: function(client, data) {
+        console.log("Got this key data updated2: " + data);
+    }
+  } //optional arguments
+);
+
+redis.registerStreamTrigger(
+  'foobar', //trigger name
+  'stream:*', //prefix
+  function(client, data) {
+    console.log("Got this stream data updated: " + data);
+  },//callback
+  {
+    description: 'Description',
+    window: 1,
+    isStreamTrimmed: false
+  } //optional arguments
+);
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZmlsZS5qcyIsInNvdXJjZXMiOlsiLi4vLi4vanNfYXBpL2dlYXJzLWFwaS5qcyIsImluZGV4LmpzIl0sInNvdXJjZXNDb250ZW50IjpbInZhciByZWRpcyA9IHJlZGlzO1xuXG5leHBvcnR7IHJlZGlzIH1cbiIsIiMhanMgbmFtZT1nZWFyc19leGFtcGxlIGFwaV92ZXJzaW9uPTEuMFxuXG5pbXBvcnQgeyByZWRpcyB9IGZyb20gJ0ByZWRpcy9nZWFycy1hcGknO1xuXG52YXIgbnVtYmVyT2ZDYWxscyA9IDA7XG5cbnJlZGlzLnJlZ2lzdGVyRnVuY3Rpb24oXCJmb29cIiwgKCkgPT4ge1xuICAgIHJldHVybiArK251bWJlck9mQ2FsbHM7XG59KTtcblxucmVkaXMucmVnaXN0ZXJBc3luY0Z1bmN0aW9uKFxuICAnYXN5bmNmb28nLCAvL0Z1bmN0aW9uIG5hbWVcbiAgZnVuY3Rpb24oY2xpZW50LCBhcmdzKSB7XG4gICAgICBjb25zb2xlLmxvZyhcIkhlbGxvIGZyb20gYXN5bmNcIilcbiAgfSwgLy9jYWxsYmFja1xuICB7XG4gICAgZGVzY3JpcHRpb246ICdkZXNjcmlwdGlvbicsXG4gICAgZmxhZ3M6IFtyZWRpcy5mdW5jdGlvbkZsYWdzLk5PX1dSSVRFUywgcmVkaXMuZnVuY3Rpb25GbGFncy5BTExPV19PT01dXG4gIH0gLy9vcHRpb25hbCBhcmd1bWVudHNcbik7XG5cbnJlZGlzLnJlZ2lzdGVyS2V5U3BhY2VUcmlnZ2VyKFxuICAnYmFyJywgLy8gdHJpZ2dlciBuYW1lXG4gICdrZXlzOionLCAvL2tleSBwcmVmaXhcbiAgZnVuY3Rpb24oY2xpZW50LCBkYXRhKSB7XG4gICAgY29uc29sZS5sb2coXCJHb3QgdGhpcyBrZXkgZGF0YSB1cGRhdGVkMTogXCIgKyBkYXRhKTtcbiAgfSwgLy9jYWxsYmFja1xuICB7XG4gICAgZGVzY3JpcHRpb246ICdkZXNjcmlwdGlvbicsXG4gICAgb25UcmlnZ2VyRmlyZWQ6IGZ1bmN0aW9uKGNsaWVudCwgZGF0YSkge1xuICAgICAgICBjb25zb2xlLmxvZyhcIkdvdCB0aGlzIGtleSBkYXRhIHVwZGF0ZWQyOiBcIiArIGRhdGEpO1xuICAgIH1cbiAgfSAvL29wdGlvbmFsIGFyZ3VtZW50c1xuKVxuXG5yZWRpcy5yZWdpc3RlclN0cmVhbVRyaWdnZXIoXG4gICdmb29iYXInLCAvL3RyaWdnZXIgbmFtZVxuICAnc3RyZWFtOionLCAvL3ByZWZpeFxuICBmdW5jdGlvbihjbGllbnQsIGRhdGEpIHtcbiAgICBjb25zb2xlLmxvZyhcIkdvdCB0aGlzIHN0cmVhbSBkYXRhIHVwZGF0ZWQ6IFwiICsgZGF0YSk7XG4gIH0sLy9jYWxsYmFja1xuICB7XG4gICAgZGVzY3JpcHRpb246ICdEZXNjcmlwdGlvbicsXG4gICAgd2luZG93OiAxLFxuICAgIGlzU3RyZWFtVHJpbW1lZDogZmFsc2VcbiAgfSAvL29wdGlvbmFsIGFyZ3VtZW50c1xuKVxuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7QUFBQSxDQUFJLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBSyxHQUFHLENBQUssQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBOztBQ0lqQixDQUFJLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQWEsQ0FBRyxDQUFBLENBQUEsQ0FBQyxDQUFDO0FBQ3RCO0FBQ0EsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFLLENBQUMsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBZ0IsQ0FBQyxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUssRUFBRSxDQUFNLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBO0FBQ3BDLENBQUksQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBTyxDQUFFLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBYSxDQUFDO0FBQzNCLENBQUMsQ0FBQyxDQUFDO0FBQ0g7QUFDQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUssQ0FBQyxDQUFxQixDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQTtBQUMzQixDQUFBLENBQUUsQ0FBVSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUE7QUFDWixDQUFBLENBQUUsQ0FBUyxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQU0sQ0FBRSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUksQ0FBRSxDQUFBLENBQUE7QUFDekIsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQU0sQ0FBTyxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFDLENBQUcsQ0FBQSxDQUFBLENBQUMsa0JBQWtCLENBQUMsQ0FBQTtBQUNyQyxDQUFHLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQTtBQUNILENBQUUsQ0FBQSxDQUFBO0FBQ0YsQ0FBSSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQVcsRUFBRSxDQUFhLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUE7QUFDOUIsQ0FBQSxDQUFBLENBQUEsQ0FBSSxDQUFLLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFFLENBQUMsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFLLENBQUMsQ0FBYSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFDLENBQVMsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBRSxDQUFLLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQyxDQUFhLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUMsU0FBUyxDQUFDO0FBQ3pFLENBQUcsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBO0FBQ0gsQ0FBQyxDQUFDO0FBQ0Y7QUFDQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUssQ0FBQyxDQUF1QixDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUE7QUFDN0IsQ0FBQSxDQUFFLENBQUssQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUE7QUFDUCxDQUFBLENBQUUsQ0FBUSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQTtBQUNWLENBQUEsQ0FBRSxDQUFTLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBTSxDQUFFLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBSSxDQUFFLENBQUEsQ0FBQTtBQUN6QixDQUFJLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQU8sQ0FBQyxDQUFHLENBQUEsQ0FBQSxDQUFDLDhCQUE4QixDQUFHLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFJLENBQUMsQ0FBQztBQUN2RCxDQUFHLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQTtBQUNILENBQUUsQ0FBQSxDQUFBO0FBQ0YsQ0FBSSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQVcsRUFBRSxDQUFhLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUE7QUFDOUIsQ0FBQSxDQUFBLENBQUEsQ0FBSSxjQUFjLENBQUUsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBUyxDQUFNLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUUsSUFBSSxDQUFFLENBQUEsQ0FBQTtBQUMzQyxDQUFRLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBTyxDQUFDLENBQUcsQ0FBQSxDQUFBLENBQUMsOEJBQThCLENBQUcsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUksQ0FBQyxDQUFDO0FBQzNELENBQUssQ0FBQSxDQUFBLENBQUEsQ0FBQTtBQUNMLENBQUcsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBO0FBQ0gsQ0FBQyxDQUFBO0FBQ0Q7QUFDQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUssQ0FBQyxDQUFxQixDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQTtBQUMzQixDQUFBLENBQUUsQ0FBUSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUE7QUFDVixDQUFBLENBQUUsQ0FBVSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBO0FBQ1osQ0FBQSxDQUFFLENBQVMsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFNLENBQUUsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFJLENBQUUsQ0FBQSxDQUFBO0FBQ3pCLENBQUksQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBTyxDQUFDLENBQUcsQ0FBQSxDQUFBLENBQUMsZ0NBQWdDLENBQUcsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUksQ0FBQyxDQUFDO0FBQ3pELENBQUcsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQTtBQUNILENBQUUsQ0FBQSxDQUFBO0FBQ0YsQ0FBSSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQVcsRUFBRSxDQUFhLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUE7QUFDOUIsQ0FBSSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBTSxFQUFFLENBQUMsQ0FBQTtBQUNiLENBQUksQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQWUsRUFBRSxDQUFLLENBQUEsQ0FBQSxDQUFBLENBQUE7QUFDMUIsQ0FBRyxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUEsQ0FBQSxDQUFBLENBQUE7QUFDSCxDQUFBIn0=
+'''
+
+"""
+A short list of debugger client messages following the V8 Inspector API.
+"""
+class DebuggerClientMessage:
+    RUNTIME_ENABLE = {
+        "method": "Runtime.enable",
+        "params": {}
+    }
+
+    DEBUGGER_ENABLE = {
+        "method": "Debugger.enable",
+        "params": {}
+    }
+
+    DEBUGGER_RESUME = {
+        "method": "Debugger.resume",
+        "params": {}
+    }
+
+    RUNTIME_RUN_IF_WAITING_FOR_DEBUGGER = {
+        "method": "Runtime.runIfWaitingForDebugger",
+        "params": {}
+    }
+
+    """
+    Generates a V8 RPC message for setting a breakpoint.
+    """
+    @staticmethod
+    def set_breakpoint(line_number: int, column_number: int, script_hash: str) -> dict:
+        return {
+            "method": "Debugger.setBreakpointByUrl",
+            "params": {
+                "lineNumber": line_number,
+                "scriptHash": script_hash,
+                "columnNumber": column_number,
+                "condition": ""
+            }
+        }
+
+    """
+    Generates a V8 RPC message for removing a breakpoint by its id.
+    """
+    @staticmethod
+    def remove_breakpoint(breakpoint_id: int) -> dict:
+        return {
+            "method": "Debugger.removeBreakpoint",
+            "params": {
+                "breakpointId": breakpoint_id,
+            }
+        }
+
+"""
+A remote debugger breakpoint.
+"""
+class Breakpoint:
+    def __init__(self, client, data: dict) -> None:
+        self._client = client
+        self.data = data
+
+    """
+    Removes this breakpoint.
+    """
+    def remove(self):
+        self.client.remove_breakpoint(self.data["breakpointId"])
+
+    """
+    Returns the breakpoint id.
+    """
+    def get_id(self) -> str:
+        return self.data["breakpointId"]
+
+"""
+The remote debugger client is a web socket client that uses the
+V8 Inspector JSON RPC API.
+"""
+class DebuggerClient:
+    """
+    The default websocket address for RedisGears V8 plugin debugger
+    server.
+    """
+    DEFAULT_WEBSOCKET_ADDRESS = "ws://127.0.0.1:9005"
+
+    """
+    Instantiates a new debugger client.
+    If the address is omitted, the default one is used.
+    """
+    def __init__(self, env: Env, address=None) -> None:
+        self._last_message_id = 1
+        self._env = env
+        self.breakpoints = []
+        self.pause = None
+        self.scripts_parsed = []
+        self._websocket = connect(address if address is not None else DebuggerClient.DEFAULT_WEBSOCKET_ADDRESS)
+        self.initiate_startup()
+
+    """
+    Initiates the debugger session start. We need to invoke a few
+    methods in order for the remote server to start. The most important
+    one to start is the "Runtime.enable" method.
+
+    After all the startup methods are received, the remote debugger
+    initialises a session, prepares stuff and so on. After all of it is
+    done, we need to tell the remote debugger server that we are ready
+    and not going to invoke any more initialisation methods for
+    setting up the environment, by calling the
+    "Runtime.runIfWaitingForDebugger" method.
+    """
+    def initiate_startup(self):
+        self.runtime_enable()
+        self.debugger_enable()
+        self.run_if_waiting_for_debugger()
+
+    """
+    Disconnects from the remote server.
+    """
+    def disconnect(self):
+        self._websocket.close_socket()
+
+    """
+    Invokes the "Runtime.enable" method.
+    """
+    def runtime_enable(self):
+        responses = self.send_message(DebuggerClientMessage.RUNTIME_ENABLE)
+        self._env.assertEqual('Runtime.executionContextCreated', responses[0]["method"])
+        self._env.assertEqual({}, responses[1]["result"])
+
+    """
+    Invokes the "Debugger.enable" method.
+    """
+    def debugger_enable(self):
+        responses = self.send_message(DebuggerClientMessage.DEBUGGER_ENABLE)
+        # Should contain at least one script parsed.
+        self._env.assertEqual('Debugger.scriptParsed', responses[0]["method"])
+        for r in responses:
+            if "method" in r and r["method"] == "Debugger.scriptParsed":
+                self.scripts_parsed.append(r["params"])
+        self._env.assertContains("result", responses[-1])
+
+    """
+    Invokes the "Runtime.runIfWaitingForDebugger" method.
+    """
+    def run_if_waiting_for_debugger(self):
+        responses = self.send_message(DebuggerClientMessage.RUNTIME_RUN_IF_WAITING_FOR_DEBUGGER )
+        self._env.assertEqual(len(responses), 1)
+        self._env.assertEqual({}, responses[0]["result"])
+        # Right after that we should receive a "Debugger.paused" event.
+        # The reason is that the v8 plugin pauses immediately on the
+        # very first instruction of the user script, so that the user
+        # can't miss anything until the debugger is attached and the
+        # user can see the execution happening.
+        pause = self.receive_event()
+        self._env.assertEqual("Debugger.paused", pause["method"])
+        self.pause = pause
+
+    """
+    Receives a single event from the server.
+    """
+    def receive_event(self) -> dict:
+        return json.loads(self._websocket.recv())
+
+    """
+    Converts a python dictionary to a json dictionary, adds the
+    mandatory "id" field, sends the message to the remote debugger
+    server and receives the response(s) to it.
+
+    This method accumulates all the responses from the server until a
+    message with the id that of the client message is received.
+    """
+    def send_message(self, message: dict) -> [dict]:
+        message["id"] = self._last_message_id
+        self._websocket.send(json.dumps(message))
+        responses = []
+        while True:
+            response = self.receive_event()
+            if "id" in response:
+                if response["id"] <= self._last_message_id:
+                    responses.append(response)
+                    if response["id"] == self._last_message_id:
+                        self._last_message_id += 1
+                        break
+            else:
+                responses.append(response)
+        return responses
+
+    """
+    Sets a breakpoint at the specified location in the script. If the
+    `script_hash` argument is omitted, the first parsed script is
+    going to be used.
+    """
+    def set_breakpoint(self, line_number: int, column_number: int, script_hash: str = None) -> Breakpoint:
+        script_hash = script_hash if script_hash is not None else self.scripts_parsed[0]["hash"]
+        message = DebuggerClientMessage.set_breakpoint(line_number, column_number, script_hash)
+        response = self.send_message(message)
+        self._env.assertContains("result", response[0])
+        self._env.assertContains("breakpointId", response[0]["result"])
+        # The resolved locations number must be greater than zero. If
+        # it is zero it indicates that the debugger couldn't resolve the
+        # breakpoint to any point in the script.
+        self._env.assertGreater(len(response[0]["result"]["locations"]), 0)
+        breakpoint = Breakpoint(self, response[0]["result"])
+        self.breakpoints.append(breakpoint)
+        return breakpoint
+
+    """
+    Resumes the execution (if it was paused) and returns all the events
+    in response to the resume request.
+    """
+    def resume(self) -> [dict]:
+        self.pause = None
+        return self.send_message(DebuggerClientMessage.DEBUGGER_RESUME)
+
+    """
+    Resumes the execution (if it was paused), waits until the next
+    pause happens and returns all the messages in between.
+    """
+    def resume_and_wait_until_pauses(self) -> [dict]:
+        messages = self.resume()
+        while True:
+            message = self.receive_event()
+            messages.append(message)
+            if "method" in message and message["method"] == "Debugger.paused":
+                self.pause = message
+                break
+        return messages
+
+def deploy_script(env: Env):
+    env.expect('TFUNCTION', 'DELETE', 'foo')
+    env.expect('TFUNCTION', 'LOAD', 'debug', SCRIPT).contains('The V8 remote debugging server is waiting for a connection')
 
 @gearsTest()
-def testDeployConnectStartDisconnect(env):
-    script = '''#!js api_version=1.0 name=foo
-redis.registerFunction("test", function(client) {
-    return 1
-})
-    '''
+def testDeployConnectStartDisconnect(env: Env):
+    deploy_script(env)
+    client = DebuggerClient(env)
+    client.disconnect()
 
-    env.expect('TFUNCTION', 'DELETE', 'foo')
-    env.expect('TFUNCTION', 'LOAD', 'debug', script).equal('OK')
-    client = ClientConnection("ws://127.0.0.1:9005")
+@gearsTest()
+def testSetBreakpointAndHitIt(env: Env):
+    deploy_script(env)
+    client = DebuggerClient(env)
+    breakpoint = client.set_breakpoint(2, 1)
+    env.assertEqual(len(client.breakpoints), 1)
+    # Now proceed from the very first instruction to the very first
+    # breakpoint we've just set.
+    client.resume_and_wait_until_pauses()
+    env.assertIsNotNone(client.pause)
+    env.assertContains("callFrames", client.pause["params"])
+    # Check that we hit the breakpoint we set above.
+    env.assertEqual(breakpoint.get_id(), client.pause["params"]["hitBreakpoints"][0])
+
+    client.disconnect()

--- a/redisgears_core/Cargo.toml
+++ b/redisgears_core/Cargo.toml
@@ -31,7 +31,7 @@ serde_derive = "=1.0.171"
 
 [build-dependencies]
 regex = "1"
-clap = "~2"
+clap = { version = "4", features = ["cargo"]}
 os_info = { version = "3", default-features = false }
 
 [lib]

--- a/redisgears_core/Cargo.toml
+++ b/redisgears_core/Cargo.toml
@@ -3,7 +3,7 @@ name = "redisgears_core"
 version = "99.99.99"
 edition = "2021"
 license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)"
-rust-version = "1.63"
+rust-version = "1.70"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/redisgears_core/src/config.rs
+++ b/redisgears_core/src/config.rs
@@ -144,4 +144,7 @@ lazy_static! {
     /// This basically means that we might bypass the `V8_MAX_MEMORY` configuration by at most
     /// `V8_LIBRARY_MEMORY_USAGE_DELTA`.
     pub(crate) static ref V8_LIBRARY_MEMORY_USAGE_DELTA: AtomicI64 = AtomicI64::default();
+
+    /// The V8 inspector debug server address.
+    pub(crate) static ref V8_DEBUG_SERVER_ADDRESS: RedisGILGuard<String> = RedisGILGuard::default();
 }

--- a/redisgears_core/src/debugging.rs
+++ b/redisgears_core/src/debugging.rs
@@ -124,12 +124,6 @@ impl Server {
             }
         }
     }
-
-    /// Returns [`true`] if the server is prepared.
-    /// See [`Self::AwaitingConnection`] for more information.
-    fn is_prepared(&self) -> bool {
-        matches!(self, Self::AwaitingConnection { .. })
-    }
 }
 
 impl Drop for Server {

--- a/redisgears_core/src/debugging.rs
+++ b/redisgears_core/src/debugging.rs
@@ -108,7 +108,7 @@ impl Server {
                 let library = if let Some(backend) = backend {
                     if backend.has_accepted_connection() {
                         let compiled_function_info =
-                            function_compile(compilation_arguments.clone(), true)
+                            function_compile(context, compilation_arguments.clone(), true)
                                 .map_err(GearsApiError::new)?;
 
                         let debug_payload =

--- a/redisgears_core/src/debugging.rs
+++ b/redisgears_core/src/debugging.rs
@@ -1,0 +1,139 @@
+use std::sync::Arc;
+
+use redis_module::Context;
+use redisgears_plugin_api::redisgears_plugin_api::{
+    backend_ctx::DebuggerBackend, GearsApiError, GearsApiResult,
+};
+
+use crate::{
+    function_load_command::{function_load_internal, CompilationArguments},
+    get_backends_mut, GearsLibrary,
+};
+
+/// A debugger server is a thread that executes a user library with
+/// a remote debugger attached.
+pub(crate) enum Server {
+    /// A state when the [`DebuggerBackend`] has been started and is
+    /// listening for a connection, but hasn't accepted any yet, so
+    /// there is no debugging session as of this moment.
+    AwaitingConnection {
+        compilation_arguments: CompilationArguments,
+        // Made an [`Option`] to be able to change the state via a
+        // mutable reference to "this".
+        backend: Option<Box<dyn DebuggerBackend>>,
+    },
+    /// A state when the [`DebuggerServer`] has established (accepted)
+    /// a connection with a remote debugger and compiled+evaluated the
+    /// script, and the debugging process is taking place.
+    InProgress {
+        /// The library being debugged.
+        library: Arc<GearsLibrary>,
+        /// The debugger backend (server).
+        backend: Box<dyn DebuggerBackend>,
+    },
+}
+
+impl Server {
+    /// Prepares a debugger server for a session.
+    pub fn prepare(
+        compilation_arguments: CompilationArguments,
+        backend: Box<dyn DebuggerBackend>,
+    ) -> Self {
+        Self::AwaitingConnection {
+            compilation_arguments,
+            backend: Some(backend),
+        }
+    }
+
+    fn ensure_connection_is_accepted(&mut self) -> GearsApiResult {
+        match self {
+            Self::AwaitingConnection { backend, .. } => backend
+                .as_mut()
+                .ok_or_else(|| GearsApiError::new("The debugger backend wasn't set correctly."))?
+                .accept_connection(),
+            _ => Ok(()),
+        }
+    }
+
+    fn ensure_script_is_compiled(&mut self, context: &Context) -> GearsApiResult {
+        match self {
+            Self::AwaitingConnection {
+                compilation_arguments,
+                backend,
+            } => {
+                let library = if let Some(backend) = backend {
+                    if backend.accepted_connection() {
+                        let library = function_load_internal(
+                            context,
+                            compilation_arguments.clone(),
+                            true,
+                            false,
+                            false,
+                        )
+                        .map_err(GearsApiError::new)?;
+
+                        let debug_payload = library.lib_ctx.get_debug_payload()?;
+
+                        backend.start_session(debug_payload)?;
+                        library
+                    } else {
+                        return Err(GearsApiError::new("The debugger will not compile a script until there is a client connection accepted."));
+                    }
+                } else {
+                    return Err(GearsApiError::new("The debugger backend wasn't set."));
+                };
+
+                let backend = backend
+                    .take()
+                    .ok_or_else(|| GearsApiError::new("The debugger backend disappeared."))?;
+
+                std::mem::swap(self, &mut Self::InProgress { library, backend });
+
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn make_progress(&mut self) -> GearsApiResult {
+        match self {
+            Self::InProgress { backend, .. } => backend.process_events(),
+            _ => Err(GearsApiError::new("Invalid state of debugger.")),
+        }
+    }
+
+    /// Process the queued incoming and outcoming messages, or advances
+    /// the state of the server (if it was prepared, it will attempt
+    /// to accept a connection).
+    pub fn process_events(&mut self, context: &Context) -> GearsApiResult {
+        self.ensure_connection_is_accepted()?;
+        self.ensure_script_is_compiled(context)?;
+        self.make_progress()
+    }
+
+    /// Returns [`true`] if the server is prepared.
+    /// See [`Self::AwaitingConnection`] for more information.
+    fn is_prepared(&self) -> bool {
+        matches!(self, Self::AwaitingConnection { .. })
+    }
+}
+
+impl std::fmt::Debug for Server {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AwaitingConnection {
+                compilation_arguments,
+                backend,
+            } => f
+                .debug_struct("AwaitingConnection")
+                .field("compilation_arguments", &compilation_arguments)
+                .field("backend", &format!("{:p}", backend))
+                .finish(),
+            Self::InProgress { library, backend } => f
+                .debug_struct("InProgress")
+                .field("library", &library)
+                .field("backend", &format!("{:p}", backend))
+                .finish(),
+        }
+    }
+}

--- a/redisgears_core/src/debugging.rs
+++ b/redisgears_core/src/debugging.rs
@@ -71,11 +71,11 @@ impl Server {
                             compiled_function_info.library_context.get_debug_payload()?;
 
                         backend.start_session(debug_payload)?;
-                        function_evaluate_and_store(context, compiled_function_info, false, false)
+                        function_evaluate_and_store(context, compiled_function_info, true, false)
                             .map_err(|e| {
-                            backend.stop_session();
-                            GearsApiError::new(e)
-                        })?
+                                backend.stop_session();
+                                GearsApiError::new(e)
+                            })?
                     } else {
                         return Err(GearsApiError::new("The debugger will not compile a script until there is a client connection accepted."));
                     }

--- a/redisgears_core/src/debugging.rs
+++ b/redisgears_core/src/debugging.rs
@@ -6,10 +6,8 @@ use redisgears_plugin_api::redisgears_plugin_api::{
 };
 
 use crate::{
-    function_load_command::{
-        function_compile, function_evaluate_and_store, function_load_internal, CompilationArguments,
-    },
-    get_backends_mut, GearsLibrary,
+    function_load_command::{function_compile, function_evaluate_and_store, CompilationArguments},
+    GearsLibrary,
 };
 
 /// A debugger server is a thread that executes a user library with
@@ -97,7 +95,7 @@ impl Server {
         }
     }
 
-    fn make_progress(&mut self) -> GearsApiResult {
+    fn make_progress(&mut self) -> GearsApiResult<bool> {
         match self {
             Self::InProgress { backend, .. } => backend.process_events(),
             _ => Err(GearsApiError::new("Invalid state of debugger.")),
@@ -107,7 +105,7 @@ impl Server {
     /// Process the queued incoming and outcoming messages, or advances
     /// the state of the server (if it was prepared, it will attempt
     /// to accept a connection).
-    pub fn process_events(&mut self, context: &Context) -> GearsApiResult {
+    pub fn process_events(&mut self, context: &Context) -> GearsApiResult<bool> {
         self.ensure_connection_is_accepted()?;
         self.ensure_script_is_compiled(context)?;
         self.make_progress()

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -450,11 +450,7 @@ fn function_load_with_args_with_debugger(
 
     let address = { &V8_DEBUG_SERVER_ADDRESS.lock(context) };
 
-    let mut global_debugger_server = crate::get_globals_mut()
-        .debugger_server
-        .lock()
-        .expect("Couldn't lock the debugger server");
-    if global_debugger_server.is_some() {
+    if crate::get_globals_mut().debugger_server.is_some() {
         return Err(RedisError::Str(
             "Only one debugging session can be established at a time.",
         ));
@@ -483,10 +479,12 @@ fn function_load_with_args_with_debugger(
 
     thread_ctx.reply(Ok(connection_hints_message));
 
-    let _ = global_debugger_server.insert(crate::debugging::Server::prepare(
-        compilation_arguments,
-        debugger_backend,
-    ));
+    let _ = crate::get_globals_mut()
+        .debugger_server
+        .insert(crate::debugging::Server::prepare(
+            compilation_arguments,
+            debugger_backend,
+        ));
 
     Ok(())
 }

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -441,6 +441,12 @@ fn function_load_with_args_with_debugger(
 
     let address = { &V8_DEBUG_SERVER_ADDRESS.lock(context) };
 
+    if address.is_empty() {
+        return Err(RedisError::Str(
+            "The debug server address was not specified in the configuration.",
+        ));
+    }
+
     if crate::get_globals_mut().debugger_server.is_some() {
         return Err(RedisError::Str(
             "Only one debugging session can be established at a time.",

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -106,7 +106,7 @@ fn start_debug_server_for_library(
     context: &Context,
     address: &str,
     compilation_arguments: &CompilationArguments,
-) -> Result<Box<dyn DebuggerBackend + Send>, GearsApiError> {
+) -> Result<Box<dyn DebuggerBackend>, GearsApiError> {
     compilation_arguments
         .get_backend_mut(context)?
         .start_debug_server(address)

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -4,8 +4,6 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
-use crate::get_globals;
-use redis_module::ContextFlags;
 use redis_module::{
     Context, NextArg, RedisError, RedisResult, RedisString, RedisValue, ThreadSafeContext,
 };

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -216,10 +216,10 @@ fn compile_library(
 }
 
 /// Evaluates the compiled function code and if everything is okay,
-/// store the compiled and evaluated script within the global storage.
+/// stores the compiled and evaluated script within the global storage.
 pub(crate) fn function_evaluate_and_store(
     context: &Context,
-    compiled_function_info: CompiledFunctionInfo,
+    compiled_function_info: CompiledLibraryInfo,
     upgrade: bool,
     is_loading_rdb: bool,
 ) -> Result<Arc<GearsLibrary>, String> {
@@ -266,7 +266,8 @@ pub(crate) fn function_evaluate_and_store(
     Ok(gears_library)
 }
 
-pub(crate) struct CompiledFunctionInfo {
+/// Contains the information of a compiled library.
+pub(crate) struct CompiledLibraryInfo {
     pub(crate) meta_data: GearsLibraryMetaData,
     pub(crate) library_context: Box<dyn LibraryCtxInterface>,
     pub(crate) internals: Arc<CompiledLibraryInternals>,
@@ -276,17 +277,17 @@ pub(crate) struct CompiledFunctionInfo {
 pub(crate) fn function_compile(
     compilation_arguments: CompilationArguments,
     debug: bool,
-) -> Result<CompiledFunctionInfo, String> {
+) -> Result<CompiledLibraryInfo, String> {
     let compiled_library_data = compilation_arguments
         .compile(debug)
-        .map_err(|e| format!("Failed library compilation: {}", e.get_msg()))?;
+        .map_err(|e| format!("Failed to compile library: {}", e.get_msg()))?;
     let (meta_data, library_context, internals) = (
         compiled_library_data.meta_data,
         compiled_library_data.library_ctx_interface,
         compiled_library_data.compiled_library_internals,
     );
 
-    Ok(CompiledFunctionInfo {
+    Ok(CompiledLibraryInfo {
         meta_data,
         library_context,
         internals,

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -16,7 +16,7 @@ use redisgears_plugin_api::redisgears_plugin_api::{GearsApiError, GearsApiResult
 
 use crate::compiled_library_api::{CompiledLibraryAPI, CompiledLibraryInternals};
 use crate::config::V8_DEBUG_SERVER_ADDRESS;
-use crate::{get_backend, get_backends_mut, verify_name, Deserialize, Serialize};
+use crate::{get_backend, get_backends_mut, get_globals, verify_name, Deserialize, Serialize};
 
 use crate::{get_libraries, GearsLibrary, GearsLibraryCtx, GearsLibraryMetaData};
 

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -547,7 +547,7 @@ pub(crate) fn function_load_on_replica(
         .ok_or(RedisError::Str("User was not provided by primary"))?;
     let compilation_arguments = CompilationArguments::new(user, args.code, args.config);
     // On replica, we always obey the primary and perform an upgrade.
-    match function_load_internal(ctx, args, false, true, true) {
+    match function_load_internal(ctx, compilation_arguments, false, true, true) {
         Ok(_) => Ok(RedisValue::SimpleStringStatic("OK")),
         Err(e) => Err(RedisError::String(e)),
     }

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -112,13 +112,6 @@ impl CompilationArguments {
         library_extract_metadata(&self.code, self.config.clone(), self.user.0.clone())
     }
 
-    /// Returns the library name.
-    pub(crate) fn get_library_name(&self) -> GearsApiResult<String> {
-        self.get_metadata()
-            .map_err(|e| GearsApiError::new(e.to_string()))
-            .map(|m| m.name)
-    }
-
     /// Returns a mutable reference to the backend for the library.
     pub(crate) fn get_backend_mut(
         &self,

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -433,6 +433,12 @@ fn function_load_with_args_with_debugger(
     context: &Context,
     args: FunctionLoadArgs,
 ) -> RedisResult<()> {
+    if mr::libmr::is_cluster_in_cluster_mode() {
+        return Err(RedisError::Str(
+            "Debugging when in cluster mode isn't supported.",
+        ));
+    }
+
     let address = { &V8_DEBUG_SERVER_ADDRESS.lock(context) };
 
     if crate::get_globals_mut().debugger_server.is_some() {

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -434,18 +434,6 @@ fn function_load_with_args_with_debugger(
     let compilation_arguments = CompilationArguments::try_from(args).map_err(|e| {
         RedisError::String(format!("Couldn't build the compilation arguments: {e}"))
     })?;
-    let library_name = compilation_arguments.get_library_name()?;
-
-    // let mut compiled_library_data = compilation_arguments.compile(true)?;
-    // let backend_name = compiled_library_data.meta_data.engine.clone();
-    // let debug_payload = compiled_library_data
-    //     .library_ctx_interface
-    //     .get_debug_payload()?;
-    let gears_library =
-        function_load_internal(context, compilation_arguments.clone(), true, false, false)
-            .map_err(RedisError::String)?;
-    let backend_name = gears_library.get_backend_name().to_owned();
-    let debug_payload = gears_library.lib_ctx.get_debug_payload()?;
 
     let (connection_hints_message, mut debugger_server) =
         start_debug_server_for_library(address, &compilation_arguments)
@@ -466,24 +454,45 @@ fn function_load_with_args_with_debugger(
 
     thread_ctx.reply(Ok(connection_hints_message));
 
+    let library_name = compilation_arguments.get_library_name()?;
+
     let join_handle = debugger_server
         .accept_connection()
         .map_err(|e| RedisError::String(e.to_string()))
-        .map(|_| {
-            std::thread::Builder::new()
-                .name(format!("DebuggerThread-{library_name}"))
-                .spawn(move || {
-                    let backend = get_backends_mut().get_mut(&backend_name).ok_or_else(|| {
-                        GearsApiError::new(format!("Unknown backend {backend_name}"))
-                    })?;
-                    debugger_server
-                        .start(backend, debug_payload)
-                        .map_err(|e| RedisError::String(e.to_string()))
-                })
-                .expect("Couldn't start a debugger thread")
-        })?;
+        .map(
+            |_| -> GearsApiResult<std::thread::JoinHandle<GearsApiResult>> {
+                // let mut compiled_library_data = compilation_arguments.compile(true)?;
+                // let backend_name = compiled_library_data.meta_data.engine.clone();
+                // let debug_payload = compiled_library_data
+                //     .library_ctx_interface
+                //     .get_debug_payload()?;
+                let gears_library = function_load_internal(
+                    context,
+                    compilation_arguments.clone(),
+                    true,
+                    false,
+                    false,
+                )
+                .map_err(GearsApiError::new)?;
+                let backend_name = gears_library.get_backend_name().to_owned();
+                let debug_payload = gears_library.lib_ctx.get_debug_payload()?;
 
-    let _ = global_debugger_server.insert(join_handle.into());
+                std::thread::Builder::new()
+                    .name(format!("DebuggerThread-{library_name}"))
+                    .spawn(move || {
+                        let backend =
+                            get_backends_mut().get_mut(&backend_name).ok_or_else(|| {
+                                GearsApiError::new(format!("Unknown backend {backend_name}"))
+                            })?;
+                        debugger_server.start(backend, debug_payload)
+                    })
+                    .map_err(|e| {
+                        GearsApiError::new(format!("Couldn't start a debugger thread: {e}"))
+                    })
+            },
+        )?;
+
+    let _ = global_debugger_server.insert(join_handle?.into());
 
     Ok(())
 }

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -16,7 +16,7 @@ use redisgears_plugin_api::redisgears_plugin_api::{GearsApiError, GearsApiResult
 
 use crate::compiled_library_api::{CompiledLibraryAPI, CompiledLibraryInternals};
 use crate::config::V8_DEBUG_SERVER_ADDRESS;
-use crate::{get_backend, get_backends_mut, get_globals, verify_name, Deserialize, Serialize};
+use crate::{get_backend, verify_name, Deserialize, Serialize};
 
 use crate::{get_libraries, GearsLibrary, GearsLibraryCtx, GearsLibraryMetaData};
 
@@ -534,26 +534,6 @@ pub(crate) fn function_load_command(
     args.user = Some(ctx.get_current_user());
     function_load_with_args(ctx, args);
     Ok(RedisValue::NoReply)
-}
-
-/// Verify that it is OK to perform an internal command.
-/// Internal command should only run if it came from replication stream
-/// or from AOF loading. In other words, the command did not came directly from a user.
-fn verify_internal_command(ctx: &Context) -> Result<(), RedisError> {
-    let flags = ctx.get_flags();
-    let globals = get_globals();
-    if !flags.contains(ContextFlags::LOADING)
-        && !(flags.contains(ContextFlags::REPLICATED) || globals.db_policy.is_pseudo_slave())
-    {
-        // Internal commands should either be loaded from AOF ([`ContextFlags::LOADING`])
-        // or sent over the replication stream([`ContextFlags::REPLICATED`]).
-        // Another special option is if the instance is pseudo slave (replica of) which is treated as if the command was replicated from primary.
-        // If none of those cases holds we will return an error.
-        return Err(RedisError::Str(
-            "Internal command should only be sent from primary or loaded from AOF",
-        ));
-    }
-    Ok(())
 }
 
 pub(crate) fn function_load_on_replica(

--- a/redisgears_core/src/keys_notifications.rs
+++ b/redisgears_core/src/keys_notifications.rs
@@ -18,12 +18,13 @@ type AckCallback = Box<dyn FnOnce(Result<(), GearsApiError>) + Send + Sync>;
 /// key space notification arrives.
 pub(crate) type NotificationCallback = Box<dyn Fn(&Context, &str, &[u8], AckCallback)>;
 
+#[derive(Debug)]
 pub(crate) enum ConsumerKey {
     Key(Vec<u8>),
     Prefix(Vec<u8>),
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct NotificationConsumerStats {
     pub(crate) num_trigger: usize,
     pub(crate) num_success: usize,
@@ -39,6 +40,23 @@ pub(crate) struct NotificationConsumer {
     callback: Option<NotificationCallback>,
     stats: Arc<RefCellWrapper<NotificationConsumerStats>>,
     description: Option<String>,
+}
+
+impl std::fmt::Debug for NotificationConsumer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let callback = if let Some(callback) = self.callback.as_ref() {
+            format!("Some({callback:p})")
+        } else {
+            "None".to_owned()
+        };
+
+        f.debug_struct("NotificationConsumer")
+            .field("key", &self.key)
+            .field("callback", &callback)
+            .field("stats", &self.stats)
+            .field("description", &self.description)
+            .finish()
+    }
 }
 
 impl NotificationConsumer {

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -299,13 +299,6 @@ struct GearsLibrary {
     compile_lib_internals: Arc<CompiledLibraryInternals>,
 }
 
-impl GearsLibrary {
-    /// Returns the backend name used by this library.
-    pub(crate) fn get_backend_name(&self) -> &str {
-        &self.gears_lib_ctx.meta_data.engine
-    }
-}
-
 impl std::fmt::Debug for GearsLibrary {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GearsLibrary")

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -1655,11 +1655,18 @@ fn cron_event_handler(ctx: &Context, _hz: u64) {
     globals.avoid_replication_traffic = ctx.avoid_replication_traffic();
 
     if let Ok(mut debugger_backend) = globals.debugger_server.lock() {
+        let mut has_error = false;
+
         if let Some(debugger_backend) = debugger_backend.as_mut() {
             // if let Some(debugger_backend) = globals.debugger_server.as_mut() {
             if let Err(e) = debugger_backend.process_events(ctx) {
                 log::error!("{e}");
+                has_error = true;
             }
+        }
+
+        if has_error {
+            let _ = debugger_backend.take();
         }
     }
 }

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -10,7 +10,6 @@
 
 #![deny(missing_docs)]
 
-use function_load_command::CompilationArguments;
 use keys_notifications_ctx::KeySpaceNotificationsCtx;
 use redis_module::redisvalue::RedisValueKey;
 use redis_module::{
@@ -59,9 +58,7 @@ use redisgears_plugin_api::redisgears_plugin_api::{
     stream_ctx::StreamCtxInterface, GearsApiError,
 };
 
-use redisgears_plugin_api::redisgears_plugin_api::{
-    FunctionCallResult, GearsApiResult, RefCellWrapper,
-};
+use redisgears_plugin_api::redisgears_plugin_api::{FunctionCallResult, RefCellWrapper};
 
 use crate::run_ctx::RunCtx;
 
@@ -274,7 +271,7 @@ impl GearsLibraryCtx {
 }
 
 impl std::fmt::Debug for GearsLibraryCtx {
-    fn fmt(&self, mut f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // TODO: add more fields.
 
         f.debug_struct("GearsLibraryCtx")
@@ -310,7 +307,7 @@ impl GearsLibrary {
 }
 
 impl std::fmt::Debug for GearsLibrary {
-    fn fmt(&self, mut f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GearsLibrary")
             .field("gears_lib_ctx", &self.gears_lib_ctx)
             .field("lib_ctx", &format!("{:p}", &self.lib_ctx))

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -1662,7 +1662,7 @@ fn cron_event_handler(ctx: &Context, _hz: u64) {
             match debugger_backend.process_events(ctx) {
                 Ok(true) => should_stop = true,
                 Err(e) => {
-                    log::error!("{e}");
+                    log::error!("Debugger error: {e}");
                     should_stop = true;
                 }
                 _ => {}

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -1655,7 +1655,7 @@ fn cron_event_handler(ctx: &Context, _hz: u64) {
     }
 
     if should_stop_debugger {
-        log::info!("Releasing the debugger.");
+        log::info!("The debugger server connection was dropped. Releasing the debugger.");
         let _ = globals.debugger_server.take();
     }
 }

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -1927,7 +1927,7 @@ mod gears_module {
                 ["gearsbox-address", &*GEARS_BOX_ADDRESS , "http://localhost:3000", ConfigurationFlags::DEFAULT, None],
                 ["v8-plugin-path", &*V8_PLUGIN_PATH , "libredisgears_v8_plugin.so", ConfigurationFlags::IMMUTABLE, None],
                 ["v8-flags", &*V8_FLAGS, "'--noexpose-wasm'", ConfigurationFlags::IMMUTABLE, None],
-                ["v8-debug-server-address", &*V8_DEBUG_SERVER_ADDRESS, "127.0.0.1:9005", ConfigurationFlags::IMMUTABLE, None],
+                ["v8-debug-server-address", &*V8_DEBUG_SERVER_ADDRESS, "", ConfigurationFlags::IMMUTABLE, None],
             ],
             bool: [
                 ["enable-debug-command", &*ENABLE_DEBUG_COMMAND , false, ConfigurationFlags::IMMUTABLE, None],

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -1381,8 +1381,7 @@ pub(crate) trait GILBackendStorage {
             })
     }
 
-    /// Returns the global redis module context after the module has been
-    /// initialized.
+    /// Returns the map of initialisied backends, accessed by their name.
     fn get_backends_mut(
         &self,
     ) -> &'static mut HashMap<String, Box<dyn BackendCtxInterfaceInitialised>> {

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -58,7 +58,9 @@ use redisgears_plugin_api::redisgears_plugin_api::{
     stream_ctx::StreamCtxInterface, GearsApiError,
 };
 
-use redisgears_plugin_api::redisgears_plugin_api::{FunctionCallResult, RefCellWrapper};
+use redisgears_plugin_api::redisgears_plugin_api::{
+    FunctionCallResult, GearsApiResult, RefCellWrapper,
+};
 
 use crate::run_ctx::RunCtx;
 
@@ -561,10 +563,10 @@ impl DbPolicy {
 /// a remote debugger attached.
 #[derive(Debug)]
 struct DebuggerServer {
-    join_handle: std::thread::JoinHandle<Result<(), RedisError>>,
+    join_handle: std::thread::JoinHandle<GearsApiResult>,
 }
-impl From<std::thread::JoinHandle<Result<(), RedisError>>> for DebuggerServer {
-    fn from(join_handle: std::thread::JoinHandle<Result<(), RedisError>>) -> Self {
+impl From<std::thread::JoinHandle<GearsApiResult>> for DebuggerServer {
+    fn from(join_handle: std::thread::JoinHandle<GearsApiResult>) -> Self {
         Self { join_handle }
     }
 }

--- a/redisgears_core/src/rdb.rs
+++ b/redisgears_core/src/rdb.rs
@@ -5,7 +5,8 @@
  */
 
 use crate::{
-    function_load_command::function_load_internal, get_globals, get_globals_mut, get_libraries,
+    function_load_command::{function_load_internal, CompilationArguments},
+    get_globals, get_globals_mut, get_libraries,
 };
 
 use mr::libmr::{calc_slot, is_my_slot};
@@ -130,7 +131,8 @@ fn aux_load_internals(ctx: &Context, rdb: *mut raw::RedisModuleIO) -> Result<(),
 
         // allow upgrade on pseudo_slave (replica-of) because we might get the same function multiple time from different source shards.
         let is_pseudo_slave = get_globals().db_policy.is_pseudo_slave();
-        match function_load_internal(ctx, user, &code, config, is_pseudo_slave, true) {
+        let compilation_arguments = CompilationArguments::new(user, code, config);
+        match function_load_internal(ctx, compilation_arguments, false, is_pseudo_slave, true) {
             Ok(_) => {}
             Err(e) => return Err(Error::generic(&format!("Failed loading librart, {}", e))),
         }

--- a/redisgears_core/src/stream_reader.rs
+++ b/redisgears_core/src/stream_reader.rs
@@ -109,7 +109,7 @@ impl TrackedStream {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct ConsumerInfo {
     pub(crate) last_processed_time: u128, // last processed time in ms
     pub(crate) total_processed_time: u128, // last processed time in ms
@@ -158,6 +158,32 @@ pub(crate) struct ConsumerData<T: StreamReaderRecord, C: StreamConsumer<T>> {
     pub(crate) on_record_acked: Option<Box<RecordAcknowledgeCallback>>,
     pub(crate) description: Option<String>,
     phantom: std::marker::PhantomData<T>,
+}
+
+impl<T, C> std::fmt::Debug for ConsumerData<T, C>
+where
+    T: StreamReaderRecord + std::fmt::Debug,
+    C: StreamConsumer<T> + std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let struct_name = format!(
+            "ConsumerData<T = {}, C = {}>",
+            std::any::type_name::<T>(),
+            std::any::type_name::<C>(),
+        );
+        f.debug_struct(&struct_name)
+            .field("prefix", &self.prefix)
+            .field("consumer", &self.consumer)
+            .field("consumed_streams", &self.consumed_streams)
+            .field("window", &self.window)
+            .field("trim", &self.trim)
+            .field(
+                "on_record_acked",
+                &self.on_record_acked.as_ref().map(|e| format!("{e:p}")),
+            )
+            .field("description", &self.description)
+            .finish()
+    }
 }
 
 impl<T, C> ConsumerData<T, C>

--- a/redisgears_core/src/stream_run_ctx.rs
+++ b/redisgears_core/src/stream_run_ctx.rs
@@ -69,6 +69,7 @@ impl<'ctx> StreamProcessCtxInterface for StreamRunCtx<'ctx> {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct GearsStreamRecord {
     pub(crate) record: StreamRecord,
 }
@@ -118,6 +119,17 @@ impl GearsStreamConsumer {
             flags,
             permissions,
         }
+    }
+}
+
+impl std::fmt::Debug for GearsStreamConsumer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GearsStreamConsumer")
+            .field("ctx", &format!("{:p}", &self.ctx))
+            .field("lib_meta_data", &self.lib_meta_data)
+            .field("flags", &self.flags)
+            .field("permissions", &self.permissions)
+            .finish()
     }
 }
 

--- a/redisgears_plugin_api/Cargo.toml
+++ b/redisgears_plugin_api/Cargo.toml
@@ -15,5 +15,6 @@ bitflags = "1"
 # this project will not be able to compromise it.
 serde = { version = "=1.0.171", features = ["derive"] }
 serde_derive = "=1.0.171"
+log = "0.4"
 
 [build-dependencies]

--- a/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
@@ -57,18 +57,27 @@ pub trait DebuggerBackend {
     /// by having the [DebuggerBackend::start] method called.
     fn accept_connection(&mut self) -> GearsApiResult;
 
-    /// Starts the main loop of the debugger server. A connection is
-    /// expected to have been established prior to calling this
-    /// method.
-    fn start(
-        &mut self,
-        backend: &mut Box<dyn BackendCtxInterfaceInitialised>,
-        payload: DebuggerBackendPayload,
-    ) -> GearsApiResult;
+    /// Starts the debugging session. A connection is expected to have
+    /// been established prior to calling this method.
+    fn start_session(&mut self, payload: DebuggerBackendPayload) -> GearsApiResult;
+
+    /// Processes the events until there are no more events to process.
+    /// It is expected to have this method called repeatedly, until the
+    /// session is stopped.
+    ///
+    /// # Note
+    ///
+    /// The connection must have been established prior to calling this
+    /// method, as well as a debugging session must have been started.
+    fn process_events(&mut self) -> GearsApiResult;
 
     /// Returns a human-readable string, explaining how to connect to
     /// the server.
     fn get_connection_hints(&self) -> Option<String>;
+
+    /// Returns [`true`] if it has previously accepted a client.
+    /// See [`DebuggerBackend::accept_connection`] for more information.
+    fn accepted_connection(&self) -> bool;
 }
 
 pub struct BackendCtx {

--- a/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
@@ -121,7 +121,7 @@ pub trait BackendCtxInterfaceInitialised {
     fn start_debug_server(
         &self,
         _address: &str,
-    ) -> Result<Box<dyn DebuggerBackend + Send>, GearsApiError> {
+    ) -> Result<Box<dyn DebuggerBackend>, GearsApiError> {
         Err(GearsApiError::new(format!(
             "Debugging isn't implemented for this backend: {}, {}",
             self.get_name(),

--- a/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
@@ -61,6 +61,9 @@ pub trait DebuggerBackend {
     /// been established prior to calling this method.
     fn start_session(&mut self, payload: DebuggerBackendPayload) -> GearsApiResult;
 
+    /// Stops the session that has been started.
+    fn stop_session(&mut self);
+
     /// Processes the events until there are no more events to process.
     /// It is expected to have this method called repeatedly, until the
     /// session is stopped.

--- a/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
@@ -80,7 +80,7 @@ pub trait DebuggerBackend {
 
     /// Returns [`true`] if it has previously accepted a client.
     /// See [`DebuggerBackend::accept_connection`] for more information.
-    fn accepted_connection(&self) -> bool;
+    fn has_accepted_connection(&self) -> bool;
 }
 
 pub struct BackendCtx {

--- a/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
@@ -72,7 +72,7 @@ pub trait DebuggerBackend {
     ///
     /// The connection must have been established prior to calling this
     /// method, as well as a debugging session must have been started.
-    fn process_events(&mut self) -> GearsApiResult;
+    fn process_events(&mut self) -> GearsApiResult<bool>;
 
     /// Returns a human-readable string, explaining how to connect to
     /// the server.

--- a/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
@@ -44,9 +44,6 @@ pub enum LibraryFatalFailurePolicy {
 /// so that those can downcast to their known type, so that that they
 /// can work with it.
 pub type DebuggerBackendPayload = Arc<dyn Any + Send + Sync>;
-/// A type for the script deletion callback. Should be invoked when
-/// the debugger no longer needs the script.
-pub type DebuggerDeleteCallback = Box<dyn FnOnce() -> GearsApiResult>;
 
 /// The trait which the plugins can implement to support the debugging.
 /// The debugging processed is assumed to follow the client-server

--- a/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
@@ -146,6 +146,10 @@ pub trait BackendCtxInterfaceUninitialised {
 
     /// Initialises the backend with the information passed and returns
     /// a successfully initialised instance.
+    /// As this is a part of the plugin API, the code loaded this way
+    /// cannot have the logger propagated automatically. For this
+    /// reason, it is required to have it passed as an argument to this
+    /// method.
     fn initialize(
         self: Box<Self>,
         logger: &'static dyn log::Log,

--- a/redisgears_plugin_api/src/redisgears_plugin_api/load_library_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/load_library_ctx.rs
@@ -13,6 +13,9 @@ use crate::redisgears_plugin_api::run_function_ctx::RemoteFunctionData;
 use crate::redisgears_plugin_api::stream_ctx::StreamCtxInterface;
 use crate::redisgears_plugin_api::GearsApiError;
 
+use super::backend_ctx::DebuggerBackendPayload;
+use super::GearsApiResult;
+
 pub const FUNCTION_FLAG_NO_WRITES_GLOBAL_NAME: &str = "NO_WRITES";
 pub const FUNCTION_FLAG_NO_WRITES_GLOBAL_VALUE: &str = "no-writes";
 
@@ -42,6 +45,7 @@ pub struct ModuleInfo {
 }
 
 pub trait LibraryCtxInterface {
+    /// Evaluates the library code.
     fn load_library(
         &self,
         load_library_ctx: &dyn LoadLibraryCtxInterface,
@@ -49,6 +53,10 @@ pub trait LibraryCtxInterface {
     ) -> Result<(), GearsApiError>;
 
     fn get_info(&self) -> Option<ModuleInfo>;
+
+    /// Returns an opaque object useful for debugging. See
+    /// [super::backend_ctx::DebuggerBackend::start].
+    fn get_debug_payload(&self) -> GearsApiResult<DebuggerBackendPayload>;
 }
 
 pub enum RegisteredKeys<'a> {

--- a/redisgears_v8_plugin/Cargo.toml
+++ b/redisgears_v8_plugin/Cargo.toml
@@ -10,8 +10,10 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 redis-module = { workspace = true }
 # v8_rs = { git = "https://github.com/RedisGears/v8-rs" }
 # v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs" }
-v8_rs = { path = "../../v8-rs" }
-v8_rs_derive = { path = "../../v8-rs/v8-rs-derive" }
+# v8_rs = { path = "../../v8-rs" }
+# v8_rs_derive = { path = "../../v8-rs/v8-rs-derive" }
+v8_rs = { path = "../../v8-rs-inspector" }
+v8_rs_derive = { path = "../../v8-rs-inspector/v8-rs-derive" }
 redisgears_plugin_api = { path = "../redisgears_plugin_api/" }
 redisgears-macros-internals = { path = "../redisgears_macros_internals/" }
 serde_json = "1"

--- a/redisgears_v8_plugin/Cargo.toml
+++ b/redisgears_v8_plugin/Cargo.toml
@@ -12,8 +12,6 @@ redis-module = { workspace = true }
 # v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs" }
 # v8_rs = { path = "../../v8-rs" }
 # v8_rs_derive = { path = "../../v8-rs/v8-rs-derive" }
-v8_rs = { path = "../../v8-rs-inspector" }
-v8_rs_derive = { path = "../../v8-rs-inspector/v8-rs-derive" }
 redisgears_plugin_api = { path = "../redisgears_plugin_api/" }
 redisgears-macros-internals = { path = "../redisgears_macros_internals/" }
 serde_json = "1"

--- a/redisgears_v8_plugin/Cargo.toml
+++ b/redisgears_v8_plugin/Cargo.toml
@@ -8,10 +8,10 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 
 [dependencies]
 redis-module = { workspace = true }
-# v8_rs = { git = "https://github.com/RedisGears/v8-rs" }
-# v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs" }
-# v8_rs = { path = "../../v8-rs" }
-# v8_rs_derive = { path = "../../v8-rs/v8-rs-derive" }
+#v8_rs = { git = "https://github.com/RedisGears/v8-rs" }
+#v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs" }
+v8_rs = { path = "../../v8-rs-inspector/" }
+v8_rs_derive = { path = "../../v8-rs-inspector/v8-rs-derive/" }
 redisgears_plugin_api = { path = "../redisgears_plugin_api/" }
 redisgears-macros-internals = { path = "../redisgears_macros_internals/" }
 serde_json = "1"

--- a/redisgears_v8_plugin/Cargo.toml
+++ b/redisgears_v8_plugin/Cargo.toml
@@ -8,8 +8,10 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 
 [dependencies]
 redis-module = { workspace = true }
-v8_rs = { git = "https://github.com/RedisGears/v8-rs" }
-v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs" }
+# v8_rs = { git = "https://github.com/RedisGears/v8-rs" }
+# v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs" }
+v8_rs = { path = "../../v8-rs" }
+v8_rs_derive = { path = "../../v8-rs/v8-rs-derive" }
 redisgears_plugin_api = { path = "../redisgears_plugin_api/" }
 redisgears-macros-internals = { path = "../redisgears_macros_internals/" }
 serde_json = "1"
@@ -19,6 +21,7 @@ serde = { version = "=1.0.171", features = ["derive"] }
 serde_derive = "=1.0.171"
 lazy_static = "1"
 bitflags = "2"
+log = "0.4"
 
 [build-dependencies]
 

--- a/redisgears_v8_plugin/Cargo.toml
+++ b/redisgears_v8_plugin/Cargo.toml
@@ -8,10 +8,8 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 
 [dependencies]
 redis-module = { workspace = true }
-#v8_rs = { git = "https://github.com/RedisGears/v8-rs" }
-#v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs" }
-v8_rs = { path = "../../v8-rs-inspector/" }
-v8_rs_derive = { path = "../../v8-rs-inspector/v8-rs-derive/" }
+v8_rs = { git = "https://github.com/RedisGears/v8-rs" }
+v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs" }
 redisgears_plugin_api = { path = "../redisgears_plugin_api/" }
 redisgears-macros-internals = { path = "../redisgears_macros_internals/" }
 serde_json = "1"

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -449,9 +449,6 @@ enum DebuggerServer {
     Started(Box<ScriptDebuggerSession>),
 }
 
-// TODO remove
-unsafe impl Send for DebuggerServer {}
-
 impl DebuggerServer {
     fn prepare<T: AsRef<str>>(address: T) -> Result<Self, GearsApiError> {
         let server =
@@ -1050,10 +1047,7 @@ impl BackendCtxInterfaceInitialised for V8Backend {
         Some(ModuleInfo { sections })
     }
 
-    fn start_debug_server(
-        &self,
-        address: &str,
-    ) -> Result<Box<dyn DebuggerBackend + Send>, GearsApiError> {
+    fn start_debug_server(&self, address: &str) -> Result<Box<dyn DebuggerBackend>, GearsApiError> {
         Ok(Box::new(DebuggerServer::prepare(address)?))
     }
 }

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -752,10 +752,7 @@ impl BackendCtxInterfaceInitialised for V8Backend {
                 let isolate_scope = isolate.enter();
                 let ctx = isolate_scope.new_context(None);
                 let ctx_scope = ctx.enter(&isolate_scope);
-                let inspector = RawInspector::new(
-                    isolate_scope.get_raw_isolate(),
-                    ctx_scope.get_raw_context().as_ptr(),
-                );
+                let inspector = RawInspector::new(ctx_scope.get_raw_context().as_ptr());
 
                 let globals = ctx_scope.get_globals();
                 if !(get_global_option().contains(GlobalOptions::AVOID_GLOBALS_ALLOW_LIST)) {

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -164,6 +164,14 @@ impl<'a> log::Log for Logger<'a> {
     }
 }
 
+/// The logger implementation for this crate. This crate has a plugin
+/// interface and is and can only be used as a plugin (so, a library
+/// loaded at runtime). For this reason, Rust cannot propagate the
+/// main crate's logger (where it is set) to the code of this crate. To
+/// address this, we require a logger to be passed in the
+/// [`BackendCtxInterfaceUninitialised::initialize`] method which is
+/// used to initialise the plugin. Until the moment of initialisation,
+/// the [`NoopLogger`] is used which does not log anything.
 static mut LOGGER: Logger = Logger(&NoopLogger);
 
 type ScriptCtxVec = Arc<Mutex<Vec<Weak<V8ScriptCtx>>>>;

--- a/redisgears_v8_plugin/src/v8_function_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_function_ctx.rs
@@ -245,7 +245,6 @@ impl V8InternalFunction {
         let isolate_scope = self.script_ctx.isolate.enter();
         let ctx_scope = self.script_ctx.context.enter(&isolate_scope);
         let trycatch = isolate_scope.new_try_catch();
-        // TODO: set .. here?
 
         let res = {
             let args = {

--- a/redisgears_v8_plugin/src/v8_function_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_function_ctx.rs
@@ -159,7 +159,7 @@ impl V8InternalFunction {
         decode_args: bool,
     ) -> FunctionCallResult {
         let isolate_scope = self.script_ctx.isolate.enter();
-        let ctx_scope = self.script_ctx.ctx.enter(&isolate_scope);
+        let ctx_scope = self.script_ctx.context.enter(&isolate_scope);
         let trycatch = isolate_scope.new_try_catch();
 
         let res = {
@@ -243,8 +243,9 @@ impl V8InternalFunction {
         decode_arguments: bool,
     ) -> FunctionCallResult {
         let isolate_scope = self.script_ctx.isolate.enter();
-        let ctx_scope = self.script_ctx.ctx.enter(&isolate_scope);
+        let ctx_scope = self.script_ctx.context.enter(&isolate_scope);
         let trycatch = isolate_scope.new_try_catch();
+        // TODO: set .. here?
 
         let res = {
             let args = {

--- a/redisgears_v8_plugin/src/v8_native_functions.rs
+++ b/redisgears_v8_plugin/src/v8_native_functions.rs
@@ -791,7 +791,7 @@ pub struct ApiVersionSupported {
 }
 impl PartialOrd for ApiVersionSupported {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.version.partial_cmp(&other.version)
+        Some(self.cmp(other))
     }
 }
 impl Ord for ApiVersionSupported {

--- a/redisgears_v8_plugin/src/v8_native_functions.rs
+++ b/redisgears_v8_plugin/src/v8_native_functions.rs
@@ -342,7 +342,7 @@ pub(crate) fn get_backgrounnd_client<'isolate_scope, 'isolate>(
                 };
 
                 let isolate_scope = script_ctx.isolate.enter();
-                let ctx_scope = script_ctx.ctx.enter(&isolate_scope);
+                let ctx_scope = script_ctx.context.enter(&isolate_scope);
 
                 let resolver = resolver.take_local(&isolate_scope).as_resolver();
                 match result {
@@ -412,7 +412,7 @@ pub(crate) fn get_backgrounnd_client<'isolate_scope, 'isolate>(
                 };
 
                 let isolate_scope = script_ctx.isolate.enter();
-                let ctx_scope = script_ctx.ctx.enter(&isolate_scope);
+                let ctx_scope = script_ctx.context.enter(&isolate_scope);
 
                 let resolver = resolver.take_local(&isolate_scope).as_resolver();
                 let results: Vec<V8LocalValue> = results.into_iter().map(|v| {
@@ -554,7 +554,7 @@ fn add_call_function(
                             }
                         };
                         let isolate_scope = script_ctx_ref.isolate.enter();
-                        let ctx_scope = script_ctx_ref.ctx.enter(&isolate_scope);
+                        let ctx_scope = script_ctx_ref.context.enter(&isolate_scope);
 
                         let resolver = persisted_resolver.take_local(&isolate_scope).as_resolver();
                         let res = call_result_to_js_object(
@@ -720,7 +720,7 @@ pub(crate) fn get_redis_client<'isolate_scope, 'isolate>(
                 .compiled_library_api
                 .run_on_background(Box::new(move || {
                     let isolate_scope = new_script_ctx_ref.isolate.enter();
-                    let ctx_scope = new_script_ctx_ref.ctx.enter(&isolate_scope);
+                    let ctx_scope = new_script_ctx_ref.context.enter(&isolate_scope);
                     let trycatch = isolate_scope.new_try_catch();
 
                     let background_client = get_backgrounnd_client(
@@ -1340,7 +1340,7 @@ pub(crate) fn initialize_globals_1_0(
                     }
                 };
                 let isolate_scope = script_ctx.isolate.enter();
-                let ctx_scope = script_ctx.ctx.enter(&isolate_scope);
+                let ctx_scope = script_ctx.context.enter(&isolate_scope);
                 let trycatch = isolate_scope.new_try_catch();
 
                 let mut args = Vec::new();
@@ -1509,7 +1509,7 @@ pub(crate) fn initialize_globals_1_0(
                                     };
                                 let isolate_scope = new_script_ctx_ref_resolve.isolate.enter();
                                 let ctx_scope =
-                                    new_script_ctx_ref_resolve.ctx.enter(&isolate_scope);
+                                    new_script_ctx_ref_resolve.context.enter(&isolate_scope);
                                 let _trycatch = isolate_scope.new_try_catch();
                                 let res = res.take_local(&isolate_scope);
                                 if let Some(mut v) = resolver_resolve.ref_cell.borrow_mut().take() {
@@ -1556,7 +1556,8 @@ pub(crate) fn initialize_globals_1_0(
                                         }
                                     };
                                 let isolate_scope = new_script_ctx_ref_reject.isolate.enter();
-                                let ctx_scope = new_script_ctx_ref_reject.ctx.enter(&isolate_scope);
+                                let ctx_scope =
+                                    new_script_ctx_ref_reject.context.enter(&isolate_scope);
                                 let _trycatch = isolate_scope.new_try_catch();
                                 let res = res.take_local(&isolate_scope);
                                 if let Some(mut v) = resolver_reject.ref_cell.borrow_mut().take() {

--- a/redisgears_v8_plugin/src/v8_notifications_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_notifications_ctx.rs
@@ -36,7 +36,7 @@ impl V8NotificationsCtxInternal {
     ) {
         let res = {
             let isolate_scope = self.script_ctx.isolate.enter();
-            let ctx_scope = self.script_ctx.ctx.enter(&isolate_scope);
+            let ctx_scope = self.script_ctx.context.enter(&isolate_scope);
             let try_catch = isolate_scope.new_try_catch();
 
             let notification_data = data.take_local(&isolate_scope);
@@ -111,7 +111,7 @@ impl V8NotificationsCtxInternal {
     ) {
         let res = {
             let isolate_scope = self.script_ctx.isolate.enter();
-            let ctx_scope = self.script_ctx.ctx.enter(&isolate_scope);
+            let ctx_scope = self.script_ctx.context.enter(&isolate_scope);
             let trycatch = isolate_scope.new_try_catch();
 
             let notification_data = data.take_local(&isolate_scope);
@@ -209,7 +209,7 @@ impl KeysNotificationsConsumerCtxInterface for V8NotificationsCtx {
 
         let data = {
             let isolate_scope = self.internal.script_ctx.isolate.enter();
-            let ctx_scope = self.internal.script_ctx.ctx.enter(&isolate_scope);
+            let ctx_scope = self.internal.script_ctx.context.enter(&isolate_scope);
             let try_catch = isolate_scope.new_try_catch();
 
             let notification_data = isolate_scope.new_object();

--- a/redisgears_v8_plugin/src/v8_redisai.rs
+++ b/redisgears_v8_plugin/src/v8_redisai.rs
@@ -209,7 +209,7 @@ pub(crate) fn get_redisai_client<'isolate, 'isolate_scope>(
                             }
                         };
                         let isolate_scope = script_ctx_ref.isolate.enter();
-                        let ctx_scope = script_ctx_ref.ctx.enter(&isolate_scope);
+                        let ctx_scope = script_ctx_ref.context.enter(&isolate_scope);
                         let resolver = persisted_resolver.take_local(&isolate_scope).as_resolver();
 
                         match res {
@@ -291,7 +291,7 @@ pub(crate) fn get_redisai_client<'isolate, 'isolate_scope>(
                             }
                         };
                         let isolate_scope = script_ctx_ref.isolate.enter();
-                        let ctx_scope = script_ctx_ref.ctx.enter(&isolate_scope);
+                        let ctx_scope = script_ctx_ref.context.enter(&isolate_scope);
 
                         let resolver = persisted_resolver.take_local(&isolate_scope).as_resolver();
 

--- a/redisgears_v8_plugin/src/v8_script_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_script_ctx.rs
@@ -493,6 +493,16 @@ impl LibraryCtxInterface for V8LibraryCtx {
         let isolate_scope = self.script_ctx.isolate.enter();
         let ctx_scope = self.script_ctx.context.enter(&isolate_scope);
         let trycatch = isolate_scope.new_try_catch();
+        self.script_ctx
+            .inspector
+            .as_ref()
+            .unwrap()
+            .set_context(ctx_scope.get_raw_context());
+        self.script_ctx
+            .inspector
+            .as_ref()
+            .unwrap()
+            .schedule_pause_on_next_statement("I want so");
 
         let script = self
             .script_ctx

--- a/redisgears_v8_plugin/src/v8_script_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_script_ctx.rs
@@ -131,14 +131,14 @@ pub(crate) struct V8ScriptCtx {
     /// Tensors API for RedisAI integrations.
     pub(crate) tensor_object_template: V8PersistedObjectTemplate,
 
+    /// The V8 Inspector (used for debugging).
+    pub(crate) inspector: Option<Arc<RawInspector>>,
+
     /// The V8 context
     pub(crate) context: V8Context,
 
     /// The V8 isolate
     pub(crate) isolate: V8Isolate,
-
-    /// The V8 Inspector (used for debugging).
-    pub(crate) inspector: Option<Arc<RawInspector>>,
 
     /// Api to interact back with Redis for operations like command invocation and logging.
     pub(crate) compiled_library_api: Box<dyn CompiledLibraryInterface + Send + Sync>,
@@ -493,16 +493,10 @@ impl LibraryCtxInterface for V8LibraryCtx {
         let isolate_scope = self.script_ctx.isolate.enter();
         let ctx_scope = self.script_ctx.context.enter(&isolate_scope);
         let trycatch = isolate_scope.new_try_catch();
-        // self.script_ctx
-        //     .inspector
-        //     .as_ref()
-        //     .unwrap()
-        //     .set_context(ctx_scope.get_raw_context());
-        self.script_ctx
-            .inspector
-            .as_ref()
-            .unwrap()
-            .schedule_pause_on_next_statement("I want so");
+
+        if let Some(inspector) = self.script_ctx.inspector.as_ref() {
+            inspector.schedule_pause_on_next_statement("Pause on load.");
+        }
 
         let script = self
             .script_ctx

--- a/redisgears_v8_plugin/src/v8_script_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_script_ctx.rs
@@ -493,11 +493,11 @@ impl LibraryCtxInterface for V8LibraryCtx {
         let isolate_scope = self.script_ctx.isolate.enter();
         let ctx_scope = self.script_ctx.context.enter(&isolate_scope);
         let trycatch = isolate_scope.new_try_catch();
-        self.script_ctx
-            .inspector
-            .as_ref()
-            .unwrap()
-            .set_context(ctx_scope.get_raw_context());
+        // self.script_ctx
+        //     .inspector
+        //     .as_ref()
+        //     .unwrap()
+        //     .set_context(ctx_scope.get_raw_context());
         self.script_ctx
             .inspector
             .as_ref()

--- a/redisgears_v8_plugin/src/v8_script_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_script_ctx.rs
@@ -234,6 +234,11 @@ impl V8ScriptCtx {
         self.is_running.store(val, Ordering::Relaxed);
     }
 
+    /// Returns [`true`] if the script is being debugged.
+    pub(crate) fn is_being_debugged(&self) -> bool {
+        self.inspector.is_some()
+    }
+
     /// Perform necessary operation after locking Redis GIL like saving
     /// the current time for timeout purposes.
     pub(crate) fn after_lock_gil(&self) {
@@ -502,7 +507,7 @@ impl LibraryCtxInterface for V8LibraryCtx {
             .script_ctx
             .script
             .to_local(&isolate_scope)
-            .map_err(|e| GearsApiError::new(e.to_string()))?;
+            .map_err(GearsApiError::new)?;
 
         let _rdb_loading_guard = self.script_ctx.mark_loading_rdb(is_being_loaded_from_rdb);
 

--- a/redisgears_v8_plugin/src/v8_stream_ctx.rs
+++ b/redisgears_v8_plugin/src/v8_stream_ctx.rs
@@ -60,7 +60,7 @@ impl V8StreamCtxInternals {
         ack_callback: Box<dyn FnOnce(StreamRecordAck) + Send>,
     ) -> Option<StreamRecordAck> {
         let isolate_scope = self.script_ctx.isolate.enter();
-        let ctx_scope = self.script_ctx.ctx.enter(&isolate_scope);
+        let ctx_scope = self.script_ctx.context.enter(&isolate_scope);
         let trycatch = isolate_scope.new_try_catch();
 
         let id = record.get_id();
@@ -198,7 +198,7 @@ impl V8StreamCtxInternals {
     ) {
         let res = {
             let isolate_scope = self.script_ctx.isolate.enter();
-            let ctx_scope = self.script_ctx.ctx.enter(&isolate_scope);
+            let ctx_scope = self.script_ctx.context.enter(&isolate_scope);
             let trycatch = isolate_scope.new_try_catch();
 
             let id = record.get_id();


### PR DESCRIPTION
Adds a possibility to debug JavaScript code. To be able to do that, the code must be uploaded to Redis with the "debug" option. Then, in the RESP3 reply, there will be connection hints reported, describing the ways that one may use in order to connect to the remote debugging server in RedisGears.

The debugging is done in a single thread, piece by piece. In the code, it is expressed by working in the cron job so that if nothing is happening with the user script, the thread isn't blocked, and any other work can be performed. However, if the user script is paused, either due to a breakpoint or for whatever other reason, this thread is blocked, waiting until the user unpauses the script. This also provides an atomicity guarantee so that if a script is paused under debugging, nothing else can touch the database.

For the debugging, the existing V8 Inspector API is used.