### PR TITLE
Add missing alias for Quick_Start_CLI.md

### DIFF
--- a/docs/docs/Quick_Start_CLI.md
+++ b/docs/docs/Quick_Start_CLI.md
@@ -4,6 +4,8 @@ linkTitle: "Quick start (redis-cli)"
 weight: 2
 description: >
     Get started with triggers and functions using redis-cli
+aliases:
+    - /docs/interact/programmability/triggers-and-functions/quick_start    
 ---
 
 Make sure that you have [Redis Stack installed](/docs/getting-started/install-stack/) and running. Alternatively, you can create a [free Redis Cloud account](https://redis.com/try-free/). The triggers and functions preview is available in the fixed subscription plan for the Google Cloud Asia Pacific (Tokyo) and AWS Asia Pacific (Singapore) regions.


### PR DESCRIPTION
We have many existing links referring to 
the `https://redis.io/docs/interact/programmability/triggers-and-functions/quick_start` URL witch now throws 404. 

@dwdougherty @thomascaudron 