### PR TITLE
Added Iterator global to allow list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,7 @@ commands:
           name: run python tests
           working_directory: pytests
           command: |
+            ulimit -n 1024
             ./run_tests.sh
       - run:
           shell: /bin/bash -l -eo pipefail

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -95,6 +95,7 @@ lazy_static::lazy_static! {
             "isNaN",
             "console",
             "WebAssembly",
+            "Iterator",
         ],
         deny_list: [
             "eval",              // Might be considered dangerous.


### PR DESCRIPTION
The Iterator was added on v8 version 11.7. Seems like it is safe to add it to the allow list:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator

@vityafx @leibale let me know what you think.