### PR TITLE
Added ProxyFiltered flag to internal commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ members = [
     "redisai_rs",
     "redisgears_macros_internals"
 ]
+
+[workspace.dependencies]
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
+redis-module-macros = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master" }

--- a/redisai_rs/Cargo.toml
+++ b/redisai_rs/Cargo.toml
@@ -7,8 +7,8 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
-redis-module-macros = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master" }
+redis-module = { workspace = true }
+redis-module-macros = { workspace = true }
 redisgears_plugin_api = { path = "../redisgears_plugin_api/" }
 
 [build-dependencies]

--- a/redisgears_core/Cargo.toml
+++ b/redisgears_core/Cargo.toml
@@ -7,8 +7,8 @@ rust-version = "1.63"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
-redis-module-macros = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master" }
+redis-module = { workspace = true }
+redis-module-macros = { workspace = true }
 lib_mr = { git = "https://github.com/RedisGears/LibMR.git", branch = "master", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
 lib_mr_derive = { git = "https://github.com/RedisGears/LibMR.git", branch = "master" }
 linkme = "0.3"

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -1659,6 +1659,7 @@ fn function_call_async(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     {
         name: "_rg_internals.function",
         flags: [MayReplicate, DenyScript, NoMandatoryKeys],
+        enterprise_flags: [ProxyFiltered],
         arity: -3,
         key_spec: [],
     }
@@ -1704,6 +1705,7 @@ fn function_command(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     {
         name: "_rg_internals.update_stream_last_read_id",
         flags: [MayReplicate, DenyScript],
+        enterprise_flags: [ProxyFiltered],
         arity: 6,
         key_spec: [
             {

--- a/redisgears_plugin_api/Cargo.toml
+++ b/redisgears_plugin_api/Cargo.toml
@@ -7,7 +7,7 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
+redis-module = { workspace = true }
 bitflags = "1"
 # DO NOT CHANGE to avoid security issues. This exact version
 # specification is required for the second level dependencies

--- a/redisgears_v8_plugin/Cargo.toml
+++ b/redisgears_v8_plugin/Cargo.toml
@@ -7,7 +7,7 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
+redis-module = { workspace = true }
 v8_rs = { git = "https://github.com/RedisGears/v8-rs" }
 v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs" }
 redisgears_plugin_api = { path = "../redisgears_plugin_api/" }


### PR DESCRIPTION
In addition, the PR move the redis-module dependency to be defined on the entire workspace so it will be easier to change it globally (when debugging locally for example).

Notice: the `ProxyFiltered` require [this PR](https://github.com/RedisLabsModules/redismodule-rs/pull/369) to function correctly