### PR TITLE
Small Replicaof fixes

### DIFF
--- a/redisgears_core/src/function_del_command.rs
+++ b/redisgears_core/src/function_del_command.rs
@@ -110,8 +110,8 @@ pub(crate) fn function_del_on_replica(
             s.try_as_str()
         })?;
     let mut libraries = get_libraries();
-    match libraries.remove(lib_name) {
-        Some(_) => Ok(RedisValue::SimpleStringStatic("OK")),
-        None => Err(RedisError::Str("library does not exists")),
-    }
+    // On replica there is no need to return an error if the function does not exists.
+    // So there is not need to check the return value of the function.
+    libraries.remove(lib_name);
+    Ok(RedisValue::SimpleStringStatic("OK"))
 }

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -338,14 +338,8 @@ pub(crate) fn function_load_on_replica(
     if args.user.is_none() {
         return Err(RedisError::Str("User was not provided by primary"));
     }
-    match function_load_internal(
-        ctx,
-        args.user.unwrap(),
-        &args.code,
-        args.config,
-        args.upgrade,
-        true,
-    ) {
+    // On replica, we always obey the primary and perform an upgrade.
+    match function_load_internal(ctx, args.user.unwrap(), &args.code, args.config, true, true) {
         Ok(_) => Ok(RedisValue::SimpleStringStatic("OK")),
         Err(e) => Err(RedisError::String(e)),
     }


### PR DESCRIPTION
The PR makes 3 small fixes for replicaof:

1. When loading a library always replace an existing library (if exists). This is mainly because we prefer to listen to the primary and if it gives us a library to load we do it.
2. When deleting a library on replica we always return an OK reply even if the library does not exists. If we return an error we will break the replication stream and we do not want to do that in case we were asked to delete a none existing library.
3. If the `_rg_internals.function` command were done successfully, we replicate it (in case we have another replica connected to us).