### PR TITLE
Specify resolver for workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "redisai_rs",
     "redisgears_macros_internals"
 ]
+resolver = "2"
 
 [workspace.dependencies]
 redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master", default-features = false, features = ["min-redis-compatibility-version-7-2"] }


### PR DESCRIPTION
According to the following [link](https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions) we need to specify the resolver to use in order to avoid a warning on compilation time:
```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
```

According to [this](https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2) and base on the changes between the resolvers, it seems OK to use resolver 2 for our case.
@vityafx let me know what you think.