### PR TITLE
Move `Iterator`  to deny_list

### DIFF
--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -95,13 +95,15 @@ lazy_static::lazy_static! {
             "isNaN",
             "console",
             "WebAssembly",
-            "Iterator",
         ],
         deny_list: [
             "eval",              // Might be considered dangerous.
             "EvalError",         // Because we remove eval, this one is also not needed.
             "SharedArrayBuffer", // Needed for workers which we are not supporting
             "Atomics",           // Needed for workers which we are not supporting
+            "Iterator",          // This one is on the deny list only on 2.0 branch as it has a potential
+                                 // of breaking rdb compatability on patch version. If a script will use it
+                                 // we will not be able to load the rdb on an older version of 2.0.
         ]
     });
 }


### PR DESCRIPTION
On https://github.com/RedisGears/RedisGears/commit/8b8c91b6fbd15b50bb5c166c602334b5fac37fd2 we added the `Iterator` to the allow list. Its wrong to do it on a patch version because old 2.0 version might not be able to load RDB that was created by some newer 2.0.x version. It is better to put the `Iterator` on the deny list for patches versions on 2.0.