### PR TITLE
Add cargo-deny configuration.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+resolver = "2"
 members = [
     "redisgears_core",
     "redisgears_plugin_api",
@@ -7,7 +7,6 @@ members = [
     "redisai_rs",
     "redisgears_macros_internals"
 ]
-resolver = "2"
 
 [workspace.dependencies]
 redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master", default-features = false, features = ["min-redis-compatibility-version-7-2"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ members = [
 [workspace.dependencies]
 redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
 redis-module-macros = { git = "https://github.com/RedisLabsModules/redismodule-rs", branch = "master" }
+serde_json = "1"
+serde = { version = "1", features = ["derive"] }
+serde_derive = "1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN apt-get install -y git build-essential autoconf libtool curl libssl-dev pkg-
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > install_rust.sh
 RUN sh install_rust.sh -y
 RUN git clone https://github.com/redis/redis; cd redis; git checkout 7.2.1; make install
+RUN $HOME/.cargo/bin/cargo install cargo-deny
+RUN $HOME/.cargo/bin/cargo deny check licenses
+RUN $HOME/.cargo/bin/cargo deny check bans
 RUN $HOME/.cargo/bin/cargo build --release
 
 CMD ["redis-server", "--protected-mode", "no", "--loadmodule", "./target/release/libredisgears.so", "v8-plugin-path", "./target/release/libredisgears_v8_plugin.so"]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,366 @@
+# This template contains all of the possible sections and their default values
+
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# Root options
+
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #{ triple = "x86_64-unknown-linux-musl" },
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+# When creating the dependency graph used as the source of truth when checks are
+# executed, this field can be used to prune crates from the graph, removing them
+# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned unless
+# they are connected to another crate in the graph that hasn't been pruned,
+# so it should be used with care. The identifiers are [Package ID Specifications]
+# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
+#exclude = []
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = true
+# If true, metadata will be collected with `--no-default-features`. The same
+# caveat with `all-features` applies
+no-default-features = false
+# If set, these feature will be enabled when collecting metadata. If `--features`
+# is specified on the cmd line they will take precedence over this option.
+#features = []
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory database is cloned/fetched into
+db-path = "~/.cargo/advisory-db"
+# The url(s) of the advisory databases to use
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# The lint level for security vulnerabilities
+vulnerability = "deny"
+# The lint level for unmaintained crates
+unmaintained = "warn"
+# The lint level for crates that have been yanked from their source registry
+yanked = "deny"
+# The lint level for crates with security notices. Note that as of
+# 2019-12-17 there are no security notice advisories in
+# https://github.com/rustsec/advisory-db
+notice = "deny"
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+    #"RUSTSEC-0000-0000",
+]
+# Threshold for security vulnerabilities, any vulnerability with a CVSS score
+# lower than the range specified will be ignored. Note that ignored advisories
+# will still output a note when they are encountered.
+# * None - CVSS Score 0.0
+# * Low - CVSS Score 0.1 - 3.9
+# * Medium - CVSS Score 4.0 - 6.9
+# * High - CVSS Score 7.0 - 8.9
+# * Critical - CVSS Score 9.0 - 10.0
+#severity-threshold =
+
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "deny"
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+    "LicenseRef-RSALv2"
+    #"Apache-2.0 WITH LLVM-exception",
+]
+# List of explicitly disallowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+deny = [
+    #"Nokia",
+]
+# Lint level for licenses considered copyleft
+copyleft = "deny"
+# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
+# * both - The license will be approved if it is both OSI-approved *AND* FSF
+# * either - The license will be approved if it is either OSI-approved *OR* FSF
+# * osi - The license will be approved if it is OSI approved
+# * fsf - The license will be approved if it is FSF Free
+# * osi-only - The license will be approved if it is OSI-approved *AND NOT* FSF
+# * fsf-only - The license will be approved if it is FSF *AND NOT* OSI-approved
+# * neither - This predicate is ignored and the default lint level is used
+allow-osi-fsf-free = "neither"
+# Lint level used when no other predicates are matched
+# 1. License isn't in the allow or deny lists
+# 2. License isn't copyleft
+# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
+default = "deny"
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+[[licenses.clarify]]
+# The name of the crate the clarification applies to
+name = "v8-rs"
+# The optional version constraint for the crate
+version = "*"
+# The SPDX expression for the license requirements of the crate
+expression = "LicenseRef-RSALv2"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+license-files = [
+    # Each entry is a crate relative path, and the (opaque) hash of its contents
+    { path = "licenses/RSALv2.txt", hash = 0x26f123cb }
+]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = false
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# The default lint level for `default` features for crates that are members of
+# the workspace that is being checked. This can be overridden by allowing/denying
+# `default` on a crate-by-crate basis if desired.
+workspace-default-features = "allow"
+# The default lint level for `default` features for external crates that are not
+# members of the workspace. This can be overridden by allowing/denying `default`
+# on a crate-by-crate basis if desired.
+external-default-features = "allow"
+# List of crates that are allowed. Use with care!
+allow = [
+#    { name = "libloading", version = "*" },
+#    { name = "bindgen", version = "*" },
+#    { name = "addroid-tzdata", version = "*" },
+#    { name = "android_system_properties", version = "*" },
+#    { name = "anyhow", version = "*" },
+#    { name = "autocfg", version = "*" },
+#    { name = "bitflags", version = "*" },
+#    { name = "block-buffer", version = "*" },
+#    { name = "bumpalo", version = "*" },
+#    { name = "byteorder", version = "*" },
+#    { name = "bytes", version = "*" },
+#    { name = "cc", version = "*" },
+#    { name = "cexpr", version = "*" },
+#    { name = "cfg-if", version = "*" },
+#    { name = "chrono", version = "*" },
+#    { name = "clang-sys", version = "*" },
+#    { name = "core-foundation-sys", version = "*" },
+#    { name = "cpufeatures", version = "*" },
+#    { name = "crypto-common", version = "*" },
+#    { name = "data-encoding", version = "*" },
+#    { name = "deranged", version = "*" },
+#    { name = "digest", version = "*" },
+#    { name = "either", version = "*" },
+#    { name = "fnv", version = "*" },
+#    { name = "form_urlencoded", version = "*" },
+#    { name = "generic-array", version = "*" },
+#    { name = "getrandom", version = "*" },
+#    { name = "glob", version = "*" },
+#    { name = "home", version = "*" },
+#    { name = "http", version = "*" },
+#    { name = "httparse", version = "*" },
+#    { name = "iana-time-zone", version = "*" },
+#    { name = "iana-time-zone-haiku", version = "*" },
+#    { name = "idna", version = "*" },
+#    { name = "itoa", version = "*" },
+#    { name = "js-sys", version = "*" },
+#    { name = "lazy_static", version = "*" },
+#    { name = "lazycell", version = "*" },
+#    { name = "libc", version = "*" }
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# List of crates to deny
+deny = [
+    # Each entry the name of a crate and a version range. If version is
+    # not specified, all versions will be matched.
+    #{ name = "ansi_term", version = "=0.11.0" },
+    #
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+]
+
+# List of features to allow/deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#[[bans.features]]
+#name = "reqwest"
+# Features to not allow
+#deny = ["json"]
+# Features to allow
+#allow = [
+#    "rustls",
+#    "__rustls",
+#    "__tls",
+#    "hyper-rustls",
+#    "rustls",
+#    "rustls-pemfile",
+#    "rustls-tls-webpki-roots",
+#    "tokio-rustls",
+#    "webpki-roots",
+#]
+# If true, the allowed features must exactly match the enabled feature set. If
+# this is set there is no point setting `deny`
+#exact = true
+
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+    #{ name = "libloading", version = "=0.7.4" },
+    { name = "socket2", version = "*" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite.
+skip-tree = [
+    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+    { name = "v8_rs", version = "*" },
+    { name = "v8_rs_derive", version = "*" },
+    { name = "libloading", version = "*" },
+    { name = "bindgen", version = "*" },
+]
+
+[bans.build]
+executables = "deny"
+
+include-dependencies = true
+include-archives = true
+
+[[bans.build.bypass]]
+name = "libloading"
+allow-globs = ["*"]
+
+[[bans.build.bypass]]
+name = "windows_x86_64_msvc"
+allow-globs = ["*"]
+
+[[bans.build.bypass]]
+name = "windows_x86_64_gnullvm"
+allow-globs = ["*"]
+
+[[bans.build.bypass]]
+name = "windows_x86_64_gnu"
+allow-globs = ["*"]
+
+[[bans.build.bypass]]
+name = "windows_aarch64_gnullvm"
+allow-globs = ["*"]
+
+[[bans.build.bypass]]
+name = "windows_aarch64_msvc"
+allow-globs = ["*"]
+
+[[bans.build.bypass]]
+name = "windows_i686_msvc"
+allow-globs = ["*"]
+
+[[bans.build.bypass]]
+name = "windows_i686_gnu"
+allow-globs = ["*"]
+
+[[bans.build.bypass]]
+name = "winapi-x86_64-pc-windows-gnu"
+allow-globs = ["*"]
+
+[[bans.build.bypass]]
+name = "winapi-i686-pc-windows-gnu"
+allow-globs = ["*"]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "deny"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "deny"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []
+
+[sources.allow-org]
+# 1 or more github.com organizations to allow git sources for
+github = [""]
+# 1 or more gitlab.com organizations to allow git sources for
+gitlab = [""]
+# 1 or more bitbucket.org organizations to allow git sources for
+bitbucket = [""]

--- a/dockerbuilds/build_and_test.incl
+++ b/dockerbuilds/build_and_test.incl
@@ -16,7 +16,9 @@ RUN sh install_rust.sh -y
 {% endif %}
 RUN bash -l -c "$HOME/.cargo/bin/cargo build -vv"
 RUN bash -l -c "$HOME/.cargo/bin/cargo build --release -vv"
-
+RUN bash -l -c "$HOME/.cargo/bin/cargo install cargo-deny"
+RUN bash -l -c "$HOME/.cargo/bin/cargo deny check licenses"
+RUN bash -l -c "$HOME/.cargo/bin/cargo deny check bans"
 RUN bash -l -c "$HOME/.cargo/bin/cargo test -vv"
 
 WORKDIR /build/pytests

--- a/redisai_rs/Cargo.toml
+++ b/redisai_rs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "redisai_rs"
 version = "0.1.0"
 edition = "2021"
-license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)"
+license = "LicenseRef-RSALv2 OR SSPL-1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/redisgears_core/Cargo.toml
+++ b/redisgears_core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "redisgears_core"
 version = "99.99.99"
 edition = "2021"
-license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)"
+license = "LicenseRef-RSALv2 OR SSPL-1.0"
 rust-version = "1.70"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -22,12 +22,8 @@ lazy_static = "1"
 log = "0.4"
 byte-unit = "4"
 serde_json = "1"
-# DO NOT CHANGE to avoid security issues. This exact version
-# specification is required for the second level dependencies
-# to use exactly this version too, so that the dependencies of
-# this project will not be able to compromise it.
-serde = { version = "=1.0.171", features = ["derive"] }
-serde_derive = "=1.0.171"
+serde = { version = "1", features = ["derive"] }
+serde_derive = "1"
 
 [build-dependencies]
 regex = "1"

--- a/redisgears_core/Cargo.toml
+++ b/redisgears_core/Cargo.toml
@@ -21,9 +21,9 @@ sha256 = "1"
 lazy_static = "1"
 log = "0.4"
 byte-unit = "4"
-serde_json = "1"
-serde = { version = "1", features = ["derive"] }
-serde_derive = "1"
+serde_json = { workspace = true }
+serde = { workspace = true }
+serde_derive = { workspace = true }
 
 [build-dependencies]
 regex = "1"

--- a/redisgears_macros_internals/Cargo.toml
+++ b/redisgears_macros_internals/Cargo.toml
@@ -13,9 +13,9 @@ syn = { version = "1", features = ["full", "extra-traits"] }
 quote = "1"
 lazy_static = "1"
 proc-macro2 = "1"
-serde = { version = "1", features = ["derive"] }
-serde_derive = "1"
 serde_syn = "0.1"
+serde = { workspace = true }
+serde_derive = { workspace = true }
 
 [lib]
 name = "redisgears_macros_internals"

--- a/redisgears_macros_internals/Cargo.toml
+++ b/redisgears_macros_internals/Cargo.toml
@@ -4,18 +4,18 @@ version = "0.1.0"
 authors = ["Meir Shpilraien <meir@redis.com>"]
 edition = "2021"
 description = "A macros crate for redisgears"
-license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)"
+license = "LicenseRef-RSALv2 OR SSPL-1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn = { version="1", features = ["full", "extra-traits"]}
+syn = { version = "1", features = ["full", "extra-traits"] }
 quote = "1"
 lazy_static = "1"
 proc-macro2 = "1"
-serde = { version = "=1.0.171", features = ["derive"] }
-serde_derive = "=1.0.171"
-serde_syn = "0.1.0"
+serde = { version = "1", features = ["derive"] }
+serde_derive = "1"
+serde_syn = "0.1"
 
 [lib]
 name = "redisgears_macros_internals"

--- a/redisgears_plugin_api/Cargo.toml
+++ b/redisgears_plugin_api/Cargo.toml
@@ -8,9 +8,9 @@ license = "LicenseRef-RSALv2 OR SSPL-1.0"
 
 [dependencies]
 redis-module = { workspace = true }
+serde = { workspace = true }
+serde_derive = { workspace = true }
 bitflags = "1"
-serde = { version = "1", features = ["derive"] }
-serde_derive = "1"
 log = "0.4"
 
 [build-dependencies]

--- a/redisgears_plugin_api/Cargo.toml
+++ b/redisgears_plugin_api/Cargo.toml
@@ -2,19 +2,15 @@
 name = "redisgears_plugin_api"
 version = "0.1.0"
 edition = "2021"
-license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)"
+license = "LicenseRef-RSALv2 OR SSPL-1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 redis-module = { workspace = true }
 bitflags = "1"
-# DO NOT CHANGE to avoid security issues. This exact version
-# specification is required for the second level dependencies
-# to use exactly this version too, so that the dependencies of
-# this project will not be able to compromise it.
-serde = { version = "=1.0.171", features = ["derive"] }
-serde_derive = "=1.0.171"
+serde = { version = "1", features = ["derive"] }
+serde_derive = "1"
 log = "0.4"
 
 [build-dependencies]

--- a/redisgears_v8_plugin/Cargo.toml
+++ b/redisgears_v8_plugin/Cargo.toml
@@ -8,13 +8,13 @@ license = "LicenseRef-RSALv2 OR SSPL-1.0"
 
 [dependencies]
 redis-module = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true }
+serde_derive = { workspace = true }
 v8_rs = { git = "https://github.com/RedisGears/v8-rs" }
 v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs" }
 redisgears_plugin_api = { path = "../redisgears_plugin_api/" }
 redisgears-macros-internals = { path = "../redisgears_macros_internals/" }
-serde_json = "1"
-serde = { version = "1", features = ["derive"] }
-serde_derive = "1"
 lazy_static = "1"
 bitflags = "2"
 log = "0.4"

--- a/redisgears_v8_plugin/Cargo.toml
+++ b/redisgears_v8_plugin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "redisgears_v8_plugin"
 version = "0.1.0"
 edition = "2021"
-license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)"
+license = "LicenseRef-RSALv2 OR SSPL-1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,10 +13,8 @@ v8_rs_derive = { git = "https://github.com/RedisGears/v8-rs" }
 redisgears_plugin_api = { path = "../redisgears_plugin_api/" }
 redisgears-macros-internals = { path = "../redisgears_macros_internals/" }
 serde_json = "1"
-# DO NOT change this exact version specification, it is required to avoid
-# the blob of serde_derive in the build.
-serde = { version = "=1.0.171", features = ["derive"] }
-serde_derive = "=1.0.171"
+serde = { version = "1", features = ["derive"] }
+serde_derive = "1"
 lazy_static = "1"
 bitflags = "2"
 log = "0.4"


### PR DESCRIPTION
This allows to:
1. Check for the license compatibility among all the dependencies.
2. Check for the binaries included within the source code of the crates.