### PR TITLE
Enabled SPOT Instance deployments on CI benchmarks

### DIFF
--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -1,4 +1,8 @@
 version: 0.1
+remote:
+ - type: oss-1nodes
+ - setup: c5.4xlarge
+ - spot_instance: oss-redisgears-c5-spot-instances
 exporter:
   redistimeseries:
     timemetric: "$.StartTime"

--- a/tests/benchmarks/rg_fcall_async.yml
+++ b/tests/benchmarks/rg_fcall_async.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "rg_fcall_asyc"
 description: "Simple script with async execution."
-remote:
- - type: oss-1nodes
- - setup: c5.4xlarge
+
 dbconfig:
   - init_commands:
     - ["TFUNCTION","LOAD","#!js api_version=1.0 name=lib\n redis.registerAsyncFunction('foo', async ()=>{return 1;});"]

--- a/tests/benchmarks/rg_fcall_redis_cmd.yml
+++ b/tests/benchmarks/rg_fcall_redis_cmd.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "rg_fcall_redis_cmd"
 description: "Simple script calling a redis command."
-remote:
- - type: oss-1nodes
- - setup: c5.4xlarge
+
 dbconfig:
   - init_commands:
     - ["TFUNCTION","LOAD","#!js api_version=1.0 name=lib\n redis.registerFunction('foo', (client)=>{return client.call('PING');});"]

--- a/tests/benchmarks/rg_fcall_redis_cmd_async.yml
+++ b/tests/benchmarks/rg_fcall_redis_cmd_async.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "rg_fcall_redis_cmd_async"
 description: "Simple script calling a redis command async."
-remote:
- - type: oss-1nodes
- - setup: c5.4xlarge
+
 dbconfig:
   - init_commands:
     - ["TFUNCTION","LOAD","#!js api_version=1.0 name=lib\n redis.registerAsyncFunction('foo', async function(client){\n    return client.block(function(redis_client){\n        return redis_client.call('ping');\n    }); \n});"]

--- a/tests/benchmarks/rg_fcall_simple.yml
+++ b/tests/benchmarks/rg_fcall_simple.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "rg_fcall_simple"
 description: ""
-remote:
- - type: oss-1nodes
- - setup: c5.4xlarge
+
 dbconfig:
   - init_commands:
     - ["TFUNCTION","LOAD","#!js api_version=1.0 name=lib\n redis.registerFunction('foo', ()=>{return 1;});"]

--- a/tests/benchmarks/rg_keyspace_async_simple.yml
+++ b/tests/benchmarks/rg_keyspace_async_simple.yml
@@ -6,9 +6,7 @@ description: " The following example shows how to register a database trigger
                You should compare against sync notifications processing ( test name rg_keyspace_sync_simple )
                and no processing ( test name rg_keyspace_baseline ).
              "
-remote:
- - type: oss-1nodes
- - setup: c5.4xlarge
+
 dbconfig:
   - init_commands:
     - ["TFUNCTION","LOAD","#!js api_version=1.0 name=lib\n redis.registerKeySpaceTrigger('consumer', '', async function(client, data){ return; });"]

--- a/tests/benchmarks/rg_keyspace_baseline.yml
+++ b/tests/benchmarks/rg_keyspace_baseline.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "rg_keyspace_baseline"
 description: "Baseline for keyspace notifications -- no listening, just normal benchmark."
-remote:
- - type: oss-1nodes
- - setup: c5.4xlarge
+
 clientconfig:
   tool: memtier_benchmark
   arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --key-minimum=1 --key-maximum=1000000 --command 'SET __key__ __data__'"

--- a/tests/benchmarks/rg_keyspace_sync.yml
+++ b/tests/benchmarks/rg_keyspace_sync.yml
@@ -3,9 +3,7 @@ name: "rg_keyspace_sync"
 description: " The following example shows how to register a database trigger 
                that will call a command in an syc manner when ever a key is changed.
              "
-remote:
- - type: oss-1nodes
- - setup: c5.4xlarge
+
 dbconfig:
   - init_commands:
     - ["TFUNCTION","LOAD","#!js api_version=1.0 name=lib\n redis.registerKeySpaceTrigger('consumer', '', function(client, data){     if (client.call('type', data.key) != 'hash') {                  return;     }      var curr_time = client.call('time')[0];       client.call('hset', data.key, '__last_updated__', curr_time); });"]

--- a/tests/benchmarks/rg_keyspace_sync_simple.yml
+++ b/tests/benchmarks/rg_keyspace_sync_simple.yml
@@ -6,9 +6,7 @@ description: " The following example shows how to register a database trigger
                You should compare against async notifications processing ( test name rg_keyspace_async_simple )
                and no processing ( test name rg_keyspace_baseline ).
              "
-remote:
- - type: oss-1nodes
- - setup: c5.4xlarge
+
 dbconfig:
   - init_commands:
     - ["TFUNCTION","LOAD","#!js api_version=1.0 name=lib\n redis.registerKeySpaceTrigger('consumer', '', function(client, data){  return; });"]

--- a/tests/benchmarks/rg_stream_baseline.yml
+++ b/tests/benchmarks/rg_stream_baseline.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "rg_stream_baseline"
 description: ""
-remote:
- - type: oss-1nodes
- - setup: c5.4xlarge
+
 clientconfig:
   benchmark_type: "read-only"
   tool: memtier_benchmark

--- a/tests/benchmarks/rg_stream_process_async.yml
+++ b/tests/benchmarks/rg_stream_process_async.yml
@@ -3,9 +3,7 @@ name: "rg_stream_process_async"
 description: "RedisGears 2.0 comes with a full stream API to processes data from Redis Stream.
               This example registers a stream consumer that logs the received message in an async manner.
              "
-remote:
- - type: oss-1nodes
- - setup: c5.4xlarge
+
 dbconfig:
   - init_commands:
     - ["TFUNCTION","LOAD","#!js api_version=1.0 name=lib\n redis.registerStreamTrigger(     'consumer',     'stream',      async  function(c, data) {         redis.log(JSON.stringify(data, (key, value) =>             typeof value === 'bigint'                 ? value.toString()                 : value          ));     } );"]

--- a/tests/benchmarks/rg_stream_process_empty_async.yml
+++ b/tests/benchmarks/rg_stream_process_empty_async.yml
@@ -6,9 +6,7 @@ description: "RedisGears 2.0 comes with a full stream API to processes data from
               You should compare against sync notifications processing ( test name rg_stream_process_empty_sync )
               and no processing ( test name rg_stream_baseline ).
              "
-remote:
- - type: oss-1nodes
- - setup: c5.4xlarge
+
 dbconfig:
   - init_commands:
     - ["TFUNCTION","LOAD","#!js api_version=1.0 name=lib\n redis.registerStreamTrigger(     'consumer',     'stream',      async  function(c, data) {  return;  } );"]

--- a/tests/benchmarks/rg_stream_process_empty_sync.yml
+++ b/tests/benchmarks/rg_stream_process_empty_sync.yml
@@ -6,9 +6,7 @@ description: "RedisGears 2.0 comes with a full stream API to processes data from
               You should compare against async notifications processing ( test name rg_stream_process_empty_async )
               and no processing ( test name rg_stream_baseline ).
              "
-remote:
- - type: oss-1nodes
- - setup: c5.4xlarge
+
 dbconfig:
   - init_commands:
     - ["TFUNCTION","LOAD","#!js api_version=1.0 name=lib\n redis.registerStreamTrigger(     'consumer',     'stream',      function(c, data) {  return;  } );"]

--- a/tests/benchmarks/rg_stream_process_sync.yml
+++ b/tests/benchmarks/rg_stream_process_sync.yml
@@ -3,9 +3,7 @@ name: "rg_stream_process_sync"
 description: "RedisGears 2.0 comes with a full stream API to processes data from Redis Stream.
               This example registers a stream consumer that logs the received message in an sync manner.
              "
-remote:
- - type: oss-1nodes
- - setup: c5.4xlarge
+
 dbconfig:
   - init_commands:
     - ["TFUNCTION","LOAD","#!js api_version=1.0 name=lib\n redis.registerStreamTrigger(     'consumer',     'stream',      function(c, data) {         redis.log(JSON.stringify(data, (key, value) =>             typeof value === 'bigint'                 ? value.toString()                 : value          ));     } );"]

--- a/tests/benchmarks/rg_sync_and_async.yml
+++ b/tests/benchmarks/rg_sync_and_async.yml
@@ -4,9 +4,7 @@ description: "RedisGears function can go to the background by implement the func
               The Coroutine is invoked on a background thread and do not block the Redis processes.
               This example shown bellow starts Sync and Moves Async.
 "
-remote:
- - type: oss-1nodes
- - setup: c5.4xlarge
+
 dbconfig:
   - init_commands:
     - ["TFUNCTION","LOAD","#!js api_version=1.0 name=lib\n redis.registerAsyncFunction('test', function(client, expected_name){    client.call('type', expected_name);    return client.executeAsync(async function(async_client) {        async_client.block((client)=>{            client.call('type', expected_name);        });    });});"]


### PR DESCRIPTION


This PR enables spot instance deployments as a 1st deployment option. If it fails it uses the default non spot deployment in an agnostic manner to the developer/CI runner.
