### PR TITLE
Fix issue where ksn might be ignored

### DIFF
--- a/redisgears_core/src/background_run_scope_guard.rs
+++ b/redisgears_core/src/background_run_scope_guard.rs
@@ -28,11 +28,11 @@ use redisai_rs::redisai::redisai_model::RedisAIModel;
 use redisai_rs::redisai::redisai_script::RedisAIScript;
 
 pub(crate) struct BackgroundRunScopeGuardCtx {
+    _notification_blocker: NotificationBlocker,
     pub(crate) detached_ctx_guard: DetachedContextGuard,
     call_options: RedisClientCallOptions,
     user: RedisString,
     lib_meta_data: Arc<GearsLibraryMetaData>,
-    _notification_blocker: NotificationBlocker,
 }
 
 unsafe impl Sync for BackgroundRunScopeGuardCtx {}


### PR DESCRIPTION
The issue is that the `detached_ctx_guard` was released before the `_notification_blocker`. This cause the Redis lock to be released before the notification was resumed. If a notification would have arrive in between the time the Redis lock was released to the time the notifications was resumed, we would have lost it.