### PR TITLE
Fixed rg_keyspace_async_simple benchmark by specifying a larger v8-maxmemory

### DIFF
--- a/.github/workflows/branch_merge-benchmark.yml
+++ b/.github/workflows/branch_merge-benchmark.yml
@@ -44,7 +44,7 @@ jobs:
         cd tests/benchmarks
         redisbench-admin run-remote \
           --required-module redisgears_2 \
-          --module_path "../../target/release/libredisgears.so v8-plugin-path ../../target/release/libredisgears_v8_plugin.so" \
+          --module_path "../../target/release/libredisgears.so v8-plugin-path ../../target/release/libredisgears_v8_plugin.so v8-maxmemory 524288000" \
           --github_actor ${{ github.triggering_actor }} \
           --github_repo ${{ github.event.repository.name }} \
           --github_org ${{ github.repository_owner }} \
@@ -52,7 +52,6 @@ jobs:
           --upload_results_s3 \
           --triggering_env circleci \
           --continue-on-module-check-error \
-          --fail_fast \
           --push_results_redistimeseries \
           --redistimeseries_host ${{ secrets.PERFORMANCE_RTS_HOST }} \
           --redistimeseries_port ${{ secrets.PERFORMANCE_RTS_PORT }} \

--- a/.github/workflows/trigger-benchmark.yml
+++ b/.github/workflows/trigger-benchmark.yml
@@ -46,7 +46,7 @@ jobs:
         cd tests/benchmarks
         redisbench-admin run-remote \
           --required-module redisgears_2 \
-          --module_path "../../target/release/libredisgears.so v8-plugin-path ../../target/release/libredisgears_v8_plugin.so" \
+          --module_path "../../target/release/libredisgears.so v8-plugin-path ../../target/release/libredisgears_v8_plugin.so v8-maxmemory 524288000" \
           --github_actor ${{ github.triggering_actor }} \
           --github_repo ${{ github.event.repository.name }} \
           --github_org ${{ github.repository_owner }} \
@@ -54,7 +54,6 @@ jobs:
           --continue-on-module-check-error \
           --upload_results_s3 \
           --triggering_env circleci \
-          --fail_fast \
           --push_results_redistimeseries \
           --redistimeseries_host ${{ secrets.PERFORMANCE_RTS_HOST }} \
           --redistimeseries_port ${{ secrets.PERFORMANCE_RTS_PORT }} \


### PR DESCRIPTION
- Fixes the failures in https://github.com/RedisGears/RedisGears/actions/runs/7198768949/job/19776796580