### PR TITLE
Fix nightly run failure

### DIFF
--- a/pytests/test_basics.py
+++ b/pytests/test_basics.py
@@ -348,7 +348,7 @@ redis.registerAsyncFunction("test1", async function(client){
     runUntil(env, 1, run_v8_gc)
     env.expect('RPUSH', 'l', '1').equal(1)
     runUntil(env, 0, run_v8_gc)
-    future.expectError('Promise was dropped without been resolved')
+    future.expectError('Err Execution was terminated due to OOM or timeout')
 
 
 
@@ -362,22 +362,6 @@ redis.registerAsyncFunction("test1", function(client){
         });
     });
 
-});
-    """
-    env.expect('config', 'set', 'redisgears_2.lock-redis-timeout', '100').equal('OK')
-    env.expectTfcallAsync('lib', 'test1').error().contains('Execution was terminated due to OOM or timeout')
-
-@gearsTest()
-def testTimeoutErrorNotCatchable(env):
-    """#!js api_version=1.0 name=lib
-redis.registerAsyncFunction("test1", async function(client){
-    try {
-        client.block(function(){
-            while (true);
-        });
-    } catch (e) {
-        return "catch timeout error"
-    }
 });
     """
     env.expect('config', 'set', 'redisgears_2.lock-redis-timeout', '100').equal('OK')

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -548,7 +548,7 @@ pub(crate) struct V8Backend {
 
 impl V8Backend {
     /// The name of this backend.
-    const NAME: &str = "js";
+    const NAME: &'static str = "js";
 }
 
 fn scan_for_isolates_timeout(script_ctx_vec: &ScriptCtxVec) {


### PR DESCRIPTION
Turns out it is not allowed to raise a termination exception on a co-routine, and as of v12.1 V8 asserts it. To fix the issue we catch the timeout error (termination exception) on `block` function and raise a regular none termination exception. This means that the user will now be able to catch timeout error on the co-routine code and handle it. Currently we do not force any timeout on co-routine so this change does not allow the user to do anything he could not yet already do.
successful nightly run: https://github.com/RedisGears/RedisGears/actions/runs/7491877476