### PR TITLE
aligning arm64v8 with aarch64, as elsewhere (#1044)

### DIFF
--- a/redisgears_core/build.rs
+++ b/redisgears_core/build.rs
@@ -152,10 +152,7 @@ fn main() {
     };
 
 
-    let mut os_arch = std::env::consts::ARCH.to_string().to_lowercase();
-    if os_arch == "aarch64" {
-        os_arch = "arm64v8".to_string();
-    }
+    let os_arch = std::env::consts::ARCH.to_string().to_lowercase();
 
     println!("cargo:rustc-env=BUILD_OS_NICK={}", os_nick);
     println!("cargo:rustc-env=BUILD_OS_ARCH={}", os_arch);


### PR DESCRIPTION
The other modules now use aarch64 throughout. This PR removes the change to rename as arm64v8 and resettles on aarch64 and provided by the OS. This is needed by redis-stack

(cherry picked from commit cb9d4d3d58064768bc66a37f7e7fb1af16480207)