### PR TITLE
Fix crash when logging NULL chars.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,4 +20,4 @@ jobs:
             os_version: 22.04
             os_family: ubuntu
             dockerfile: dockerbuilds/dockerfile.debian.tmpl
-            msrv: 1.70.0
+            msrv: 1.74.0

--- a/docs/build_instructions.md
+++ b/docs/build_instructions.md
@@ -75,7 +75,7 @@ export PATH=/home/meir/.cargo/bin:$PATH
 ```
 
 #### MSRV (Minimally Supported Rust Version)
-Currently the edition 2021 of Rust language is used and the MSRV is `1.67`.
+Currently the edition 2021 of Rust language is used and the MSRV is `1.74`.
 
 ## Build_Release
 

--- a/pytests/test_basics.py
+++ b/pytests/test_basics.py
@@ -21,6 +21,16 @@ redis.registerFunction("test", function(){
     env.expectTfcall('foo', 'test').equal(1)
 
 @gearsTest()
+def testLogWithBinaryData(env):
+    """#!js api_version=1.0 name=foo
+redis.registerFunction("test", function(){
+    redis.log('foo\x00\xaa');
+    return 1
+})
+    """
+    env.expectTfcall('foo', 'test').equal(1)
+
+@gearsTest()
 def testCommandInvocation(env):
     """#!js api_version=1.0 name=foo
 redis.registerFunction("test", function(client){

--- a/redisgears_core/Cargo.toml
+++ b/redisgears_core/Cargo.toml
@@ -3,7 +3,7 @@ name = "redisgears_core"
 version = "99.99.99"
 edition = "2021"
 license = "LicenseRef-RSALv2 OR SSPL-1.0"
-rust-version = "1.70"
+rust-version = "1.74"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/redisgears_v8_plugin/src/v8_native_functions.rs
+++ b/redisgears_v8_plugin/src/v8_native_functions.rs
@@ -1436,9 +1436,10 @@ pub(crate) fn initialize_globals_1_0(
         ctx_scope,
         LOG_GLOBAL_NAME,
         new_native_function!(move |_isolate, _curr_ctx_scope, msg: V8LocalUtf8| {
+            let m = msg.as_str().escape_default().to_string();
             match script_ctx_ref.upgrade() {
-                Some(s) => s.compiled_library_api.log_info(msg.as_str()),
-                None => crate::v8_backend::log_info(msg.as_str()), /* do not abort logs */
+                Some(s) => s.compiled_library_api.log_info(m.as_str()),
+                None => crate::v8_backend::log_info(m.as_str()), /* do not abort logs */
             }
             Ok::<Option<V8LocalValue>, String>(None)
         }),


### PR DESCRIPTION
When log NULL char, the server crashed on panic on redismodule-rs when trying to convert the `&str` to `CString`:
https://github.com/RedisLabsModules/redismodule-rs/blob/bf2b3a6a04b795ad1d58d5252ae22d25430c3349/src/logging.rs#L55

When we create our logs we can be sure we do not have embedded NULLs inside the log message, but when the log message comes from user script we can not be sure. To solve it we escape the string using `escape_default` which will escape all chars according to the following rules:

* Tab is escaped as `\t`.
* Carriage return is escaped as `\r`.
* Line feed is escaped as `\n`.
* Single quote is escaped as `\'`.
* Double quote is escaped as `\"`.
* Backslash is escaped as `\\`.
* Any character in the 'printable ASCII' range `0x20` .. `0x7e` inclusive is not escaped.
* All other characters are given hexadecimal Unicode escapes; see