### PR TITLE
Downgrade scripts log level to debug on enterprise cluster. (#1095)

### DIFF
--- a/redisgears_core/src/compiled_library_api.rs
+++ b/redisgears_core/src/compiled_library_api.rs
@@ -64,12 +64,14 @@ impl CompiledLibraryInternals {
 
 pub(crate) struct CompiledLibraryAPI {
     internals: Arc<CompiledLibraryInternals>,
+    log_scirpt_msg_for_debug: bool,
 }
 
 impl CompiledLibraryAPI {
-    pub(crate) fn new() -> CompiledLibraryAPI {
+    pub(crate) fn new(log_scirpt_msg_for_debug: bool) -> CompiledLibraryAPI {
         CompiledLibraryAPI {
             internals: Arc::new(CompiledLibraryInternals::new()),
+            log_scirpt_msg_for_debug,
         }
     }
 
@@ -83,6 +85,14 @@ impl CompiledLibraryAPI {
 }
 
 impl CompiledLibraryInterface for CompiledLibraryAPI {
+    fn log_script_message(&self, msg: &str) {
+        if self.log_scirpt_msg_for_debug {
+            log::debug!("{msg}");
+        } else {
+            log::info!("{msg}");
+        }
+    }
+
     fn log_debug(&self, msg: &str) {
         log::debug!("{msg}");
     }

--- a/redisgears_core/src/function_load_command.rs
+++ b/redisgears_core/src/function_load_command.rs
@@ -10,7 +10,7 @@ use redis_module::{
 use redisgears_plugin_api::redisgears_plugin_api::GearsApiError;
 
 use crate::compiled_library_api::CompiledLibraryAPI;
-use crate::{get_backend, verify_name, Deserialize, Serialize};
+use crate::{get_backend, get_globals, verify_name, Deserialize, Serialize};
 
 use crate::{
     get_libraries, GearsLibrary, GearsLibraryCtx, GearsLibraryMetaData, GearsLoadLibraryCtx,
@@ -103,7 +103,8 @@ pub(crate) fn function_load_internal(
     let meta_data = library_extract_metadata(code, config, user).map_err(|e| e.to_string())?;
     let backend_name = meta_data.engine.as_str();
     let backend = get_backend(ctx, backend_name).map_err(|e| e.to_string())?;
-    let compile_lib_ctx = CompiledLibraryAPI::new();
+    let globals = get_globals();
+    let compile_lib_ctx = CompiledLibraryAPI::new(globals.redis_version.is_enterprise);
     let compile_lib_internals = compile_lib_ctx.take_internals();
     let lib_ctx = backend.compile_library(
         &meta_data.name,

--- a/redisgears_core/src/lib.rs
+++ b/redisgears_core/src/lib.rs
@@ -14,7 +14,7 @@ use keys_notifications_ctx::KeySpaceNotificationsCtx;
 use redis_module::redisvalue::RedisValueKey;
 use redis_module::{
     BlockingCallOptions, CallOptionResp, CallOptionsBuilder, CallResult, ContextFlags, ErrorReply,
-    PromiseCallReply, RedisGILGuard,
+    PromiseCallReply, RedisGILGuard, Version,
 };
 use redisgears_plugin_api::redisgears_plugin_api::backend_ctx::BackendCtxInterfaceInitialised;
 use redisgears_plugin_api::redisgears_plugin_api::load_library_ctx::{
@@ -115,16 +115,14 @@ pub const BUILD_TYPE: Option<&str> = std::option_env!("BUILD_TYPE");
 const PSEUDO_SLAVE_READONLY_CONFIG_NAME: &str = "pseudo-slave-readonly";
 const PSEUDO_SLAVE_CONFIG_NAME: &str = "pseudo-slave";
 
-fn check_redis_version_compatible(ctx: &Context) -> Result<(), String> {
-    use redis_module::Version;
-
+fn get_and_verify_redis_version_compatible(ctx: &Context) -> Result<RedisVersion, String> {
     const VERSION: Version = Version {
         major: 7,
         minor: 1,
         patch: 242,
     };
 
-    match ctx.get_redis_version() {
+    let version = match ctx.get_redis_version() {
         Ok(v) => {
             if v.cmp(&VERSION) == std::cmp::Ordering::Less {
                 return Err(format!(
@@ -132,13 +130,22 @@ fn check_redis_version_compatible(ctx: &Context) -> Result<(), String> {
                     VERSION.major, VERSION.minor, VERSION.patch
                 ));
             }
+            v
         }
         Err(e) => {
             return Err(format!("Failed getting Redis version, version is probably to old, please use Redis 7.0 or above. {}", e));
         }
-    }
+    };
 
-    Ok(())
+    let is_enterprise = ctx
+        .server_info("server")
+        .field("rlec_version")
+        .map_or(false, |_| true);
+
+    Ok(RedisVersion {
+        version,
+        is_enterprise,
+    })
 }
 
 /// A string converted into a sha256 hash-sum. The string is unique
@@ -526,7 +533,14 @@ impl DbPolicy {
     }
 }
 
+#[derive(Debug)]
+struct RedisVersion {
+    version: Version,
+    is_enterprise: bool,
+}
+
 struct GlobalCtx {
+    redis_version: RedisVersion,
     libraries: Mutex<HashMap<String, Arc<GearsLibrary>>>,
     backends: HashMap<String, Box<dyn BackendCtxInterfaceInitialised>>,
     uninitialised_backends: HashMap<String, Box<dyn BackendCtxInterfaceUninitialised>>,
@@ -895,20 +909,25 @@ fn js_init(ctx: &Context, _args: &[RedisString]) -> Status {
         Err(_) => ctx.log_notice("Failed loading RedisAI API."),
     }
 
+    let redis_version = match get_and_verify_redis_version_compatible(ctx) {
+        Ok(v) => v,
+        Err(e) => {
+            log::error!("{e}");
+            return Status::Err;
+        }
+    };
+
     log::info!(
-        "RedisGears v{}, sha='{}', build_type='{}', built_for='{}-{}.{}'.",
+        "RedisGears v{}, sha='{}', build_type='{}', built_for='{}-{}.{}', redis_version:'{}', enterprise:'{}'.",
         VERSION_STR.unwrap_or_default(),
         GIT_SHA.unwrap_or_default(),
         BUILD_TYPE.unwrap_or_default(),
         BUILD_OS.unwrap_or_default(),
         BUILD_OS_NICK.unwrap_or_default(),
-        BUILD_OS_ARCH.unwrap_or_default()
+        BUILD_OS_ARCH.unwrap_or_default(),
+        format!("{}.{}.{}", redis_version.version.major, redis_version.version.minor, redis_version.version.patch),
+        redis_version.is_enterprise,
     );
-
-    if let Err(e) = check_redis_version_compatible(ctx) {
-        log::error!("{e}");
-        return Status::Err;
-    }
 
     if let Err(e) = verify_v8_mem_usage_values() {
         log::error!("{e}");
@@ -939,13 +958,21 @@ fn js_init(ctx: &Context, _args: &[RedisString]) -> Status {
     };
 
     let v8_flags = V8_FLAGS.lock(ctx).to_owned();
+    let is_enterprise = redis_version.is_enterprise;
     let backend_ctx = BackendCtx {
         allocator: &RedisAlloc,
         log_info: Box::new(|msg| log::info!("{msg}")),
         log_trace: Box::new(|msg| log::trace!("{msg}")),
         log_debug: Box::new(|msg| log::debug!("{msg}")),
         log_error: Box::new(|msg| log::error!("{msg}")),
-        log_warning: Box::new(|msg| log::warn!("{msg}")),
+        log_warning: Box::new(|msg| log::info!("{msg}")),
+        log_script_message: Box::new(move |msg| {
+            if is_enterprise {
+                log::debug!("{msg}")
+            } else {
+                log::info!("{msg}")
+            }
+        }),
         get_on_oom_policy: Box::new(|| match *FATAL_FAILURE_POLICY.lock().unwrap() {
             FatalFailurePolicyConfiguration::Abort => LibraryFatalFailurePolicy::Abort,
             FatalFailurePolicyConfiguration::Kill => LibraryFatalFailurePolicy::Kill,
@@ -973,6 +1000,7 @@ fn js_init(ctx: &Context, _args: &[RedisString]) -> Status {
         return Status::Err;
     }
     let global_ctx = GlobalCtx {
+        redis_version,
         libraries: Mutex::new(HashMap::new()),
         backends: HashMap::new(),
         uninitialised_backends: HashMap::from([(v8_backend_name, v8_backend)]),

--- a/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
+++ b/redisgears_plugin_api/src/redisgears_plugin_api/backend_ctx.rs
@@ -21,6 +21,7 @@ pub trait CompiledLibraryInterface {
     fn log_trace(&self, msg: &str);
     fn log_warning(&self, msg: &str);
     fn log_error(&self, msg: &str);
+    fn log_script_message(&self, msg: &str);
     fn run_on_background(&self, job: Box<dyn FnOnce() + Send>);
     fn redisai_create_tensor(
         &self,
@@ -43,6 +44,7 @@ pub struct BackendCtx {
     pub log_trace: Box<dyn Fn(&str) + 'static>,
     pub log_warning: Box<dyn Fn(&str) + 'static>,
     pub log_error: Box<dyn Fn(&str) + 'static>,
+    pub log_script_message: Box<dyn Fn(&str) + 'static>,
     pub get_on_oom_policy: Box<dyn Fn() -> LibraryFatalFailurePolicy + 'static>,
     pub get_lock_timeout: Box<dyn Fn() -> u128 + 'static>,
     pub get_rdb_lock_timeout: Box<dyn Fn() -> u128 + 'static>,

--- a/redisgears_v8_plugin/src/v8_backend.rs
+++ b/redisgears_v8_plugin/src/v8_backend.rs
@@ -157,6 +157,19 @@ static mut GLOBAL: Globals = Globals {
     global_options: GlobalOptions::empty(),
 };
 
+/// Log a generic script message which are not related to
+/// a specific library.
+/// Gears core will decide if this message should go to the
+/// Redis log file.
+pub(crate) fn log_script_message(msg: &str) {
+    #[cfg(not(test))]
+    unsafe {
+        (GLOBAL.backend_ctx.as_ref().unwrap().log_script_message)(msg)
+    };
+    #[cfg(test)]
+    println!("log message: {msg}");
+}
+
 /// Log a generic info message which are not related to
 /// a specific library.
 /// Notice that logging messages which are library related

--- a/redisgears_v8_plugin/src/v8_native_functions.rs
+++ b/redisgears_v8_plugin/src/v8_native_functions.rs
@@ -1438,8 +1438,8 @@ pub(crate) fn initialize_globals_1_0(
         new_native_function!(move |_isolate, _curr_ctx_scope, msg: V8LocalUtf8| {
             let m = msg.as_str().escape_default().to_string();
             match script_ctx_ref.upgrade() {
-                Some(s) => s.compiled_library_api.log_info(m.as_str()),
-                None => crate::v8_backend::log_info(m.as_str()), /* do not abort logs */
+                Some(s) => s.compiled_library_api.log_script_message(m.as_str()),
+                None => crate::v8_backend::log_script_message(m.as_str()), /* do not abort logs */
             }
             Ok::<Option<V8LocalValue>, String>(None)
         }),


### PR DESCRIPTION
Downgrade scripts log level to debug on enterprise cluster.

Logs that was written from scripts will now be written with debug log level when running on enterprise cluster.

(cherry picked from commit 8110449fda7d4a4316c008514fe9a5f5a87dd22a)