### PR TITLE
Clear last error after successful run

### DIFF
--- a/src/readers/command_reader.c
+++ b/src/readers/command_reader.c
@@ -995,6 +995,10 @@ static void CommandReader_OnDone(ExecutionPlan* ep, void* privateData){
         ++crtCtx->numAborted;
     } else {
         ++crtCtx->numSuccess;
+        if(crtCtx->lastError){
+            RG_FREE(crtCtx->lastError);
+            crtCtx->lastError = NULL;
+        }
     }
 
     CommandReaderTriggerCtx_Free(crtCtx);

--- a/src/readers/keys_reader.c
+++ b/src/readers/keys_reader.c
@@ -836,6 +836,10 @@ static void KeysReader_ExecutionDone(ExecutionPlan* ctx, void* privateData){
         ++rData->numAborted;
     } else {
         ++rData->numSuccess;
+        if(rData->lastError){
+            RG_FREE(rData->lastError);
+            rData->lastError = NULL;
+        }
     }
 
     KeysReaderRegisterData_Free(rData);

--- a/src/readers/streams_reader.c
+++ b/src/readers/streams_reader.c
@@ -724,6 +724,10 @@ static void StreamReader_ExecutionDone(ExecutionPlan* ctx, void* privateData){
     } else {
         ackAndTrim = true;
         ++srctx->numSuccess;
+        if(srctx->lastError){
+            RG_FREE(srctx->lastError);
+            srctx->lastError = NULL;
+        }
     }
 
     if(ackAndTrim && ssrctx->createdEpoc == srctx->epoc){

--- a/src/utils/thpool.c
+++ b/src/utils/thpool.c
@@ -153,6 +153,7 @@ struct Gears_thpool_* Gears_thpool_init(int num_threads) {
 
   /* Wait for threads to initialize */
   while (thpool_p->num_threads_alive != num_threads) {
+    sleep(1);
   }
 
   return thpool_p;

--- a/src/utils/thpool.c
+++ b/src/utils/thpool.c
@@ -153,7 +153,7 @@ struct Gears_thpool_* Gears_thpool_init(int num_threads) {
 
   /* Wait for threads to initialize */
   while (thpool_p->num_threads_alive != num_threads) {
-    sleep(1);
+    usleep(1);
   }
 
   return thpool_p;


### PR DESCRIPTION
The PR introduce 2 changes:
1. Clear last error once an execution was finished successfully.
2. On error/unregister/unpaus, clear a not yet started executions.