### PR TITLE
Fix valgrind failure

### DIFF
--- a/pytest/test_errors.py
+++ b/pytest/test_errors.py
@@ -384,8 +384,8 @@ def testCommandReaderOverrideExecRaiseError(env):
     env.expect('rg.pyexecute', 'GB("CommandReader").register(hook="exec")').error().contains('Can not override a command which are not allowed inside a script')
 
 @gearsTest()
-def testCommandReaderOverrideBlpopRaiseError(env):
-    env.expect('rg.pyexecute', 'GB("CommandReader").register(hook="blpop")').error().contains('Can not override a command which are not allowed inside a script')
+def testCommandReaderOverrideEvalRaiseError(env):
+    env.expect('rg.pyexecute', 'GB("CommandReader").register(hook="eval")').error().contains('Can not override a command which are not allowed inside a script')
 
 @gearsTest()
 def testKeysReaderWithUnexistingCommandRaiseError(env):
@@ -404,8 +404,8 @@ def testKeysReaderOverrideExecRaiseError(env):
     env.expect('rg.pyexecute', 'GB().register(commands=["exec"])').error().contains('Can not hook a command which are not allowed inside a script')
 
 @gearsTest()
-def testKeysReaderOverrideBlpopRaiseError(env):
-    env.expect('rg.pyexecute', 'GB().register(commands=["blpop"])').error().contains('Can not hook a command which are not allowed inside a script')
+def testKeysReaderOverrideEvalRaiseError(env):
+    env.expect('rg.pyexecute', 'GB().register(commands=["eval"])').error().contains('Can not hook a command which are not allowed inside a script')
 
 @gearsTest()
 def testCallNextOnMapWrongScopes(env):

--- a/src/readers/streams_reader.c
+++ b/src/readers/streams_reader.c
@@ -816,7 +816,7 @@ static void StreamReader_RunOnEvent(SingleStreamReaderCtx* ssrctx, size_t batch,
         if(err){
             RG_FREE(err);
         }
-    } else if (EPIsFlagOff(ep, EFDone)) {
+    } else if (srtctx->mode == ExecutionModeAsyncLocal) {
         RedisModule_Assert(!ssrctx->currentRunningExecution);
         ssrctx->currentRunningExecution = RG_STRDUP(RedisGears_GetId(ep));
     }

--- a/src/readers/streams_reader.c
+++ b/src/readers/streams_reader.c
@@ -667,8 +667,10 @@ static void StreamReader_ExecutionDone(ExecutionPlan* ctx, void* privateData){
 
     int flags = RedisModule_GetContextFlags(staticCtx);
 
-    RG_FREE(ssrctx->currentRunningExecution);
-    ssrctx->currentRunningExecution = NULL;
+    if (ssrctx->currentRunningExecution) {
+        RG_FREE(ssrctx->currentRunningExecution);
+        ssrctx->currentRunningExecution = NULL;
+    }
 
     // Add the execution id to the localDoneExecutions list
     char *currentRunningExecution = RG_STRDUP(RedisGears_GetId(ctx));
@@ -814,7 +816,8 @@ static void StreamReader_RunOnEvent(SingleStreamReaderCtx* ssrctx, size_t batch,
         if(err){
             RG_FREE(err);
         }
-    } else {
+    } else if (EPIsFlagOff(ep, EFDone)) {
+        RedisModule_Assert(!ssrctx->currentRunningExecution);
         ssrctx->currentRunningExecution = RG_STRDUP(RedisGears_GetId(ep));
     }
 }


### PR DESCRIPTION
Fix failure on valgrind run: https://app.circleci.com/jobs/github/RedisGears/RedisGears/13580
The failure was recently introduce on this commit: https://github.com/RedisGears/RedisGears/commit/569d6e3e8aabb95d61f84f4880feb8b87a7b474d

The failure can only happened in case the stream registration is sync. In this case there is no point in saving the execution ID as when we finish the `RG_Run` call the execution was already finished. We will do this only for `async_local` executions.