### PR TITLE
Fix issue where generated ID got lower value after reload from RDB

### DIFF
--- a/pytest/test_register.py
+++ b/pytest/test_register.py
@@ -2256,6 +2256,7 @@ GB('StreamReader').register(batch=1, duration=100, onFailedPolicy='retry', onFai
 
     id1 = int(env.cmd('RG.DUMPREGISTRATIONS')[0][1].split('-')[1])
 
+    env.cmd('save')
     env.dumpAndReload(restart=True)
 
     env.expect('RG.PYEXECUTE', script, 'ID', 'test', 'UPGRADE').ok()

--- a/src/common.c
+++ b/src/common.c
@@ -107,7 +107,7 @@ void SetId(char* finalId, char* idBuf, char* idStrBuf, long long* lastID){
         finalId = generatedId;
         ++(*lastID);
     }else{
-        *lastID = MAX((long long)finalId[REDISMODULE_NODE_ID_LEN] + 1, *lastID);
+        *lastID = MAX(*(long long*)&finalId[REDISMODULE_NODE_ID_LEN] + 1, *lastID);
     }
     memcpy(idBuf, finalId, ID_LEN);
     snprintf(idStrBuf, STR_ID_LEN, "%.*s-%lld", REDISMODULE_NODE_ID_LEN, idBuf, *(long long*)&idBuf[REDISMODULE_NODE_ID_LEN]);


### PR DESCRIPTION
The issue only happened after bypass ID of 128. The issue is that we first got the a byte of the id buffer and then cast it to long long, while the intention was to take 8 bytes of the ID buffer and then cast them to long long.