### PR TITLE
MOD-10638 Add event-dispatch workflow to master

### DIFF
--- a/.github/workflows/event-dispatch.yaml
+++ b/.github/workflows/event-dispatch.yaml
@@ -9,8 +9,9 @@ on:
         type: choice
         default: focal
         options:
-          - rhel8
-          - rhel9
+          - "rhel8"
+          - "rhel9"
+          - ""
 
       publish_snapshot:
         description: "Copy snapshot artifacts to S3"


### PR DESCRIPTION
Adding this workflow to master is needed because of a github workflows limitation: workflows can only be triggered if they exist on the default branch, and we want to trigger this dispatch flow from side branches as well as from the 1.x branches.